### PR TITLE
Workaround for Eigen-3.3.1:

### DIFF
--- a/include/igl/vector_area_matrix.cpp
+++ b/include/igl/vector_area_matrix.cpp
@@ -47,7 +47,7 @@ IGL_INLINE void igl::vector_area_matrix(
 
 	aux.setFromTriplets(auxTripletList.begin(), auxTripletList.end());
 	auxT.setFromTriplets(auxTTripletList.begin(), auxTTripletList.end());
-	A = (aux + auxT)/2;
+	A = (aux + auxT)*0.5;
 }
 
 #ifdef IGL_STATIC_LIBRARY


### PR DESCRIPTION
https://github.com/libigl/libigl/issues/441



bazel-out/clang_k8-opt/genfiles/third_party/Eigen/src/SparseCore/SparseCwiseBinaryOp.h:266:62: error: no member named 'outer' in 'Eigen::internal::binary_evaluator<Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::SparseMatrix<double, 0, int>, const Eigen::SparseMatrix<double, 0, int> >, Eigen::internal::IteratorBased, Eigen::internal::IteratorBased, double, double>::InnerIterator'
        Scalar rhsVal = m_rhsEval.coeff(IsRowMajor?m_lhsIter.outer():m_id,
                                                   ~~~~~~~~~ ^
bazel-out/clang_k8-opt/genfiles/third_party/Eigen/src/SparseCore/SparseAssign.h:90:78: note: in instantiation of member function 'Eigen::internal::binary_evaluator<Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::SparseMatrix<double, 0, int>, const Eigen::SparseMatrix<double, 0, int> >, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, const Eigen::Matrix<double, -1, -1, 0, -1, -1> > >, Eigen::internal::IteratorBased, Eigen::internal::IndexBased, double, double>::InnerIterator::operator++' requested here
      for (typename SrcEvaluatorType::InnerIterator it(srcEvaluator, j); it; ++it)
                                                                             ^
bazel-out/clang_k8-opt/genfiles/third_party/Eigen/src/SparseCore/SparseAssign.h:132:5: note: in instantiation of function template specialization 'Eigen::internal::assign_sparse_to_sparse<Eigen::SparseMatrix<double, 0, long>, Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::SparseMatrix<double, 0, int>, const Eigen::SparseMatrix<double, 0, int> >, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, const Eigen::Matrix<double, -1, -1, 0, -1, -1> > > >' requested here
    assign_sparse_to_sparse(dst.derived(), src.derived());
    ^
bazel-out/clang_k8-opt/genfiles/third_party/Eigen/src/SparseCore/SparseAssign.h:38:13: note: in instantiation of member function 'Eigen::internal::Assignment<Eigen::SparseMatrix<double, 0, long>, Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::SparseMatrix<double, 0, int>, const Eigen::SparseMatrix<double, 0, int> >, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, const Eigen::Matrix<double, -1, -1, 0, -1, -1> > >, Eigen::internal::assign_op<double, double>, Eigen::internal::Sparse2Sparse, void>::run' requested here
          ::run(derived(), other.derived(), internal::assign_op<Scalar,typename OtherDerived::Scalar>());
            ^
bazel-out/clang_k8-opt/genfiles/third_party/Eigen/src/SparseCore/SparseMatrix.h:1120:18: note: in instantiation of function template specialization 'Eigen::SparseMatrixBase<Eigen::SparseMatrix<double, 0, long> >::operator=<Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::SparseMatrix<double, 0, int>, const Eigen::SparseMatrix<double, 0, int> >, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, const Eigen::Matrix<double, -1, -1, 0, -1, -1> > > >' requested here
    return Base::operator=(other.derived());
                 ^
bazel-out/clang_k8-opt/genfiles/third_party/Eigen/src/SparseCore/SparseMatrix.h:680:15: note: in instantiation of function template specialization 'Eigen::SparseMatrix<double, 0, long>::operator=<Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::SparseMatrix<double, 0, int>, const Eigen::SparseMatrix<double, 0, int> >, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, const Eigen::Matrix<double, -1, -1, 0, -1, -1> > > >' requested here
        *this = other.derived();
              ^
bazel-out/clang_k8-opt/genfiles/third_party/Eigen/src/SparseCore/SparseMatrix.h:1075:15: note: in instantiation of function template specialization 'Eigen::SparseMatrix<double, 0, long>::SparseMatrix<Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::SparseMatrix<double, 0, int>, const Eigen::SparseMatrix<double, 0, int> >, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, const Eigen::Matrix<double, -1, -1, 0, -1, -1> > > >' requested here
    OtherCopy otherCopy(other.derived());
              ^
external/libigl/include/igl/vector_area_matrix.cpp:50:4: note: in instantiation of function template specialization 'Eigen::SparseMatrix<double, 0, int>::operator=<Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::SparseMatrix<double, 0, int>, const Eigen::SparseMatrix<double, 0, int> >, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, const Eigen::Matrix<double, -1, -1, 0, -1, -1> > > >' requested here
        A = (aux + auxT)/2;
          ^
external/libigl/include/igl/lscm.cpp:28:8: note: in instantiation of function template specialization 'igl::vector_area_matrix<Eigen::Matrix<int, -1, -1, 0, -1, -1>, double>' requested here
  igl::vector_area_matrix(F,A);