### PR TITLE
add option for uniform laplacian operator in harmonic mapping function

### DIFF
--- a/include/igl/harmonic.h
+++ b/include/igl/harmonic.h
@@ -1,15 +1,15 @@
 // This file is part of libigl, a simple c++ geometry processing library.
-// 
+//
 // Copyright (C) 2013 Alec Jacobson <alecjacobson@gmail.com>
-// 
-// This Source Code Form is subject to the terms of the Mozilla Public License 
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 #ifndef IGL_HARMONIC_H
 #define IGL_HARMONIC_H
 #include "igl_inline.h"
 #include <Eigen/Core>
-namespace igl 
+namespace igl
 {
   // Compute k-harmonic weight functions "coordinates".
   //
@@ -20,6 +20,7 @@ namespace igl
   //   b  #b boundary indices into V
   //   bc #b by #W list of boundary values
   //   k  power of harmonic operation (1: harmonic, 2: biharmonic, etc)
+  //   use_cotan_weights  flag to indicate whether the laplacian operator is uniform
   // Outputs:
   //   W  #V by #W list of weights
   //
@@ -35,6 +36,7 @@ namespace igl
     const Eigen::PlainObjectBase<Derivedb> & b,
     const Eigen::PlainObjectBase<Derivedbc> & bc,
     const int k,
+    const bool use_cotan_weights,
     Eigen::PlainObjectBase<DerivedW> & W);
 };
 #ifndef IGL_STATIC_LIBRARY

--- a/include/igl/harmonic.h
+++ b/include/igl/harmonic.h
@@ -20,7 +20,6 @@ namespace igl
   //   b  #b boundary indices into V
   //   bc #b by #W list of boundary values
   //   k  power of harmonic operation (1: harmonic, 2: biharmonic, etc)
-  //   use_cotan_weights  flag to indicate whether the laplacian operator is uniform
   // Outputs:
   //   W  #V by #W list of weights
   //
@@ -36,9 +35,32 @@ namespace igl
     const Eigen::PlainObjectBase<Derivedb> & b,
     const Eigen::PlainObjectBase<Derivedbc> & bc,
     const int k,
-    const bool use_cotan_weights,
     Eigen::PlainObjectBase<DerivedW> & W);
-};
+
+ // Compute harmonic map using uniform laplacian operator
+ //
+ //
+ // Inputs:
+ //   F  #F by simplex-size list of element indices
+ //   b  #b boundary indices into V
+ //   bc #b by #W list of boundary values
+ //   k  power of harmonic operation (1: harmonic, 2: biharmonic, etc)
+ // Outputs:
+ //   W  #V by #W list of weights
+ //
+ template <
+   typename DerivedF,
+   typename Derivedb,
+   typename Derivedbc,
+   typename DerivedW>
+ IGL_INLINE bool harmonic(
+   const Eigen::PlainObjectBase<DerivedF> & F,
+   const Eigen::PlainObjectBase<Derivedb> & b,
+   const Eigen::PlainObjectBase<Derivedbc> & bc,
+   int k,
+   Eigen::PlainObjectBase<DerivedW> & W);
+ };
+
 #ifndef IGL_STATIC_LIBRARY
 #include "harmonic.cpp"
 #endif

--- a/tutorial/401_BiharmonicDeformation/main.cpp
+++ b/tutorial/401_BiharmonicDeformation/main.cpp
@@ -30,11 +30,11 @@ bool pre_draw(igl::viewer::Viewer & viewer)
   {
     MatrixXd D;
     MatrixXd D_bc = U_bc_anim - V_bc;
-    igl::harmonic(V,F,b,D_bc,2,D);
+    igl::harmonic(V,F,b,D_bc,2,true,D);
     U = V+D;
   }else
   {
-    igl::harmonic(V,F,b,U_bc_anim,2,U);
+    igl::harmonic(V,F,b,U_bc_anim,2,true,U);
   }
   viewer.data.set_vertices(U);
   viewer.data.compute_normals();
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
   VectorXi S;
   igl::readDMAT(TUTORIAL_SHARED_PATH "/decimated-max-selection.dmat",S);
   igl::colon<int>(0,V.rows()-1,b);
-  b.conservativeResize(stable_partition( b.data(), b.data()+b.size(), 
+  b.conservativeResize(stable_partition( b.data(), b.data()+b.size(),
    [&S](int i)->bool{return S(i)>=0;})-b.data());
 
   // Boundary conditions directly on deformed positions

--- a/tutorial/401_BiharmonicDeformation/main.cpp
+++ b/tutorial/401_BiharmonicDeformation/main.cpp
@@ -30,11 +30,11 @@ bool pre_draw(igl::viewer::Viewer & viewer)
   {
     MatrixXd D;
     MatrixXd D_bc = U_bc_anim - V_bc;
-    igl::harmonic(V,F,b,D_bc,2,true,D);
+    igl::harmonic(V,F,b,D_bc,2,D);
     U = V+D;
   }else
   {
-    igl::harmonic(V,F,b,U_bc_anim,2,true,U);
+    igl::harmonic(V,F,b,U_bc_anim,2.,U);
   }
   viewer.data.set_vertices(U);
   viewer.data.compute_normals();

--- a/tutorial/402_PolyharmonicDeformation/main.cpp
+++ b/tutorial/402_PolyharmonicDeformation/main.cpp
@@ -21,7 +21,7 @@ bool pre_draw(igl::viewer::Viewer & viewer)
   using namespace Eigen;
   if(resolve)
   {
-    igl::harmonic(V,F,b,bc,k,Z);
+    igl::harmonic(V,F,b,bc,k,true,Z);
     resolve = false;
   }
   U.col(2) = z_max*Z;
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
   VectorXb is_inner = (V.rowwise().norm().array()-0.15)<1e-15;
   VectorXb in_b = is_outer.array() || is_inner.array();
   igl::colon<int>(0,V.rows()-1,b);
-  b.conservativeResize(stable_partition( b.data(), b.data()+b.size(), 
+  b.conservativeResize(stable_partition( b.data(), b.data()+b.size(),
    [&in_b](int i)->bool{return in_b(i);})-b.data());
   bc.resize(b.size(),1);
   for(int bi = 0;bi<b.size();bi++)

--- a/tutorial/402_PolyharmonicDeformation/main.cpp
+++ b/tutorial/402_PolyharmonicDeformation/main.cpp
@@ -21,7 +21,7 @@ bool pre_draw(igl::viewer::Viewer & viewer)
   using namespace Eigen;
   if(resolve)
   {
-    igl::harmonic(V,F,b,bc,k,true,Z);
+    igl::harmonic(V,F,b,bc,k,Z);
     resolve = false;
   }
   U.col(2) = z_max*Z;

--- a/tutorial/403_BoundedBiharmonicWeights/main.cpp
+++ b/tutorial/403_BoundedBiharmonicWeights/main.cpp
@@ -32,7 +32,7 @@
 
 #include "tutorial_shared_path.h"
 
-typedef 
+typedef
   std::vector<Eigen::Quaterniond,Eigen::aligned_allocator<Eigen::Quaterniond> >
   RotationList;
 
@@ -78,7 +78,7 @@ bool pre_draw(igl::viewer::Viewer & viewer)
     MatrixXd CT;
     MatrixXi BET;
     igl::deform_skeleton(C,BE,T,CT,BET);
-    
+
     viewer.data.set_vertices(U);
     viewer.data.set_edges(CT,BET,sea_green);
     viewer.data.compute_normals();

--- a/tutorial/501_HarmonicParam/main.cpp
+++ b/tutorial/501_HarmonicParam/main.cpp
@@ -44,8 +44,8 @@ int main(int argc, char *argv[])
   igl::map_vertices_to_circle(V,bnd,bnd_uv);
 
   // Harmonic parametrization for the internal vertices
-  igl::harmonic(V,F,bnd,bnd_uv,1,V_uv);
-  
+  igl::harmonic(V,F,bnd,bnd_uv,1,true,V_uv);
+
   // Scale UV to make the texture more clear
   V_uv *= 5;
 

--- a/tutorial/501_HarmonicParam/main.cpp
+++ b/tutorial/501_HarmonicParam/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   igl::map_vertices_to_circle(V,bnd,bnd_uv);
 
   // Harmonic parametrization for the internal vertices
-  igl::harmonic(V,F,bnd,bnd_uv,1,true,V_uv);
+  igl::harmonic(V,F,bnd,bnd_uv,1,V_uv);
 
   // Scale UV to make the texture more clear
   V_uv *= 5;

--- a/tutorial/503_ARAPParam/main.cpp
+++ b/tutorial/503_ARAPParam/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   Eigen::MatrixXd bnd_uv;
   igl::map_vertices_to_circle(V,bnd,bnd_uv);
 
-  igl::harmonic(V,F,bnd,bnd_uv,1,true,initial_guess);
+  igl::harmonic(V,F,bnd,bnd_uv,1,initial_guess);
 
   // Add dynamic regularization to avoid to specify boundary conditions
   igl::ARAPData arap_data;

--- a/tutorial/503_ARAPParam/main.cpp
+++ b/tutorial/503_ARAPParam/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   Eigen::MatrixXd bnd_uv;
   igl::map_vertices_to_circle(V,bnd,bnd_uv);
 
-  igl::harmonic(V,F,bnd,bnd_uv,1,initial_guess);
+  igl::harmonic(V,F,bnd,bnd_uv,1,true,initial_guess);
 
   // Add dynamic regularization to avoid to specify boundary conditions
   igl::ARAPData arap_data;


### PR DESCRIPTION
- added a boolean `use_cotan_weight` to indicate use the cotangent weights or uniform weights laplacian operator. (`true` means use cotangent weights)

- also modified function calls in tutorial 401 402 501 503