### PR TITLE
Tetrahedral Analogue for HalfEdgeIterator and triangle_triangle_adjacency.

### DIFF
--- a/include/igl/tetrahedron_tetrahedron_adjacency.cpp
+++ b/include/igl/tetrahedron_tetrahedron_adjacency.cpp
@@ -1,0 +1,134 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2017 Zhongshi Jiang <zhongshi@cims.nyu.edu>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
+#include "tetrahedron_tetrahedron_adjacency.h"
+#include "all_edges.h"
+#include "unique_simplices.h"
+#include "parallel_for.h"
+#include "unique_edge_map.h"
+#include "slice.h"
+#include <Eigen/Core>
+#include <algorithm>
+#include <iostream>
+#include <array>
+namespace igl
+{
+  struct tetrahedron_tetrahedron_adjacency_tet_cell
+  {
+    int v1;
+    int v2;
+    int v3;
+    int t;
+    int f;
+  };
+
+// Extract the face adjacencies
+  template<typename DerivedT, typename TTT_type, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE void tetrahedron_tetrahedron_adjacency_extractTTi(
+      const Eigen::MatrixBase<DerivedT> &F,
+      std::vector<TTT_type> &TTT,
+      Eigen::MatrixBase<DerivedTT> &TT,
+      Eigen::MatrixBase<DerivedTTif> &TTif,
+      Eigen::MatrixBase<DerivedTTie> &TTie)
+  {
+    TT.derived().setConstant((int) (F.rows()), 4, -1);
+    TTif.derived().setConstant((int) (F.rows()), 4, -1);
+    TTie.derived().setConstant((int) (F.rows()), 4 * 3, -1);
+
+    for(int i = 1; i < (int) TTT.size(); ++i)
+    {
+      auto &r1 = TTT[i - 1];
+      auto &r2 = TTT[i];
+
+      // if get same face.
+      if((r1.v1 == r2.v1) && (r1.v2 == r2.v2) && (r1.v3 == r2.v3))
+      {
+        TT(r1.t, r1.f) = r2.t;
+        TT(r2.t, r2.f) = r1.t;
+
+        // inverse for face
+        TTif(r1.t, r1.f) = r2.f;
+        TTif(r2.t, r2.f) = r1.f;
+
+        // inverse for edge
+        Eigen::RowVector3i f1v, f2v;
+        for(int i = 0; i < 3; i++)
+        {
+          f1v[i] = F(r1.t, tetrahedron_local_FF(r1.f, i));
+          f2v[i] = F(r2.t, tetrahedron_local_FF(r2.f, i));
+        }
+
+        std::vector<int> emap = {0, 1, 2};
+        for(int e = 0; e < 3; e++)
+          for(int i = 0; i < 3 - e; i++)
+            if(f1v(e) == f2v(emap[i]))
+            {
+              TTie(r1.t, 3 * r1.f + (e + 2) % 3) = emap[i];
+              TTie(r2.t, 3 * r2.f + (emap[i] + 2) % 3) = e;
+              emap[i] = emap[2 - e]; // fill with the last
+              break;
+            }
+
+      } //if
+    }
+  }
+
+  template<typename DerivedT, typename TTT_type>
+  IGL_INLINE void tetrahedron_tetrahedron_adjacency_preprocess(
+      const Eigen::MatrixBase<DerivedT> &F,
+      std::vector<TTT_type> &TTT)
+  {
+    for(int t = 0; t < (int) F.rows(); ++t)
+      for(int f = 0; f < 4; ++f)
+      {
+        std::array<int, 3> v;
+        for(int i = 0; i < 3; ++i)
+        {
+          v[i] = F(t, tetrahedron_local_FF(f, i));
+        }
+        std::sort(v.begin(), v.end());
+        TTT.push_back({v[0], v[1], v[2], t, f});
+      }
+    std::sort(TTT.begin(), TTT.end(),
+              [](const tetrahedron_tetrahedron_adjacency_tet_cell &r1,
+                 const tetrahedron_tetrahedron_adjacency_tet_cell &r2)
+              {
+                return std::tie(r1.v1, r1.v2, r1.v3, r1.t) <
+                       std::tie(r2.v1, r2.v2, r2.v3, r2.t);
+              });
+  }
+}
+
+// Compute tetrahedron-tetrahedron adjacency with indices
+template<typename DerivedT, typename DerivedTT,
+         typename DerivedTTif,typename DerivedTTie>
+IGL_INLINE void
+igl::tetrahedron_tetrahedron_adjacency(const Eigen::MatrixBase<DerivedT> &F,
+                                       Eigen::MatrixBase<DerivedTT> &TT,
+                                       Eigen::MatrixBase<DerivedTTif> &TTif,
+                                       Eigen::MatrixBase<DerivedTTie> &TTie)
+{
+  std::vector<igl::tetrahedron_tetrahedron_adjacency_tet_cell> TTT;
+  tetrahedron_tetrahedron_adjacency_preprocess(F, TTT);
+  tetrahedron_tetrahedron_adjacency_extractTTi(F, TTT, TT, TTif, TTie);
+}
+
+template <typename DerivedT, typename DerivedTT>
+IGL_INLINE void igl::tetrahedron_tetrahedron_adjacency(
+    const Eigen::MatrixBase<DerivedT>& F,
+    Eigen::MatrixBase<DerivedTT>& TT)
+{
+  std::vector<igl::tetrahedron_tetrahedron_adjacency_tet_cell> TTT;
+  tetrahedron_tetrahedron_adjacency_preprocess(F, TTT);
+  Eigen::MatrixBase<DerivedTT> TTif,TTie;
+  tetrahedron_tetrahedron_adjacency_extractTTi(F,TTT,TT,TTif,TTie);
+}
+#ifdef IGL_STATIC_LIBRARY
+// Explicit template instantiation
+template void igl::tetrahedron_tetrahedron_adjacency<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1> >(Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> >&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> >&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> >&);
+#endif

--- a/include/igl/tetrahedron_tetrahedron_adjacency.h
+++ b/include/igl/tetrahedron_tetrahedron_adjacency.h
@@ -1,0 +1,72 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2017 Zhongshi Jiang <zhongshi@cims.nyu.edu>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
+#ifndef IGL_TETRAHEDRON_TETRAHEDRON_ADJACENCY_H
+#define IGL_TETRAHEDRON_TETRAHEDRON_ADJACENCY_H
+#include "igl_inline.h"
+#include <Eigen/Core>
+#include <vector>
+
+namespace igl
+{
+  // Constructs the tetrahedron-tetrahedron adjacency matrix for a given
+  // tet mesh (V,T).
+  //
+  // Inputs:
+  //   T  #T by 4 list of mesh faces (must be tetrahedrons)
+  // Outputs:
+  //   TT   #T by #4  adjacent matrix, the element i,j is the id of
+  //          the tetrahedron adjacent to the j face of tetrahedron i
+  //   TTif #T by #4  adjacent matrix, the element i,j is the id of
+  //          face of the tetrahedron TT(i,j) adjacent with tetrahedron i
+  //   TTie #T by #12 adjacent matrix, the element i, 3*j+k is the id of
+  //          edge of the face TTif(i,j) of tet TT(i,j)
+  //          adjacent with tetrahedron i
+  // NOTE:
+  //   Faces are indexed by opposite corner vertex and
+  //   orientation is determined looking from the opposite vertex,
+  //   For tet T = [v0,v1,v2,v3]:
+  //    F[0] = v3,v2,v1;
+  //    F[1] = v2,v3,v0;
+  //    F[2] = v1,v0,v3;
+  //    F[3] = v0,v1,v2;
+  //   However, to be compatible with triangle_triangle_adjacency,
+  //   edges are indexed with its starting vertex:
+  //   the first edge for [v0,v1,v2] is [v0,v1] the second [v1,v2]
+  //   and the third [v2,v3].
+  //       this convention is DIFFERENT from cotmatrix_entries.h
+  template<typename DerivedT, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE void tetrahedron_tetrahedron_adjacency(
+      const Eigen::MatrixBase<DerivedT> &T,
+      Eigen::MatrixBase<DerivedTT> &TT,
+      Eigen::MatrixBase<DerivedTTif> &TTif,
+      Eigen::MatrixBase<DerivedTTie> &TTie);
+
+  template<typename DerivedT, typename DerivedTT>
+  IGL_INLINE void tetrahedron_tetrahedron_adjacency(
+      const Eigen::MatrixBase<DerivedT> &T,
+      Eigen::MatrixBase<DerivedTT> &TT);
+
+  // Helper Matrix
+  // Local Triangle-Triangle-Adjacency.
+  // Face indexing matrix from the opposite corner
+  // the matrix has the property that FFi is always identity with edge.
+  // can be rephrased as (i-j+3+(i%2)*(2*j-2))%4
+  static Eigen::Matrix<int, 4, 3> tetrahedron_local_FF =
+      (Eigen::Matrix<int, 4, 3>() <<
+          3, 2, 1,
+          2, 3, 0,
+          1, 0, 3,
+          0, 1, 2).finished();
+}
+
+#ifndef IGL_STATIC_LIBRARY
+#  include "tetrahedron_tetrahedron_adjacency.cpp"
+#endif
+
+#endif

--- a/include/igl/tetrahedron_tuple.cpp
+++ b/include/igl/tetrahedron_tuple.cpp
@@ -1,0 +1,204 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2017 Zhongshi Jiang <zhongshi@cims.nyu.edu>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "tetrahedron_tuple.h"
+#include "tetrahedron_tetrahedron_adjacency.h"
+namespace igl
+{
+  template<typename DerivedT, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE void tet_tuple_switch_vert(
+      int &ti, int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie)
+  {
+    along = !along;
+  };
+
+  template<typename DerivedT, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE void tet_tuple_switch_edge(
+      int &ti, int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie)
+  {
+    ei = (ei + (along ? 2 : 1)) % 3;
+    tet_tuple_switch_vert(ti, fi, ei, along, T, TT, TTif, TTie);
+  };
+
+  template<typename DerivedT, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE void tet_tuple_switch_face(
+      int &ti, int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie)
+  {
+    fi = tetrahedron_local_FF(fi, (ei + 2) % 3);
+    tet_tuple_switch_vert(ti, fi, ei, along, T, TT, TTif, TTie);
+  };
+
+  template<typename DerivedT, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE void tet_tuple_switch_tet(
+      int &ti, int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie)
+  {
+    if(tet_tuple_is_on_boundary(ti, fi, ei, along, T, TT, TTif, TTie)) return;
+    int tin = TT(ti, fi);
+    int fin = TTif(ti, fi);
+    int ein = TTie(ti, 3 * fi + ei);
+
+    ti = tin;
+    fi = fin;
+    ei = ein;
+    tet_tuple_switch_vert(ti, fi, ei, along, T, TT, TTif, TTie);
+  };
+
+  template<typename DerivedT, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE int tet_tuple_get_vert(
+      const int &ti, const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie)
+  {
+    assert(ti >= 0);
+    assert(ti < T.rows());
+    assert(fi <= 3);
+    assert(fi >= 0);
+    assert(ei >= 0);
+    assert(ei <= 2);
+
+    // legacy edge indexing
+    return T(ti,
+             (tetrahedron_local_FF)(fi,
+                                    along ? ei: (ei + 1) % 3));
+  };
+
+  template<typename DerivedT,
+           typename DerivedTT,
+           typename DerivedTTif,
+           typename DerivedTTie>
+  IGL_INLINE int tet_tuple_get_edge(
+      const int &ti, const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie)
+  {
+    return ei;
+  };
+
+  template<typename DerivedT,
+           typename DerivedTT,
+           typename DerivedTTif,
+           typename DerivedTTie>
+  IGL_INLINE int tet_tuple_get_face(
+      const int &ti, const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie)
+  {
+    return fi;
+  };
+
+  template<typename DerivedT,
+           typename DerivedTT,
+           typename DerivedTTif,
+           typename DerivedTTie>
+  IGL_INLINE int tet_tuple_get_tet(
+      const int &ti, const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie)
+  {
+    return ti;
+  };
+
+  template<typename DerivedT,
+           typename DerivedTT,
+           typename DerivedTTif,
+           typename DerivedTTie>
+  IGL_INLINE bool tet_tuple_next_in_one_ring(
+      int &ti, int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie)
+  {
+    if(tet_tuple_is_on_boundary(ti, fi, ei, along, T, TT, TTif, TTie))
+    {
+      do
+      {
+        tet_tuple_switch_face(ti, fi, ei, along, T, TT, TTif, TTie);
+        tet_tuple_switch_tet(ti, fi, ei, along, T, TT, TTif, TTie);
+        tet_tuple_switch_face(ti, fi, ei, along, T, TT, TTif, TTie);
+        tet_tuple_switch_edge(ti, fi, ei, along, T, TT, TTif, TTie);
+      } while(!tet_tuple_is_on_boundary(ti, fi, ei, along, T, TT, TTif,
+                                        TTie));
+      tet_tuple_switch_edge(ti, fi, ei, along, T, TT, TTif, TTie);
+      return false;
+    }
+    else
+    {
+      tet_tuple_switch_face(ti, fi, ei, along, T, TT, TTif, TTie);
+      tet_tuple_switch_tet(ti, fi, ei, along, T, TT, TTif, TTie);
+      tet_tuple_switch_face(ti, fi, ei, along, T, TT, TTif, TTie);
+      tet_tuple_switch_edge(ti, fi, ei, along, T, TT, TTif, TTie);
+      return true;
+    }
+  };
+
+  template<typename DerivedT,
+           typename DerivedTT,
+           typename DerivedTTif,
+           typename DerivedTTie>
+  IGL_INLINE bool tet_tuple_is_on_boundary(
+      const int &ti, const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie)
+  {
+    return TT(ti, fi) == -1;
+  };
+
+  IGL_INLINE bool tet_tuples_equal(
+      const int &t1, const int &f1, const int &e1, const bool &rev1,
+      const int &t2, const int &f2, const int &e2, const bool &rev2)
+  {
+    return t1 == t2 &&
+           f1 == f2 &&
+           e1 == e2 &&
+           rev1 == rev2;
+  };
+}
+
+#ifdef IGL_STATIC_LIBRARY
+// Explicit template instantiation
+template int igl::tet_tuple_get_tet<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1> >(const int&, const int&, const int&, const bool&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&);
+template int igl::tet_tuple_get_edge<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1> >(const int&, const int&, const int&, const bool&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&);
+template int igl::tet_tuple_get_face<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1> >(const int&, const int&, const int&, const bool&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&);
+template int igl::tet_tuple_get_vert<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1> >(const int&, const int&, const int&, const bool&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&);
+template void igl::tet_tuple_switch_tet<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1> >(int&, int&, int&, bool&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&);
+template void igl::tet_tuple_switch_edge<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1> >(int&, int&, int&, bool&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&);
+template void igl::tet_tuple_switch_face<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1> >(int&, int&, int&, bool&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&);
+template void igl::tet_tuple_switch_vert<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1> >(int&, int&, int&, bool&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&);
+#endif

--- a/include/igl/tetrahedron_tuple.h
+++ b/include/igl/tetrahedron_tuple.h
@@ -1,0 +1,173 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2017 Zhongshi Jiang <zhongshi@cims.nyu.edu>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
+#ifndef IGL_TETTUPLEITERATOR_H
+#define IGL_TETTUPLEITERATOR_H
+
+#include <igl/igl_inline.h>
+#include <Eigen/Core>
+
+namespace igl
+{
+  // TetTupleIterator - Fake half-edge for fast and easy navigation
+  // on tetrahedral meshes with tet_tet_adjacency.
+  // 3D analogue for triangle_tuple.
+  // Recommend read and understand triangle_tuple first.
+  //
+  // Note: this is different to classical Half Edge as in OpenVolumeMesh.
+  //    Instead, it follows cell-tuple in [Brisson, 1989]
+  //    "Representing geometric structures in d dimensions: topology and order."
+  //    This class can achieve local navigation similar to OpenVolumeMesh
+  //    But the logic behind each atom operation is different.
+  //
+  // Each tuple contains information on (tet, face, edge, vertex)
+  //    and encoded by (tet, face, edge \in {0,1,2}, bool along)
+  //
+  // Inputs:
+  //    (ti, fi, ei, along) as detailed above.
+  //    T #T by 3 list of "faces"
+  //    TT #T by 3 list of triangle-triangle adjacency.
+  //    TTif #T by 3 list of TT inverse w.r.t face.
+  //    TTie #T by 3 list of TT inverse w.r.t edge.
+  //        For TT and TTi, refer to "tetrahedron_tetrahedron_adjacency.h"
+  // Usages:
+  //    tet_tuple_get_{vert/edge/face/tet} returns the
+  //      {from-vertex id / *local* edge id/ *local* face id / tet id}
+  //      associated with the represented half edge.
+  //
+  //    tet_tuple_switch_{vert/edge/face/tet} switches to another half edge
+  //      that differes in only one v/e/f/t information.
+  //
+  //    tet_tuple_next_in_one_ring switch to next half edge
+  //      in one-ring of the from vertex with proper handling of boundary.
+  //
+  //    triangle_tuple_is_on_boundary determines whether the current encoded
+  //      half edge is on boundary.
+  //
+  //    triangle_tuples_equal is only a wrapper comparing the (t, f,e,a) tuple
+
+
+  template<typename DerivedT, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE void tet_tuple_switch_vert(
+      int &ti, int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie
+  );
+
+  template<typename DerivedT, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE void tet_tuple_switch_edge(
+      int &ti, int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie
+  );
+
+  template<typename DerivedT, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE void tet_tuple_switch_face(
+      int &ti, int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie
+  );
+
+  template<typename DerivedT, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE void tet_tuple_switch_tet(
+      int &ti, int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie
+  );
+
+  template<typename DerivedT, typename DerivedTT,
+           typename DerivedTTif, typename DerivedTTie>
+  IGL_INLINE int tet_tuple_get_vert(
+      const int &ti, const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie
+  );
+
+  template<typename DerivedT,
+           typename DerivedTT,
+           typename DerivedTTif,
+           typename DerivedTTie>
+  IGL_INLINE int tet_tuple_get_edge(
+      const int &ti, const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie
+  );
+
+  template<typename DerivedT,
+           typename DerivedTT,
+           typename DerivedTTif,
+           typename DerivedTTie>
+  IGL_INLINE int tet_tuple_get_face(
+      const int &ti, const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie
+  );
+
+  template<typename DerivedT,
+           typename DerivedTT,
+           typename DerivedTTif,
+           typename DerivedTTie>
+  IGL_INLINE int tet_tuple_get_tet(
+      const int &ti, const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie
+  );
+
+  template<typename DerivedT,
+           typename DerivedTT,
+           typename DerivedTTif,
+           typename DerivedTTie>
+  IGL_INLINE bool tet_tuple_next_in_one_ring(
+      int &ti, int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie
+  );
+
+  template<typename DerivedT,
+           typename DerivedTT,
+           typename DerivedTTif,
+           typename DerivedTTie>
+  IGL_INLINE bool tet_tuple_is_on_boundary(
+      const int &ti, const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedT> &T,
+      const Eigen::MatrixBase<DerivedTT> &TT,
+      const Eigen::MatrixBase<DerivedTTif> &TTif,
+      const Eigen::MatrixBase<DerivedTTie> &TTie
+  );
+
+  IGL_INLINE bool tet_tuples_equal(
+      const int &t1, const int &f1, const int &e1, const bool &rev1,
+      const int &t2, const int &f2, const int &e2, const bool &rev2
+  );
+}
+
+#ifndef IGL_STATIC_LIBRARY
+#  include "TetTupleIterator.cpp"
+#endif
+#endif //EXAMPLE_HALFFACEITERATOR_H

--- a/include/igl/triangle_tuple.cpp
+++ b/include/igl/triangle_tuple.cpp
@@ -1,0 +1,146 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2017 Zhongshi Jiang <zhongshi@cims.nyu.edu>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "triangle_tuple.h"
+
+namespace igl
+{
+  template<typename DerivedF, typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE void triangle_tuple_switch_vert(
+      int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi)
+  {
+    along = !along;
+  };
+
+  template<typename DerivedF, typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE void triangle_tuple_switch_edge(
+      int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi)
+  {
+    ei = (ei + ((!along) ? 1 : 2)) % 3;
+    triangle_tuple_switch_vert(fi, ei, along, F, FF, FFi);
+  };
+
+  template<typename DerivedF, typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE void triangle_tuple_switch_face(
+      int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi)
+  {
+    int fin = FF(fi, ei);
+    int ein = FFi(fi, ei);
+
+    fi = fin;
+    ei = ein;
+    triangle_tuple_switch_vert(fi, ei, along, F, FF, FFi);
+  };
+
+  template<typename DerivedF, typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE int triangle_tuple_get_vert(
+      const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi)
+  {
+    assert(fi <= F.rows());
+    assert(fi >= 0);
+    assert(ei >= 0);
+    assert(ei <= 2);
+
+    // legacy edge indexing
+    return F(fi, (!along) ? (ei + 1) % 3 : ei);
+  };
+
+  template<typename DerivedF,
+           typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE int triangle_tuple_get_edge(
+      const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi)
+  {
+    return ei;
+  };
+
+  template<typename DerivedF,
+           typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE int triangle_tuple_get_face(
+      const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi)
+  {
+    return fi;
+  };
+
+  template<typename DerivedF,
+           typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE bool triangle_tuple_next_in_one_ring(
+      int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi)
+  {
+    if(triangle_tuple_is_on_boundary(fi, ei, along, F, FF, FFi))
+    {
+      do
+      {
+        triangle_tuple_switch_face(fi, ei, along, F, FF, FFi);
+        triangle_tuple_switch_edge(fi, ei, along, F, FF, FFi);
+      } while(!triangle_tuple_is_on_boundary(fi, ei, along, F, FF, FFi));
+      triangle_tuple_switch_edge(fi, ei, along, F, FF, FFi);
+      return false;
+    }
+    else
+    {
+      triangle_tuple_switch_face(fi, ei, along, F, FF, FFi);
+      triangle_tuple_switch_edge(fi, ei, along, F, FF, FFi);
+      return true;
+    }
+  };
+
+  template<typename DerivedF,
+           typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE bool triangle_tuple_is_on_boundary(
+      const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi)
+  {
+    return F(fi, ei) == -1;
+  };
+
+  IGL_INLINE bool triangle_tuples_equal(
+      const int &f1, const int &e1, const bool &a1,
+      const int &f2, const int &e2, const bool &a2)
+  {
+    return f1 == f2 &&
+           e1 == e2 &&
+           a1 == a2;
+  };
+}
+
+#ifdef IGL_STATIC_LIBRARY
+// Explicit template instantiation
+template int igl::triangle_tuple_get_vert<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1> >(int const&, int const&, bool const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&);
+template bool igl::triangle_tuple_next_in_one_ring<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1> >(int &, int &, bool &, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&);
+#endif

--- a/include/igl/triangle_tuple.h
+++ b/include/igl/triangle_tuple.h
@@ -1,0 +1,151 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2017 Zhongshi Jiang <zhongshi@cims.nyu.edu>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
+#ifndef IGL_TRIANGLE_TUPLE_H
+#define IGL_TRIANGLE_TUPLE_H
+
+#include <igl/igl_inline.h>
+#include <Eigen/Core>
+
+namespace igl
+{
+  // triangle cell tuple - Fake half-edge for fast and easy navigation
+  // on trianglerahedral meshes with triangle_triangle_adjacency.
+
+  // on triangle meshes with vertex_triangle_adjacency and
+  // triangle_triangle adjacency
+  //
+  // Note: this is different to classical Half Edge data structure.
+  //    Instead, it follows cell-tuple in [Brisson, 1989]
+  //    "Representing geometric structures in d dimensions: topology and order."
+  //    This class can achieve local navigation similar to half edge in OpenMesh
+  //    But the logic behind each atom operation is different.
+  //    So this should be more properly called TriangleTupleIterator.
+  //
+  // Each tuple contains information of (face, edge, (from)vertex) associated
+  // with a directed half edge and encoded by (face, edge \in {0,1,2}, bool
+  // along), stands for the index of triangle, local index of edge, and whether
+  // the half edge is along the natural positive direction of the edge.
+  // There are two type of atom operation: switch/get detailed below.
+  //
+  // Templates:
+  //    DerivedF/FF/FFi Matrix Type for F/FF/FFi. Can be implicitly captured.
+  // Inputs:
+  //    (fi, ei, along) as detailed above.
+  //    F #F by 3 list of triangular faces
+  //    FF #F by 3 list of triangle-triangle adjacency.
+  //    FFi #F by 3 list of FF inverse. Refer to
+  //        "triangle_triangle_adjacency.h"
+  // Usages:
+  //    triangle_tuple_get_{vert/edge/face} returns the
+  //      {index of from-vertex / *local* edge index / index of triangle}
+  //      associated with the represented half edge.
+  //
+  //    triangle_tuple_switch_{vert/edge/face} switches to another half edge
+  //      that differes in only one v/e/f information.
+  //
+  //    triangle_tuple_next_in_one_ring switch to next half edge
+  //      in one-ring of the from vertex: (switch_face + switch_edge)
+  //      with proper handling of boundary.
+  //
+  //    triangle_tuple_is_on_boundary determines whether the current encoded
+  //      half edge is on boundary.
+  //
+  //    triangle_tuples_equal is only a wrapper comparing the (f,e,a) tuple
+  
+  // Basic Switch: only change information for one face/edge/vert resp.
+  template<typename DerivedF, typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE void triangle_tuple_switch_vert(
+      int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi);
+
+  template<typename DerivedF, typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE void triangle_tuple_switch_edge(
+      int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi);
+
+  template<typename DerivedF, typename DerivedFF,
+           typename DerivedFFi> 
+  IGL_INLINE void triangle_tuple_switch_face(
+      int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi);
+
+  //getters
+  template<typename DerivedF, typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE int triangle_tuple_get_vert(
+      const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi);
+
+  template<typename DerivedF,
+           typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE int triangle_tuple_get_edge(
+      const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi);
+
+  template<typename DerivedF,
+           typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE int triangle_tuple_get_face(
+      const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi);
+
+  // Advanced Navigation
+  /*!
+     * Returns the next edge skipping the border
+     *      _________
+     *     /\ c | b /\
+     *    /  \  |  /  \
+     *   / d  \ | / a  \
+     *  /______\|/______\
+     *          v
+     * In this example, if a and d are of-border and the pos is iterating counterclockwise, this method iterate through the faces incident on vertex v,
+     * producing the sequence a, b, c, d, a, b, c, ...
+     */
+  template<typename DerivedF,
+           typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE bool triangle_tuple_next_in_one_ring(
+      int &fi, int &ei, bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi);
+
+  // helper boolean functions
+  template<typename DerivedF,
+           typename DerivedFF,
+           typename DerivedFFi>
+  IGL_INLINE bool triangle_tuple_is_on_boundary(
+      const int &fi, const int &ei, const bool &along,
+      const Eigen::MatrixBase<DerivedF> &F,
+      const Eigen::MatrixBase<DerivedFF> &FF,
+      const Eigen::MatrixBase<DerivedFFi> &FFi);
+
+  IGL_INLINE bool triangle_tuples_equal(
+      const int &f1, const int &e1, const bool &a1,
+      const int &f2, const int &e2, const bool &a2);
+}
+
+#ifndef IGL_STATIC_LIBRARY
+#  include "triangle_tuple.cpp"
+#endif
+#endif


### PR DESCRIPTION
In this pull request, I have created new class `TetTupleIterator`: Tetrahedral Analogue for `HalfEdgeIterator` (which should be more properly called Cell-Tuple)

and the helper function `tetrahedron_tetrahedron_adjacency` , also as a tet analogue of  `triangle_triangle_adjacency`.

I've submit a pull request to libigl/libigl-unit-tests#10