### PR TITLE
add while loop for comb_cross_field.cpp, making comb support separated manifold

### DIFF
--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -145,6 +145,7 @@ namespace glfw
     #ifdef __APPLE__
       glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
       glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+      glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
     #endif
     if(fullscreen)
     {


### PR DESCRIPTION
I run into an assertion error when running Example 505 (505_MIQ) on my custom mesh (made of an inner surface and a outer surface), and found that comb() function does not support manifold with separated parts.

I did a minor modification: add while loop outside of the flood fill loop, and then it works well. So is it proper to merge into the main repo?