### PR TITLE
Bugfix: boundary_loop crash on meshes without boundary

### DIFF
--- a/include/igl/boundary_loop.cpp
+++ b/include/igl/boundary_loop.cpp
@@ -114,6 +114,13 @@ IGL_INLINE void igl::boundary_loop(
     }
   }
 
+  //Check for meshes without boundary
+  if (idxMax == -1)
+  {
+      L.clear();
+      return;
+  }
+
   L.resize(Lall[idxMax].size());
   for (size_t i = 0; i < Lall[idxMax].size(); ++i)
   {


### PR DESCRIPTION

Fix a crash when calling ```igl::boundary_loop()``` with a mesh without boundary (as "bumpy.off") 

Now, when called with a mesh with no boundary, boundary_loop() returns an empty vector.

Case test:
```cpp
  Eigen::MatrixXd V;
  Eigen::MatrixXi F;
  igl::readOFF("bumpy.off", V, F);

  //Compute Boundary Loop
  Eigen::RowVectorXi boundary;
  igl::boundary_loop(F, boundary);
  std::cout<<"Num of boundary vertex: " << boundary.size() << std::endl;
```