### PR TITLE
Changes in "file_dialog_open.cpp" and "file_dialog_save.cpp" to help compilation in Vista

### DIFF
--- a/include/igl/file_dialog_open.cpp
+++ b/include/igl/file_dialog_open.cpp
@@ -32,7 +32,7 @@ IGL_INLINE std::string igl::file_dialog_open()
   while ( fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL )
   {
   }
-#elif _WIN32
+#elif defined _WIN32
   
   // Use native windows file dialog box
   // (code contributed by Tino Weinkauf)

--- a/include/igl/file_dialog_save.cpp
+++ b/include/igl/file_dialog_save.cpp
@@ -34,7 +34,7 @@ IGL_INLINE std::string igl::file_dialog_save()
   while ( fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL )
   {
   }
-#elif _WIN32
+#elif defined _WIN32
 
   // Use native windows file dialog box
   // (code contributed by Tino Weinkauf)


### PR DESCRIPTION
Minor changes to "file_dialog_open.cpp" and "file_dialog_save.cpp" eliminated two similar error messages:

error: #elif with no expression #elif _WIN32

when trying to compile Example 102_DrawMesh with g++ in Cygwin on Windows Vista.

(Not 100% sure these changes are correct though.)