### PR TITLE
Fixed explicit instantiation problem when compiling as header-only.

### DIFF
--- a/include/igl/svd3x3/svd3x3_avx.cpp
+++ b/include/igl/svd3x3/svd3x3_avx.cpp
@@ -99,8 +99,10 @@ IGL_INLINE void igl::svd3x3_avx(
 }
 #pragma runtime_checks( "u", restore )
 
+#ifdef IGL_STATIC_LIBRARY
 // forced instantiation
 template void igl::svd3x3_avx(const Eigen::Matrix<float, 3*8, 3>& A, Eigen::Matrix<float, 3*8, 3> &U, Eigen::Matrix<float, 3*8, 1> &S, Eigen::Matrix<float, 3*8, 3>&V);
 // doesn't even make sense with double because the wunder-SVD code is only single precision anyway...
 template void igl::svd3x3_avx<float>(Eigen::Matrix<float, 24, 3, 0, 24, 3> const&, Eigen::Matrix<float, 24, 3, 0, 24, 3>&, Eigen::Matrix<float, 24, 1, 0, 24, 1>&, Eigen::Matrix<float, 24, 3, 0, 24, 3>&);
+#endif
 #endif


### PR DESCRIPTION
When compiling tutorial 405_AsRigidAsPossible under linux with libigl as a header-only library, the default build configuration uses AVX for vectorization. The svd3x3_avx.cpp ended up being included (at least) twice and the double explicit instantiation fired an error in the compiler. Now, the explicit instantiations are guarded by #ifdef, so they only apply when compiling libigl as a static library.
