### PR TITLE
Convert the file string_to_mesh_booean_type.cpp to UTF8-BOM

### DIFF
--- a/include/igl/copyleft/cgal/string_to_mesh_boolean_type.cpp
+++ b/include/igl/copyleft/cgal/string_to_mesh_boolean_type.cpp
@@ -1,4 +1,4 @@
-#include "string_to_mesh_boolean_type.h"
+﻿#include "string_to_mesh_boolean_type.h"
 #include <algorithm>
 #include <cassert>
 #include <vector>


### PR DESCRIPTION
The special characters "∪","∩","∆" hinder the file to be compiled with msvc. For UTF-8 files which contain such special characters, only UTF-8 with BOM is allowed.