### PR TITLE
n-dimensional OBJ vertex support

### DIFF
--- a/include/igl/readOBJ.cpp
+++ b/include/igl/readOBJ.cpp
@@ -14,6 +14,8 @@
 #include <iostream>
 #include <cstdio>
 #include <fstream>
+#include <sstream>
+#include <iterator>
 
 template <typename Scalar, typename Index>
 IGL_INLINE bool igl::readOBJ(
@@ -77,22 +79,18 @@ IGL_INLINE bool igl::readOBJ(
       char * l = &line[strlen(type)];
       if(type == v)
       {
-        double x[4];
-        int count =
-        sscanf(l,"%lf %lf %lf %lf\n",&x[0],&x[1],&x[2],&x[3]);
-        if(count != 3 && count != 4)
+        std::istringstream ls(&line[1]);
+        std::vector<Scalar > vertex{ std::istream_iterator<Scalar >(ls), std::istream_iterator<Scalar >() };
+
+        if (vertex.size() < 3)
         {
           fprintf(stderr,
-                  "Error: readOBJ() vertex on line %d should have 3 or 4 coordinates",
+                  "Error: readOBJ() vertex on line %d should have at least 3 coordinates",
                   line_no);
           fclose(obj_file);
           return false;
         }
-        std::vector<Scalar > vertex(count);
-        for(int i = 0;i<count;i++)
-        {
-          vertex[i] = x[i];
-        }
+      
         V.push_back(vertex);
       }else if(type == vn)
       {


### PR DESCRIPTION
Extend readOBJ to support n-dimensional vertex lines, n >= 3

Modification in response to issue #454 enhancement request. readOBJ vertex matrix will contain columns equal to the number of components on the "v ..." .obj file line as encountered.