### PR TITLE
Python bindings for remove_duplicate_vertices()

### DIFF
--- a/python/py_doc.cpp
+++ b/python/py_doc.cpp
@@ -905,6 +905,25 @@ const char *__doc_igl_read_triangle_mesh = R"igl_Qu8mg5v7(// read mesh from an a
   //   V  eigen double matrix #V by 3
   //   F  eigen int matrix #F by 3
   // Returns true iff success)igl_Qu8mg5v7";
+const char *__doc_igl_remove_duplicate_vertices = R"igl_Qu8mg5v7(  // REMOVE_DUPLICATE_VERTICES Remove duplicate vertices upto a uniqueness
+  // tolerance (epsilon)
+  //
+  // Inputs:
+  //   V  #V by dim list of vertex positions
+  //   epsilon  uniqueness tolerance (significant digit), can probably think of
+  //     this as a tolerance on L1 distance
+  // Outputs:
+  //   SV  #SV by dim new list of vertex positions
+  //   SVI #V by 1 list of indices so SV = V(SVI,:)
+  //   SVJ #SV by 1 list of indices so V = SV(SVJ,:)
+  //
+  // Example:
+  //   % Mesh in (V,F)
+  //   [SV,SVI,SVJ] = remove_duplicate_vertices(V,1e-7);
+  //   % remap faces
+  //   SF = SVJ(F);
+  //
+  //)igl_Qu8mg5v7";
 const char *__doc_igl_rotate_vectors = R"igl_Qu8mg5v7(// Rotate the vectors V by A radiants on the tangent plane spanned by B1 and
   // B2
   //

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -72,6 +72,7 @@ extern const char *__doc_igl_readMESH;
 extern const char *__doc_igl_readOBJ;
 extern const char *__doc_igl_readOFF;
 extern const char *__doc_igl_read_triangle_mesh;
+extern const char *__doc_igl_remove_duplicate_vertices;
 extern const char *__doc_igl_rotate_vectors;
 extern const char *__doc_igl_setdiff;
 extern const char *__doc_igl_signed_distance;

--- a/python/py_igl.cpp
+++ b/python/py_igl.cpp
@@ -61,6 +61,7 @@
 #include <igl/readOBJ.h>
 #include <igl/readOFF.h>
 #include <igl/read_triangle_mesh.h>
+#include <igl/remove_duplicate_vertices.h>
 #include <igl/rotate_vectors.h>
 #include <igl/setdiff.h>
 #include <igl/signed_distance.h>
@@ -140,6 +141,7 @@ void python_export_igl(py::module &m)
 #include "py_igl/py_readOBJ.cpp"
 #include "py_igl/py_readOFF.cpp"
 #include "py_igl/py_read_triangle_mesh.cpp"
+#include "py_igl/py_remove_duplicate_vertices.cpp"
 #include "py_igl/py_rotate_vectors.cpp"
 #include "py_igl/py_setdiff.cpp"
 #include "py_igl/py_signed_distance.cpp"

--- a/python/py_igl/py_remove_duplicate_vertices.cpp
+++ b/python/py_igl/py_remove_duplicate_vertices.cpp
@@ -1,0 +1,14 @@
+m.def("remove_duplicate_vertices", []
+(
+  const Eigen::MatrixXd& V,
+  const Eigen::MatrixXi& F,
+  const double epsilon,
+  Eigen::MatrixXd& SV,
+  Eigen::MatrixXi& SVI,
+  Eigen::MatrixXi& SVJ,
+  Eigen::MatrixXi& SF
+)
+{
+  return igl::remove_duplicate_vertices(V, F, epsilon, SV, SVI, SVJ, SF);
+}, __doc_igl_remove_duplicate_vertices,
+py::arg("V"), py::arg("F"), py::arg("epsilon"), py::arg("SV"), py::arg("SVI"), py::arg("SVJ"), py::arg("SF"));

--- a/python/python_shared.cpp
+++ b/python/python_shared.cpp
@@ -119,6 +119,7 @@ PYBIND11_PLUGIN(pyigl) {
            readOBJ
            readOFF
            read_triangle_mesh
+           remove_duplicate_vertices
            rotate_vectors
            setdiff
            signed_distance


### PR DESCRIPTION
Python bindings for remove_duplicate_vertices() function.

Tested in python2.7 and 3.5 on GNU/linux