### PR TITLE
Minor update to tinyxml2 enum.

### DIFF
--- a/include/igl/xml/serialize_xml.cpp
+++ b/include/igl/xml/serialize_xml.cpp
@@ -41,7 +41,7 @@ namespace igl
       {
         // Check if file exists
         tinyxml2::XMLError error = doc->LoadFile(filename.c_str());
-        if(error != tinyxml2::XML_NO_ERROR)
+        if(error != tinyxml2::XML_SUCCESS)
         {
           doc->Clear();
         }
@@ -58,7 +58,7 @@ namespace igl
   
       // Save
       tinyxml2::XMLError error = doc->SaveFile(filename.c_str());
-      if(error != tinyxml2::XML_NO_ERROR)
+      if(error != tinyxml2::XML_SUCCESS)
       {
         doc->PrintError();
       }
@@ -120,7 +120,7 @@ namespace igl
       tinyxml2::XMLDocument* doc = new tinyxml2::XMLDocument();
   
       tinyxml2::XMLError error = doc->LoadFile(filename.c_str());
-      if(error != tinyxml2::XML_NO_ERROR)
+      if(error != tinyxml2::XML_SUCCESS)
       {
         std::cerr << "File not found!" << std::endl;
         doc->PrintError();


### PR DESCRIPTION
It seems tinyxml2 has discarded the enum ``XML_NO_ERROR``.  Switch it to ``XML_SUCCESS`` to avoid compilation errors.