### PR TITLE
Fix for compilation with Visual C++ 2015

### DIFF
--- a/include/igl/mosek/mosek_quadprog.cpp
+++ b/include/igl/mosek/mosek_quadprog.cpp
@@ -110,6 +110,10 @@ IGL_INLINE bool igl::mosek::mosek_quadprog(
   //  printf("%s",str);
   //}
   //mosek_guarded(MSK_linkfunctoenvstream(env,MSK_STREAM_LOG,NULL,printstr));
+#if MSK_VERSION_MAJOR <= 7
+  // initialize mosek environment
+  mosek_guarded(MSK_initenv(env));
+#endif
   // Create the optimization task
   mosek_guarded(MSK_maketask(env,m,n,&task));
   verbose("Creating task with %ld linear constraints and %ld variables...\n",m,n);

--- a/include/igl/mosek/mosek_quadprog.cpp
+++ b/include/igl/mosek/mosek_quadprog.cpp
@@ -110,8 +110,6 @@ IGL_INLINE bool igl::mosek::mosek_quadprog(
   //  printf("%s",str);
   //}
   //mosek_guarded(MSK_linkfunctoenvstream(env,MSK_STREAM_LOG,NULL,printstr));
-  // initialize mosek environment
-  mosek_guarded(MSK_initenv(env));
   // Create the optimization task
   mosek_guarded(MSK_maketask(env,m,n,&task));
   verbose("Creating task with %ld linear constraints and %ld variables...\n",m,n);
@@ -318,7 +316,7 @@ IGL_INLINE bool igl::mosek::mosek_quadprog(
   vector<double> vux = matrix_to_list(ux);
 
   vector<double> vx;
-  bool ret = mosek_quadprog(
+  bool ret = mosek_quadprog<int, double>(
     Q.rows(),vQi,vQj,vQv,
     vc,
     cf,


### PR DESCRIPTION
To be able to compile with Visual C++ 2015, template parameters `<int, double>` must be explicitly specified to be able to call the overloaded `mosek_quadprog` template function (otherwise the compiler tries to recursively call the same caller function).

In addition, `MSK_initenv` has been removed since it is no longer present in Mosek 8 and is probably not necessary even with Mosek 7 and previous: `MSK_makeenv` should do everything that is needed.
