### PR TITLE
fixed a bug concerning load mesh from dialog

### DIFF
--- a/include/igl/file_dialog_open.cpp
+++ b/include/igl/file_dialog_open.cpp
@@ -68,9 +68,8 @@ IGL_INLINE std::string igl::file_dialog_open()
       buffer[pos] = (char)ofn.lpstrFile[pos];
       pos++;
     }
-    buffer[pos] = 0;
   } 
-  
+  buffer[pos] = 0;
 #else
   
   // For linux use zenity


### PR DESCRIPTION
"buffer[pos] = 0" probably should be moved out of the if block, because if a user opens a dialog but press "ESC", then line 64 judgement fails. But "buffer[pos] = 0" should still be set, otherwise line 86 will not return an empty string.