### PR TITLE
*fix bug: stl file is closed twiced when reading ascii

### DIFF
--- a/include/igl/readSTL.cpp
+++ b/include/igl/readSTL.cpp
@@ -187,7 +187,6 @@ IGL_INLINE bool igl::readSTL(
       }
     }
     // read endfacet
-    fclose(stl_file);
     goto close_true;
   }else
   {


### PR DESCRIPTION
I think the STL file was closed twiced. This occurs an errors in my case.