### PR TITLE
Allowing per-corner-uvs when face_based rendering is true in viewer. 

### DIFF
--- a/include/igl/viewer/OpenGL_state.cpp
+++ b/include/igl/viewer/OpenGL_state.cpp
@@ -160,7 +160,7 @@ IGL_INLINE void igl::viewer::OpenGL_state::set_data(const igl::viewer::ViewerDat
         V_uv_vbo.resize(2,data.F.rows()*3);
         for (unsigned i=0; i<data.F.rows();++i)
           for (unsigned j=0;j<3;++j)
-            V_uv_vbo.col(i*3+j) = data.V_uv.row(data.F(i,j)).transpose().cast<float>();
+            V_uv_vbo.col(i*3+j) = data.V_uv.row(per_corner_uv ? data.F_uv(i,j) : data.F(i,j)).transpose().cast<float>();
       }
     }
   }


### PR DESCRIPTION
This minor fix allows the viewer code to render textures with per-corner-uvs
defined even when face_based is set to false. I think the face_based rendering
property shouldn't affect the way UVs should be interpreted.