### PR TITLE
Remove unused variable in Viewer.cpp 

### DIFF
--- a/include/igl/viewer/Viewer.cpp
+++ b/include/igl/viewer/Viewer.cpp
@@ -80,7 +80,7 @@ static igl::viewer::Viewer * __viewer;
 static double highdpi = 1;
 static double scroll_x = 0;
 static double scroll_y = 0;
-static int global_KMod = 0;
+//static int global_KMod = 0;
 
 static void glfw_mouse_press(GLFWwindow* window, int button, int action, int modifier)
 {


### PR DESCRIPTION
Remove another warning due to an unused variable in Viewer.cpp.

Not sure if variable ```global_KMod``` has still any utility. I have executed the command:

```sh
find libigl -type f -name "*.cpp" -exec grep "global_KMod" {} \;
find libigl -type f -name "*.h" -exec grep "global_KMod" {} \;
```

and the only reference found is the declaration in line 83. I have removed it just because it shows a warning on every source file including "igl/viewer/Viewer.h"
