### PR TITLE
FindLIBCOMISO include directory fix

### DIFF
--- a/tutorial/504_NRosyDesign/CMakeLists.txt
+++ b/tutorial/504_NRosyDesign/CMakeLists.txt
@@ -5,7 +5,8 @@ include("../CMakeLists.shared")
 
 find_package(LIBCOMISO REQUIRED)
 
-include_directories( ${LIBCOMISO_INCLUDE_DIR} )
+include_directories( ${LIBCOMISO_INCLUDE_DIR}
+                     ${LIBCOMISO_INCLUDE_DIRS} )
 
 set(SOURCES
 ${PROJECT_SOURCE_DIR}/main.cpp

--- a/tutorial/505_MIQ/CMakeLists.txt
+++ b/tutorial/505_MIQ/CMakeLists.txt
@@ -5,7 +5,8 @@ include("../CMakeLists.shared")
 
 find_package(LIBCOMISO REQUIRED)
 
-include_directories( ${LIBCOMISO_INCLUDE_DIR} )
+include_directories( ${LIBCOMISO_INCLUDE_DIR}
+                     ${LIBCOMISO_INCLUDE_DIRS} )
 
 set(SOURCES
 ${PROJECT_SOURCE_DIR}/main.cpp

--- a/tutorial/506_FrameField/CMakeLists.txt
+++ b/tutorial/506_FrameField/CMakeLists.txt
@@ -5,7 +5,8 @@ include("../CMakeLists.shared")
 
 find_package(LIBCOMISO REQUIRED)
 
-include_directories( ${LIBCOMISO_INCLUDE_DIR} )
+include_directories( ${LIBCOMISO_INCLUDE_DIR}
+                     ${LIBCOMISO_INCLUDE_DIRS} )
 
 set(SOURCES
 ${PROJECT_SOURCE_DIR}/main.cpp

--- a/tutorial/cmake/FindLIBCOMISO.cmake
+++ b/tutorial/cmake/FindLIBCOMISO.cmake
@@ -38,12 +38,32 @@ FIND_LIBRARY(LIBCOMISO_LIBRARY NAMES CoMISo
     ${PROJECT_SOURCE_DIR}/../../../CoMISo/
     ${PROJECT_SOURCE_DIR}/../../../CoMISo/build/Build/lib/CoMISo/
     /Users/olkido/Documents/igl/MIQ/src/CoMISo/Build
+    /usr/local/lib
+    /usr/local/lib/CoMISo
+    /usr/lib
+    /usr/lib/CoMISo
 )
 #message(STATUS "${LIBCOMISO_LIBRARY}")
 
 if(LIBCOMISO_INCLUDE_DIR AND LIBCOMISO_LIBRARY)
 
-   set(LIBCOMISO_INCLUDE_DIR ${LIBCOMISO_INCLUDE_DIR} ${LIBCOMISO_INCLUDE_DIR}/CoMISo/gmm/include)
+   #message("${LIBCOMISO_INCLUDE_DIR}")
+
+   set(LIBCOMISO_INCLUDE_DIRS
+      ${LIBCOMISO_INCLUDE_DIR}
+      ${LIBCOMISO_INCLUDE_DIR}/CoMISo
+      ${LIBCOMISO_INCLUDE_DIR}/CoMISo/Solver
+      ${LIBCOMISO_INCLUDE_DIR}/CoMISo/EigenSolver
+      ${LIBCOMISO_INCLUDE_DIR}/CoMISo/NSolver
+      ${LIBCOMISO_INCLUDE_DIR}/CoMISo/Config
+      ${LIBCOMISO_INCLUDE_DIR}/CoMISo/Utils
+      ${LIBCOMISO_INCLUDE_DIR}/CoMISo/QtWidgets
+      ${LIBCOMISO_INCLUDE_DIR}/CoMISo/gmm/include
+      )
+
+   #message("${LIBCOMISO_INCLUDE_DIRS}")
+
+   set(LIBCOMISO_INCLUDE_DIR ${LIBCOMISO_INCLUDE_DIR})
 
    add_definitions(-DINCLUDE_TEMPLATES)
    message(STATUS "Found LIBCOMISO: ${LIBCOMISO_INCLUDE_DIR} ${LIBCOMISO_LIBRARY}")


### PR DESCRIPTION
FindLIBCOMISO.cmake re-defined (expanded) the variable LIBCOMISO_INCLUDE_DIR every time it was called by adding a sub-directory. This leads to a "recursive" expansion of LIBCOMISO_INCLUDE_DIR, which was probably not intended. Instead I would recommended to write such additional include directories into a new variable (LIBCOMISO_INCLUDE_DIRS) and use this instead. I also added additional search paths for finding the library.