### PR TITLE
write object bug: need newline between end of v and start of f

### DIFF
--- a/include/igl/writeOBJ.cpp
+++ b/include/igl/writeOBJ.cpp
@@ -106,8 +106,8 @@ IGL_INLINE bool igl::writeOBJ(
     return false;
   }
   s<<
-    V.format(IOFormat(FullPrecision,DontAlignCols," ","\n","v ","","",""))<<
-    (F.array()+1).format(IOFormat(FullPrecision,DontAlignCols," ","\n","f ","","",""));
+    V.format(IOFormat(FullPrecision,DontAlignCols," ","\n","v ","","","\n"))<<
+    (F.array()+1).format(IOFormat(FullPrecision,DontAlignCols," ","\n","f ","","","\n"));
   return true;
 }
 


### PR DESCRIPTION
Hi,
Small bug with serialization into obj format