### PR TITLE
using std::abs() instead of abs() for double input (issue #62)

### DIFF
--- a/include/igl/trackball.cpp
+++ b/include/igl/trackball.cpp
@@ -18,6 +18,8 @@
 #include <algorithm>
 #include <iostream>
 
+using namespace std;
+
 // Utility IGL_INLINE functions
 template <typename Q_type>
 static IGL_INLINE Q_type _QuatD(double w, double h)


### PR DESCRIPTION
c math.h abs() function will cast input to int, you probably want to use std::abs() for floating point input 
as discussed in issue #62 