### PR TITLE
Bug Fix for 2d uniform grad

### DIFF
--- a/include/igl/grad.cpp
+++ b/include/igl/grad.cpp
@@ -139,7 +139,7 @@ IGL_INLINE void grad_tri(const Eigen::PlainObjectBase<DerivedV>&V,
     // This does correct l2 norm of rows, so that it contains #F list of twice
     // triangle areas
     double dblA = std::sqrt(n.dot(n));
-    Eigen::Matrix<typename DerivedV::Scalar, 1, 3> u;
+    Eigen::Matrix<typename DerivedV::Scalar, 1, 3> u(0,0,1);
     if (!uniform) {
       // now normalize normals to get unit normals
       u = n / dblA;


### PR DESCRIPTION
`u` is not initialized or computed in the `else` `(uniform == true)` branch at 4 lines below. It can cause some error afterward.