### PR TITLE
Added overload that returns barycentric coordinates of hit

### DIFF
--- a/include/igl/embree/unproject_onto_mesh.cpp
+++ b/include/igl/embree/unproject_onto_mesh.cpp
@@ -19,7 +19,7 @@ IGL_INLINE bool igl::unproject_onto_mesh(
   const Eigen::Vector4f& viewport,
   const igl::EmbreeIntersector & ei,
   int& fid,
-  int& vid)
+  Eigen::Vector3f& bc)
 {
   using namespace std;
   using namespace Eigen;
@@ -31,16 +31,30 @@ IGL_INLINE bool igl::unproject_onto_mesh(
 
   if (hits.size()> 0)
   {
-    Vector3d bc(1.0-hits[0].u-hits[0].v, hits[0].u, hits[0].v);
-    int i;
-    bc.maxCoeff(&i);
-
+    bc << 1.0-hits[0].u-hits[0].v, hits[0].u, hits[0].v;
     fid = hits[0].id;
-    vid = F(fid,i);
     return true;
   }
 
   return false;
+}
+
+IGL_INLINE bool igl::unproject_onto_mesh(
+  const Eigen::Vector2f& pos,
+  const Eigen::MatrixXi& F,
+  const Eigen::Matrix4f& model,
+  const Eigen::Matrix4f& proj,
+  const Eigen::Vector4f& viewport,
+  const igl::EmbreeIntersector & ei,
+  int& fid,
+  int& vid)
+{
+  Eigen::Vector3f bc;
+  bool hit = unproject_onto_mesh(pos,F,model,proj,viewport,ei,fid,bc);
+  int i;
+  bc.maxCoeff(&i);
+  vid = F(fid,i);
+  return hit;
 }
 
 

--- a/include/igl/embree/unproject_onto_mesh.h
+++ b/include/igl/embree/unproject_onto_mesh.h
@@ -18,6 +18,30 @@ namespace igl
   // Forward define
   class EmbreeIntersector;
   // Unproject a screen location (using the given model, proj and viewport) to find
+  // the first hit on a mesh.
+  //
+  // Inputs:
+  //    pos        screen space coordinates
+  //    F          #F by 3 face matrix
+  //    model      model matrix
+  //    proj       projection matrix
+  //    viewport   vieweport vector
+  //    ei         EmbreeIntersector containing (V,F)
+  // Outputs:
+  //    fid        id of the first face hit
+  //    bc         barycentric coordinates of hit
+  // Returns true if there is a hit
+  IGL_INLINE bool unproject_onto_mesh(
+    const Eigen::Vector2f& pos,
+    const Eigen::MatrixXi& F,
+    const Eigen::Matrix4f& model,
+    const Eigen::Matrix4f& proj,
+    const Eigen::Vector4f& viewport,
+    const igl::EmbreeIntersector & ei,
+    int& fid,
+    Eigen::Vector3f& bc);
+  
+  // Unproject a screen location (using the given model, proj and viewport) to find
   // the first face on the mesh and the closest vertex
   //
   // Inputs:
@@ -31,9 +55,6 @@ namespace igl
   //    fid        id of the first face hit
   //    vid        vertex id of the closest vertex hit
   // Returns true if there is a hit
-  //
-  // Known bugs: This should return the barycentric coordinates in F(fid,:)
-  // rather than vid.
   IGL_INLINE bool unproject_onto_mesh(
     const Eigen::Vector2f& pos,
     const Eigen::MatrixXi& F,
@@ -43,6 +64,7 @@ namespace igl
     const igl::EmbreeIntersector & ei,
     int& fid,
     int& vid);
+
 }
 #ifndef IGL_STATIC_LIBRARY
 #  include "unproject_onto_mesh.cpp"


### PR DESCRIPTION
Added overload that returns barycentric coordinates of hit instead of vid of closest vertex of hit