### PR TITLE
issue 482: add discrete exterior calculus operator

### DIFF
--- a/include/igl/discrete_exterior_calculus.cpp
+++ b/include/igl/discrete_exterior_calculus.cpp
@@ -1,0 +1,257 @@
+
+#include "discrete_exterior_calculus.h"
+#include "halfedge_flip.h"
+#include "doublearea.h"
+#include "cotmatrix_entries.h"
+
+#include <vector>
+#include <iostream>
+namespace igl
+{
+    namespace dec2d
+    {
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void d0(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& D)
+        {
+            using namespace std;
+            if (F.cols() != 3)
+            {
+                cerr << "discrete_exterior_calculus.h: Error: Simplex size ("<<
+                    F.cols() << ") not supported" << endl;
+                assert(false);
+            }
+
+            int m = F.rows();
+            int n = V.rows();
+            /* build derivative operator matrix
+             * for halfedge he = (u, v):
+             * D(he, u) = -1, D(he, v) = 1 
+             */ 
+            typedef Eigen::Triplet<Scalar> T;
+            vector<T> d0_coeff;
+            d0_coeff.clear();
+            d0_coeff.reserve(6 * m);
+            for(int i = 0; i < m; i++)
+            {
+                d0_coeff.push_back(T(3 * i    , F(i, 1), -1));
+                d0_coeff.push_back(T(3 * i    , F(i, 2),  1));
+
+                d0_coeff.push_back(T(3 * i + 1, F(i, 2), -1));
+                d0_coeff.push_back(T(3 * i + 1, F(i, 0),  1));
+
+                d0_coeff.push_back(T(3 * i + 2, F(i, 0), -1));
+                d0_coeff.push_back(T(3 * i + 2, F(i, 1),  1));
+            }
+
+            D = Eigen::SparseMatrix<Scalar>(3 * m, n);
+            D.setFromTriplets(d0_coeff.begin(), d0_coeff.end());
+        }
+        
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void d1(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& D)
+        {
+            using namespace std;
+            if (F.cols() != 3)
+            {
+                cerr << "discrete_exterior_calculus.h: Error: Simplex size ("<<
+                    F.cols() << ") not supported" << endl;
+                assert(false);
+            }
+
+            int m = F.rows();
+
+            /* get halfedge flip information */
+            Eigen::MatrixXi HE;
+            halfedge_flip(F, HE);
+
+            /* build direvative operator 
+             * if HE is boundary, contribute 1 to facet integration 
+             * if not, average the HE on both side and then get facet integration 
+             * 
+             * t = [u, v, w] 
+             * if he0 = (u, v) and he0 has opposite halfedge he1 = (v, u)
+             *      D(t, he0) = 0.5, D(t, he1) = -0.5
+             * if he0 = (u, v) and he0 is boundary, thus has no opposite halfedge
+             *      D(t, he0) = 1.0
+             */
+            typedef Eigen::Triplet<Scalar> T;
+            vector<T> d1_coeff;
+            d1_coeff.clear();
+            d1_coeff.reserve(6 * m);
+            for (int i = 0; i < m; i++)
+                for(int j = 0; j < 3; j++)
+                {
+                    if (HE(i, j) < 0)
+                    {
+                        d1_coeff.push_back(T(i, 3 * i + j, 1));
+                    }else
+                    {
+                        d1_coeff.push_back(T(i, 3 * i + j, 0.5));
+                        d1_coeff.push_back(T(i, HE(i,j),  -0.5));
+                    }
+                }
+            D = Eigen::SparseMatrix<Scalar>(m, 3 * m);
+            D.setfromTriplets(d1_coeff.begin(), d1_coeff.end());
+        }
+
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void dual_d0(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& D)
+        {
+            d0(V, F, D);
+            D = -0.5 * D.transpose();
+        }
+
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void dual_d1(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& D)
+        {
+            d1(V, F, D);
+            D = 2 * D.transpose();
+        }
+
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void hs0(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS)
+        {
+            using namespace std;
+            if (F.cols() != 3)
+            {
+                cerr << "discrete_exterior_calculus.h: Error: Simplex size ("<<
+                    F.cols() << ") not supported" << endl;
+                assert(false);
+            }
+
+            int n = V.rows();
+            int m = F.rows();
+
+            Eigen::VectorXd area;
+            doublearea(V, F, area);
+            area /= 6.0;  /* 2.0 for doubled area, 3.0 for three vertices */
+            
+            Eigen::VectorXd v_area = Eigen::VectorXd::Zero(n);
+            parallel_for(
+                    m,
+                    [&F, &area, &v_area](const int i)
+                    {
+                        v_area(F(i, 0)) += area(i);
+                        v_area(F(i, 1)) += area(i);
+                        v_area(F(i, 2)) += area(i);
+                    },
+                    1000);
+            HS = v_area.asDiagonal();
+        }
+
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void hs1(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS)
+        {
+            using namespace std;
+            using namespace Eigen;
+            if (F.cols() != 3)
+            {
+                cerr << "discrete_exterior_calculus.h: Error: Simplex size ("<<
+                    F.cols() << ") not supported" << endl;
+                assert(false);
+            }
+
+            int m = F.rows();
+            /* get halfedge flip information */
+            Eigen::MatrixXi HE;
+            halfedge_flip(F, HE);
+
+            /* get cot value of each halfedge's corresponding angle */
+            Eigen::Matrix<double, Dynamic, Dynamic, RowMajor> Cot;
+            cotmatrix_entries(V, F, Cot);
+            
+            /* get transform between halfedges and dual halfedges */
+            Eigen::Matrix<double, Dynamic, Dynamic, RowMajor> HS_diag = Cot;
+            for(int i = 0; i < m; i++)
+                for(int j = 0; j < 3; j++)
+                {   /* if halfedge is boundary, contribute cot() to dual halfedge integration 
+                     * if not, average the cot() on both side and then get halfedge integration 
+                     */
+                    if (HE(i, j) < 0) 
+                    {
+                        HS_diag(i, j) += Cot(i, j);
+                    }else
+                    {
+                        HS_diag(i, j) += Cot(HE(i, j));  /* only when Cot is RowMajor */
+                    }
+                }
+            HS_diag *= 0.5;
+            HS_diag.resize(HS_diag.size(), 1);  /* only when HS_diag is RowMajor */
+            HS = HS_diag.asDiagonal();
+        }
+
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void hs2(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS)
+        {
+            using namespace std;
+            if (F.cols() != 3)
+            {
+                cerr << "discrete_exterior_calculus.h: Error: Simplex size ("<<
+                    F.cols() << ") not supported" << endl;
+                assert(false);
+            }
+            Eigen::VectorXd area;
+            doublearea(V, F, area);
+            area /= 2.0;  /* 2.0 for doubled area */
+            HS = area.asDiagonal();
+        }
+
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void dual_hs0(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS)
+        {
+            hs0(V, F, HS);
+            auto v_area = HS.diagonal();
+            v_area = 1.0 / v_area.array();
+            HS = v_area.asDiagonal();
+        }
+
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void dual_hs1(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS)
+        {
+            hs1(V, F, HS);
+            auto he_length = HS.diagonal();
+            he_length = - 1.0 / he_length.array();
+            HS = he_length.asDiagonal();
+        }
+
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void dual_hs2(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS)
+        {
+            hs2(V, F, HS);
+            auto area = HS.diagonal();
+            area = 1.0 / area.array();
+            HS = area.asDiagonal();
+        }
+
+    }
+}

--- a/include/igl/discrete_exterior_calculus.h
+++ b/include/igl/discrete_exterior_calculus.h
@@ -1,0 +1,171 @@
+
+#ifndef IGL_DISCRETE_EXTERIOR_CALCULUS_H
+#define IGL_DISCRETE_EXTERIOR_CALCULUS_H
+
+#include "igl_inline.h"
+#include <Eigen/Dense>
+#include <Eigen/Sparse>
+
+namespace igl
+{
+    namespace dec2d
+    {
+        /*
+         * Discrete Exterior Calculus Operators based on Halfedge concept
+         *
+         * There are two operators in exterior calculus: derivative operator d, and 
+         * hodge star operator *. They have different behaviors when operate on 
+         * different object (0-form, 1-from and 2-from), so here we distinguash them
+         * by adding prefix
+         *
+         *         V  --- d0 -->  E  -- d1 -->  F       (original graph)
+         *         |              |             | 
+         *      *0 |           *1 |          *2 |
+         *         v              v             v
+         *         V* <-- ~d0 --- E* <-- ~d1 -- F*      (dual graph)
+         *
+         *   V: Represents of 0-form on vertex. 
+         *      R^|V|, Row i represents 0-form value on v_i.
+         *
+         *   E: Represents of 1-form on halfedge.
+         *      R^|E| = R^|3F|, Row 3*i+j represents integration of 1-form along 
+         *      the j th halfedge of orinted triangle i, in its interior.
+         *
+         *   F: Represents of 2-form on triangle face.
+         *      R^|F|, row i represents integration of 2-form on triangle i.
+         *   
+         *   V*: Represents of 2-form on dual vertex.
+         *      R^|V|, row i represents integration of 2-form on dual area of vertex i.
+         *
+         *   E*: Represents of 1-form on dual halfedge.
+         *      R^|E| = R^|3F|, row 3*i+j represents integration of 1-form along
+         *      the dual edge of j th halfedge of orinted triangle i.
+         *
+         *   F*: Represents of 0-form on dual triangle face.
+         *      R^|F|, row i represents 0-form value on dual vertex of triangle i.
+         *
+         *   d0:  d operator on 0-form represented by vertex, results in 1-form 
+         *      represented by halfedge. R^{|E|*|V|}.
+         *   d1:  d operator on 1-form represented by halfedge, results in 2-form 
+         *      represented by triangle face. R^{|F|*|E|}.
+         *   ~d0: d operator on 1-form represented by dual halfedge, results in 
+         *      2-form represented by dual vertex. R^{|V|*|E|}.
+         *   ~d1: d operator on 0-form represented by dual face, results in 1-form 
+         *      represented by dual halfedge. R^{|E|*|F|}.
+         *
+         *   *0: hodge-star operator on 0-form represented by vertex, results in 
+         *      2-form represented by dual vertex, R^{|V|*|V|}.
+         *   *1: hodge-star operator on 1-form represented by halfedge, results 
+         *      in 1-form represented by dual halfedge, R^{|E|*|E|}.
+         *   *2: hodge-star operator on 2-form represented by triangle face, 
+         *      results in 0-form represented by dual triangle face, R^{|F|*|F|}.
+         *   ~*0: hodge-star operator on 2-form represented by dual vertex, results 
+         *      in 0-form represented by vertex, R^{|V|*|V|}. 
+         *   ~*1: hodge-star operator on 1-form represented by dual halfedge, results 
+         *      in 1-form represented by halfedge, R^{|E|*|E|}.
+         *   ~*2: hodge-star operator on 0-form represented by dual face vertex, 
+         *      results in 2-form represented by triangle face, R^{|F|*|F|}.
+         */
+
+
+        /*  Consctruct exterior derivative operator
+         *
+         *  Templates:
+         *      DerivedV derived from vertex positions matrix type: i.e. MatrixXd
+         *      DerivedF derived from face indices matrix type: i.e. MatrixXi
+         *      Scalar derived from sparse matrix type: i.e. SparseMatrix<double>
+         *
+         *  Inputs:
+         *      V eigen matrix #V by 3
+         *      F #F by 3 list of mesh faces (must be triangles)
+         *
+         *  Outputs:
+         *      D exterior derivative operator represented in SparseMatrix
+         */
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void d0(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& D);
+        
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void d1(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& D);
+
+        /* ~d0 = - 1/2 * transpose(d0) */
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void dual_d0(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& D);
+
+        /* ~d1 = 2 * transpose(d1) */
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void dual_d1(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& D);
+        
+        /*  Consctruct hodge star operator
+         *
+         *  Templates:
+         *      DerivedV derived from vertex positions matrix type: i.e. MatrixXd
+         *      DerivedF derived from face indices matrix type: i.e. MatrixXi
+         *      Scalar derived from sparse matrix type: i.e. SparseMatrix<double>
+         *
+         *  Inputs:
+         *      V eigen matrix #V by 3
+         *      F #F by 3 list of mesh faces (must be triangles)
+         *
+         *  Outputs:
+         *      HS hodge star operator represented in SparseMatrix
+         */
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void hs0(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS);
+
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void hs1(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS);
+
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void hs2(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS);
+
+        /* ~*0 = inverse(*0) */
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void dual_hs0(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS);
+
+        /* ~*1 = - inverse(*1) */
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void dual_hs1(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS);
+        
+        /* ~*2 = inverse(*2)*/
+        template <typename DerivedV, typename DerivedF, typename Scalar>
+        IGL_INLINE void dual_hs2(
+                const Eigen::MatrixBase<DerivedV>& V,
+                const Eigen::MatrixBase<DerivedF>& F,
+                Eigen::SparseMatrix<Scalar>& HS);
+    }
+}
+
+
+#ifndef IGL_STATIC_LIBRARY
+#include "discrete_exterior_calculus.cpp"
+#endif
+
+#endif

--- a/include/igl/halfedge_flip.cpp
+++ b/include/igl/halfedge_flip.cpp
@@ -1,0 +1,73 @@
+
+#include "halfedge_flip.h"
+#include "parallel_for.h"
+#include "sortrows.h"
+#include <iostream>
+
+#define min(x, y) ((x < y) ? x : y)
+#define max(x, y) ((x > y) ? x : y) 
+
+template <typename DerivedF, typename DerivedHE>
+IGL_INLINE void igl::halfedge_flip(
+    const Eigen::MatrixBase<DerivedF>& F,
+    Eigen::PlainObjectBase<DerivedHE>& HE)
+{
+    using namespace std;
+    const int m = F.rows();
+    switch(F.cols())
+    {
+        case 3:
+        {
+            /* each row is (v_start, v_target, f_id, e_rank) */
+            Eigen::MatrixXi H(3 * m, 4);
+            parallel_for(
+                m,
+                [&F, &H](const int i)
+                {
+                    int v0 = F(i, 0);
+                    int v1 = F(i, 1);
+                    int v2 = F(i, 2);
+
+                    H.row(3 * i    ) << min(v1, v2), max(v1, v2), i, 0;
+                    H.row(3 * i + 1) << min(v2, v0), max(v2, v0), i, 1;
+                    H.row(3 * i + 2) << min(v0, v1), max(v0, v1), i, 2;
+                },
+                1000);
+
+            /* sort H and then get halfedge pairs */
+            Eigen::MatrixXi H_sort;
+            Eigen::VectorXi I;
+            sortrows(H, true, H_sort, I);
+            
+            /* extract opposite adjacency */
+            HE = - Eigen::PlainObjectBase<DerivedHE>::Ones(m, 3);
+            int iter = 1;
+            while (iter < 3 * m)
+            {
+                /* if the halfedge matches, write to adjT and adjR */
+                if (H_sort(iter, 0) == H_sort(iter - 1, 0) &&
+                    H_sort(iter, 1) == H_sort(iter - 1, 1))
+                {
+                    /* get useful information (f_id, v_rank, v_id) */
+                    auto a = H_sort.row(iter).tail(2);
+                    auto b = H_sort.row(iter - 1).tail(2);
+
+                    /* record halfedge flip relation */
+                    HE(a(0), a(1)) = 3 * b(0) + b(1);
+                    HE(b(0), b(1)) = 3 * a(0) + a(1);
+
+                    iter += 2;
+                }else{
+                    iter++;
+                }
+            }
+            break;
+        }
+        default:
+        {
+            cerr << "opposite_adjacency.h: Error: Simplex size ("<< F.cols() <<
+                ") not supported" << endl;
+            assert(false);
+        }
+    }
+};

--- a/include/igl/halfedge_flip.h
+++ b/include/igl/halfedge_flip.h
@@ -1,0 +1,36 @@
+
+#ifndef IGL_HALFEDGE_FLIP_H
+#define IGL_HALFEDGE_FLIP_H
+
+#include "igl_inline.h"
+#include <Eigen/Dense>
+namespace igl
+{
+    /*
+     * Get information of halfedge flips of triangle meshes
+     *
+     *  Templates:
+     *      DerivedF derived from face indices matrix type: i.e. MatrixXi
+     *      DerivedHE derived from halfedge flip matrix type: i.e. MatrixXi
+     *
+     *  Inputs:
+     *      F #F by 3 list of mesh faces (must be triangles)
+     *
+     *  Outputs:
+     *      HE #F by 3 list of id of flipped halfedge, HE(i, j) = 3 * u + v stands
+     *          for flip relation between halfedge (3 * i + j) and (3 * u + v).
+     *          The id (3 * i + j) of a halfedge depends on the tirangle id (i) 
+     *          it belongs to and corresponding vertex rank (j \in {0, 1, 2})
+     */
+    template <typename DerivedF, typename DerivedHE>
+    IGL_INLINE void halfedge_flip(
+            const Eigen::MatrixBase<DerivedF>& F,
+            Eigen::PlainObjectBase<DerivedHE>& HE);
+}
+
+#ifndef IGL_STATIC_LIBRARY
+#include "halfedge_flip.cpp"
+#endif
+
+
+#endif


### PR DESCRIPTION
- add `halfedge_flip.h/cpp` to compute half-edge topology, maybe duplicate with `edge_flaps` or `edge_topology`
- add `discrete_exterior_calculus.h/cpp`, which implement DEC.

There are several difference between standard algorithms and this implementation:
- the 1-form is represented on half-edges rather than edges, since half-edges are much easier to address than edges in the (V, F) representation
- the voronoi area of vertex is approximated by 1/3 of sum of its neighbor triangle faces.