### PR TITLE
Fixed order of operations bug when computing model transform

### DIFF
--- a/include/igl/viewer/ViewerCore.cpp
+++ b/include/igl/viewer/ViewerCore.cpp
@@ -145,11 +145,11 @@ IGL_INLINE void igl::viewer::ViewerCore::get_scale_and_shift_to_fit_mesh(
   if (V.rows() == 0)
     return;
 
-  auto min_point = V.colwise().minCoeff().eval();
-  auto max_point = V.colwise().maxCoeff().eval();
-  auto centroid  = 0.5*(min_point + max_point).eval();
+  auto min_point = V.colwise().minCoeff();
+  auto max_point = V.colwise().maxCoeff();
+  auto centroid  = (0.5*(min_point + max_point)).eval();
   shift.setConstant(0);
-  shift.head(centroid.size())= -centroid.cast<float>();
+  shift.head(centroid.size()) = -centroid.cast<float>();
   zoom = 2.0 / (max_point-min_point).array().abs().maxCoeff();
 }
 


### PR DESCRIPTION
A minor bug, where Eigen doesn't like casting from a temporary. Without the proper brackets, the multiply by 0.5 results in an Eigen temporary type, which doesn't cast well. Changing the order of operations before the eval makes centroid a Vector3f type which can be cast. Also means we can get rid of the extra evals.

Apparently this manifests only in the debug mode in Visual Studio, and is fine in release.