### PR TITLE
change "w" to "wb" in fopen to fix the binary dmat writing error

### DIFF
--- a/include/igl/writeDMAT.cpp
+++ b/include/igl/writeDMAT.cpp
@@ -18,7 +18,7 @@ IGL_INLINE bool igl::writeDMAT(
   const Mat & W,
   const bool ascii)
 {
-  FILE * fp = fopen(file_name.c_str(),"w");
+  FILE * fp = fopen(file_name.c_str(),"wb");
   if(fp == NULL)
   {
     fprintf(stderr,"IOError: writeDMAT() could not open %s...",file_name.c_str());


### PR DESCRIPTION
i found an error in writing binary dmat file.
i tried change "w" to "wb" in fopen and it works.