### PR TITLE
[bug] render_to_png wrong data size

### DIFF
--- a/include/igl/png/render_to_png.cpp
+++ b/include/igl/png/render_to_png.cpp
@@ -17,7 +17,7 @@ IGL_INLINE bool igl::png::render_to_png(
   const bool alpha,
   const bool fast)
 {
-  unsigned char * data = new unsigned char[width*height];
+  unsigned char * data = new unsigned char[4*width*height];
   glReadPixels(
     0,
     0,
@@ -35,7 +35,7 @@ IGL_INLINE bool igl::png::render_to_png(
       data[4*(i+j*width)+3] = 255;
     }
   }
-  bool ret = stbi_write_png(png_file.c_str(), width, height, 4, data, width*sizeof(unsigned char));
+  bool ret = stbi_write_png(png_file.c_str(), width, height, 4, data, 4*width*sizeof(unsigned char));
   delete [] data;
   return ret;
 }


### PR DESCRIPTION
- fixed data size to consider the 4 channels (Red, Green, Blue, Alpha)
- fixed stride_in_bytes to consider the 4 channels
