### PR TITLE
Adds interface for the multi-zone mesh generation capabilities of TetGen

### DIFF
--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
@@ -56,6 +56,7 @@ IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
     }
   }
   
+  in.numberofholes = H.size(); 
   in.holelist = new double[3 * in.numberofholes];
   // loop over holes
   for(size_t holeID = 0, nHoles = H.size(); holeID < nHoles; holeID++)
@@ -66,6 +67,7 @@ IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
   }	  
 
   in.numberofregions = R.size();
+  cout << "Input number of regions in library: " << in.numberofregions << endl << flush;
   in.regionlist = new REAL[ 5 * in.numberofregions];
   // loop over regions
   for(size_t regionID = 0, nRegions = R.size(); regionID < nRegions; regionID++)

--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
@@ -17,8 +17,8 @@
 IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
   const std::vector<std::vector<REAL > > & V,
   const std::vector<std::vector<int> > & F,
-  const std::vector<std::vector<REAL> > & H, // hole points
-  const std::vector<std::vector<REAL> > & R, // region points
+  const std::vector<std::vector<REAL> > & H, 
+  const std::vector<std::vector<REAL> > & R, 
   tetgenio & in)
 {
   using namespace std;
@@ -67,7 +67,6 @@ IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
   }	  
 
   in.numberofregions = R.size();
-  cout << "Input number of regions in library: " << in.numberofregions << endl << flush;
   in.regionlist = new REAL[ 5 * in.numberofregions];
   // loop over regions
   for(size_t regionID = 0, nRegions = R.size(); regionID < nRegions; regionID++)

--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
@@ -28,7 +28,7 @@ IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
   //loop over points
   for(size_t i = 0; i < (size_t)V.size(); i++)
   {
-    assert(V[i].size() == 3)
+    assert(V[i].size() == 3);
     in.pointlist[i*3+0] = V[i][0];
     in.pointlist[i*3+1] = V[i][1];
     in.pointlist[i*3+2] = V[i][2];    
@@ -56,7 +56,7 @@ IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
     }
   }
   
-  in.numberofholes = new double[3 * in.numberofholes];
+  in.holelist = new double[3 * in.numberofholes];
   // loop over holes
   for(size_t holeID = 0, nHoles = H.size(); holeID < nHoles; holeID++)
   {
@@ -70,11 +70,11 @@ IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
   // loop over regions
   for(size_t regionID = 0, nRegions = R.size(); regionID < nRegions; regionID++)
   {
-    in.regionlist[holeID * 5 + 0] = H[holeID][0]; 
-    in.regionlist[holeID * 5 + 1] = H[holeID][1];
-    in.regionlist[holeID * 5 + 2] = H[holeID][2];
-    in.regionlist[holeID * 5 + 3] = H[holeID][3];
-    in.regionlist[holeID * 5 + 4] = H[holeID][4]
+    in.regionlist[regionID * 5 + 0] = R[regionID][0]; 
+    in.regionlist[regionID * 5 + 1] = R[regionID][1];
+    in.regionlist[regionID * 5 + 2] = R[regionID][2];
+    in.regionlist[regionID * 5 + 3] = R[regionID][3];
+    in.regionlist[regionID * 5 + 4] = R[regionID][4];
   }	  
 
   return true;

--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
@@ -13,6 +13,77 @@
 // STL includes
 #include <cassert>
 
+
+
+IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
+  const std::vector<std::vector<REAL > > & V,
+  const std::vector<std::vector<int> > & F,
+  const std::vector<std::vector<REAL> > & H,
+  const std::vector<std::vector<REAL> > & R,
+  tetgenio & in)
+{
+  using namespace std;
+  in.firstnumber = 0;
+  in.numberofpoints = V.size();
+  in.pointlist = new REAL[in.numberofpoints * 3];
+  //loop over points
+  for(size_t i = 0; i < (size_t)V.size(); i++)
+  {
+    assert(V[i].size() == 3)
+    in.pointlist[i*3+0] = V[i][0];
+    in.pointlist[i*3+1] = V[i][1];
+    in.pointlist[i*3+2] = V[i][2];    
+  }
+  in.numberoffacets = F.size();
+  in.facetlist = new tetgenio::facet[in.numberoffacets];
+  in.facetmarkerlist = new int[in.numberoffacets];
+
+  // loop over face
+  for(size_t i = 0;i < (size_t)F.size(); i++)
+  {
+    in.facetmarkerlist[i] = i;
+    tetgenio::facet * f = &in.facetlist[i];
+    f->numberofpolygons = 1;
+    f->polygonlist = new tetgenio::polygon[f->numberofpolygons];
+    f->numberofholes = 0;
+    f->holelist = NULL;
+    tetgenio::polygon * p = &f->polygonlist[0];
+    p->numberofvertices = F[i].size();
+    p->vertexlist = new int[p->numberofvertices];
+    // loop around face
+    for(int j = 0;j < (int)F[i].size(); j++)
+    {
+      p->vertexlist[j] = F[i][j];
+    }
+  }
+  
+  in.numberofholes = new double[3 * in.numberofholes];
+  // loop over holes
+  for(size_t holeID = 0, nHoles = H.size(); holeID < nHoles; holeID++)
+  {
+    in.holelist[holeID * 3 + 0] = H[holeID][0]; 
+    in.holelist[holeID * 3 + 1] = H[holeID][1];
+    in.holelist[holeID * 3 + 2] = H[holeID][2];
+  }	  
+
+  in.numberofregions = R.size();
+  in.regionlist = new REAL[ 5 * in.numberofregions];
+  // loop over regions
+  for(size_t regionID = 0, nRegions = R.size(); regionID < nRegions; regionID++)
+  {
+    in.regionlist[holeID * 5 + 0] = H[holeID][0]; 
+    in.regionlist[holeID * 5 + 1] = H[holeID][1];
+    in.regionlist[holeID * 5 + 2] = H[holeID][2];
+    in.regionlist[holeID * 5 + 3] = H[holeID][3];
+    in.regionlist[holeID * 5 + 4] = H[holeID][4]
+  }	  
+
+  return true;
+    
+}	
+
+
+
 IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
   const std::vector<std::vector<REAL > > & V, 
   const std::vector<std::vector<int> > & F, 

--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
@@ -81,6 +81,23 @@ IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
     
 }	
 
+template <typename DerivedV, typename DerivedF, typename DerivedH, typename DerivedR>
+IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
+  const Eigen::PlainObjectBase<DerivedV>& V,
+  const Eigen::PlainObjectBase<DerivedF>& F,
+  const Eigen::PlainObjectBase<DerivedH>& H,
+  const Eigen::PlainObjectBase<DerivedR>& R,
+  tetgenio & in)
+{
+  using namespace std;
+  vector<vector<REAL> > vV, vH, vR;
+  vector<vector<int> > vF;
+  matrix_to_list(V,vV);
+  matrix_to_list(F,vF);
+  matrix_to_list(H, vH);
+  matrix_to_list(R, vR);
+  return mesh_to_tetgenio(vV,vF,vH,vR,in);
+}
 
 
 IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(

--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
@@ -14,12 +14,11 @@
 #include <cassert>
 
 
-
 IGL_INLINE bool igl::copyleft::tetgen::mesh_to_tetgenio(
   const std::vector<std::vector<REAL > > & V,
   const std::vector<std::vector<int> > & F,
-  const std::vector<std::vector<REAL> > & H,
-  const std::vector<std::vector<REAL> > & R,
+  const std::vector<std::vector<REAL> > & H, // hole points
+  const std::vector<std::vector<REAL> > & R, // region points
   tetgenio & in)
 {
   using namespace std;

--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.h
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.h
@@ -44,19 +44,36 @@ namespace igl
         const Eigen::PlainObjectBase<DerivedF>& F,
         tetgenio & in);
     
+
+      // Load a vertex list and face list into a tetgenio object
+      // Inputs:
+      //   V  #V by 3 vertex position list
+      //   F  #F list of polygon face indices into V (0-indexed)
+      //   H  #H list of seed point inside each hole
+      //   R  #R list of seed point inside each region	
+      // Outputs:
+      //   in  tetgenio input object
+      // Returns true on success, false on error
       IGL_INLINE bool mesh_to_tetgenio(
         const std::vector<std::vector<REAL> > & V,
 	const std::vector<std::vector<int> > & F,
-	const std::vector<std::vector<REAL > > & H, // holes
-	const std::vector<std::vector<REAL > > & R, // regions
+	const std::vector<std::vector<REAL > > & H, 
+	const std::vector<std::vector<REAL > > & R, 
 	tetgenio & in);	
-      
+
+
+      // Wrapper with Eigen types
+      // Templates:
+      //   DerivedV  real-value: i.e. from MatrixXd
+      //   DerivedF  integer-value: i.e. from MatrixXi
+      //   DerivedH  real-value
+      //   DerivedR  real-value		      
       template <typename DerivedV, typename DerivedF, typename DerivedH, typename DerivedR>
       IGL_INLINE bool mesh_to_tetgenio(
 	const Eigen::PlainObjectBase<DerivedV>& V,
 	const Eigen::PlainObjectBase<DerivedF>& F,
-	const Eigen::PlainObjectBase<DerivedH>& H, // holes
-	const Eigen::PlainObjectBase<DerivedR>& R, // regions
+	const Eigen::PlainObjectBase<DerivedH>& H, 
+	const Eigen::PlainObjectBase<DerivedR>& R, 
 	tetgenio& in);	
     }
   }

--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.h
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.h
@@ -43,6 +43,13 @@ namespace igl
         const Eigen::PlainObjectBase<DerivedV>& V,
         const Eigen::PlainObjectBase<DerivedF>& F,
         tetgenio & in);
+    
+      IGL_INLINE bool mesh_to_tetgenio(
+        const std::vector<std::vector<REAL> > & V,
+	const std::vector<std::vector<int> > & F,
+	const std::vector<std::vector<REAL > > & H, // holes
+	const std::vector<std::vector<REAL > > & R, // regions
+	tetgenio & in);	
     }
   }
 }

--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.h
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.h
@@ -50,6 +50,14 @@ namespace igl
 	const std::vector<std::vector<REAL > > & H, // holes
 	const std::vector<std::vector<REAL > > & R, // regions
 	tetgenio & in);	
+      
+      typename <typename DerivedV, typename DerivedF, typename DerivedH, typename DerivedR>
+      IGL_INLINE bool mesh_to_tetgenio(
+	const Eigen::PlainObjectBase<DerivedV>& V,
+	const Eigen::PlainObjectBase<DerivedF>& F,
+	const Eigen::PlainObjectBase<DerivedH>& H, // holes
+	const Eigen::PlainObjectBase<DerivedR>& R, // regions
+	tetgenio& in);	
     }
   }
 }

--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.h
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.h
@@ -51,7 +51,7 @@ namespace igl
 	const std::vector<std::vector<REAL > > & R, // regions
 	tetgenio & in);	
       
-      typename <typename DerivedV, typename DerivedF, typename DerivedH, typename DerivedR>
+      template <typename DerivedV, typename DerivedF, typename DerivedH, typename DerivedR>
       IGL_INLINE bool mesh_to_tetgenio(
 	const Eigen::PlainObjectBase<DerivedV>& V,
 	const Eigen::PlainObjectBase<DerivedF>& F,

--- a/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
+++ b/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
@@ -22,9 +22,10 @@ IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
   std::vector<std::vector<int > >& N,
   std::vector<std::vector<int > >& PT,
   std::vector<std::vector<int > >& FT,
-  size_t nR ) 
+  size_t & nR ) 
 {
    using namespace std;
+   cout << "inside tetgeniototetmesh!!" << flush << endl;	
    // process points
    if(out.pointlist == NULL)
    {
@@ -63,6 +64,7 @@ IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
        max_index = (max_index < index ? index : max_index);
      }
    }
+  
    assert(min_index >= 0);
    assert(max_index >= 0);
    assert(max_index < (int)V.size());
@@ -85,34 +87,49 @@ IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
      }
    }
 
-   
-   // extract region marks
-   nR = out.numberofregions;
-   R.resize(out.numberoftetrahedra, vector<REAL>(out.numberoftetrahedronattributes));
+   R.resize(out.numberoftetrahedra, vector<REAL>(1));
+   unordered_map<REAL, REAL> hashUniqueRegions;
    for(size_t i = 0; i < out.numberoftetrahedra; i++)
    {
-	for (size_t tetAttributeID = 0; tetAttributeID < out.numberoftetrahedronattributes; tetAttributeID++)
-		R[i][tetAttributeID] = out.tetrahedronattributelist[i * out.numberoftetrahedronattributes + tetAttributeID];
+//	for (size_t tetAttributeID = 0; tetAttributeID < 1; tetAttributeID++)
+		R[i][0] = out.tetrahedronattributelist[i];
+   		hashUniqueRegions[R[i][0]] = i;
    }
+  // extract region marks
+   nR = hashUniqueRegions.size();
+
+   cout << "Number of regions in library: " << nR << endl << flush;
 
    // extract neighbor list 
+   N.resize(out.numberoftetrahedra, vector<int>(4));   
    for (size_t i = 0; i < out.numberoftetrahedra; i++)
    {
 	for (size_t j = 0; j < 4; j++)
 		N[i][j] = out.neighborlist[i * 4 + j];
    } 
-   
+  
    // extract point 2 tetrahedron list 
-   for (size_t i = 0; i < out.numberofpoints; i++)
+   PT.resize(out.numberofpoints, vector<int>(1));
+   if (out.point2tetlist != NULL)
    {
-	PT[i][0] = out.point2tetlist[i]; 
+	for (size_t i = 0; i < out.numberofpoints; i++)
+	   {
+		PT[i][0] = out.point2tetlist[i]; 
+	   }	
+   	cout << "No probs!!" << endl << flush;
    }
+   else
+	{
+		cout << "NULL11" << endl << flush;
+	}
+ 
    //extract face to tetrahedron list
+/*   FT.resize(out.numberoftrifaces, vector<int>(1));
    for (size_t i = 0; i < out.numberoftrifaces; i++)
    {
 	FT[i][0] = out.face2tetlist[i]; 
    }
-
+*/
    return true;
 }
 

--- a/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
+++ b/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
@@ -19,6 +19,8 @@ IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
   std::vector<std::vector<int> > & T,
   std::vector<std::vector<int > > & F,
   std::vector<std::vector<REAL > >&  R, // region marks for tetrahedron
+  std::vector<std::vector<int > >& N,
+  std::vector<std::vector<int > >& PT,
   size_t nR ) 
 {
    using namespace std;
@@ -90,6 +92,19 @@ IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
    {
 	for (size_t tetAttributeID = 0; tetAttributeID < out.numberoftetrahedronattributes; tetAttributeID++)
 		R[i][tetAttributeID] = out.tetrahedronattributelist[i * out.numberoftetrahedronattributes + tetAttributeID];
+   }
+
+   // extract neighbor list TODO
+   for (size_t i = 0; i < out.numberoftetrahedra; i++)
+   {
+	for (size_t j = 0; j < 4; j++)
+		N[i][j] = out.neighborlist[i * 4 + j];
+   } 
+   
+   // extract point 2 tetrahedron list TODO
+   for (size_t i = 0; i < out.numberofpoints; i++)
+   {
+	PT[i][0] = out.point2tetlist[i]; 
    }
 
    return true;

--- a/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
+++ b/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
@@ -18,9 +18,9 @@ IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
   std::vector<std::vector<REAL > > & V,
   std::vector<std::vector<int> > & T,
   std::vector<std::vector<int > > & F,
-  size_t nR,
-  std::vector<std::vector<REAL > > & R) // region marks for tetrahedron
- {
+  std::vector<std::vector<REAL > >&  R, // region marks for tetrahedron
+  size_t nR ) 
+{
    using namespace std;
    // process points
    if(out.pointlist == NULL)
@@ -85,10 +85,13 @@ IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
    
    // extract region marks
    nR = out.numberofregions;
-   R = new REAL[out.numberoftetrahedra];
+   R.resize(out.numberoftetrahedra, vector<REAL>(out.numberoftetrahedronattributes));
    for(size_t i = 0; i < out.numberoftetrahedra; i++)
-     R[i] = out.tetrahedronattributelist[i];
-   
+   {
+	for (size_t tetAttributeID = 0; tetAttributeID < out.numberoftetrahedronattributes; tetAttributeID++)
+		R[i][tetAttributeID] = out.tetrahedronattributelist[i * out.numberoftetrahedronattributes + tetAttributeID];
+   }
+
    return true;
 }
 

--- a/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
+++ b/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
@@ -15,6 +15,86 @@
 
 IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
   const tetgenio & out,
+  std::vector<std::vector<REAL > > & V,
+  std::vector<std::vector<int> > & T,
+  std::vector<std::vector<int > > & F,
+  size_t nR,
+  std::vector<std::vector<REAL > > & R) // region marks for tetrahedron
+ {
+   using namespace std;
+   // process points
+   if(out.pointlist == NULL)
+   {
+     cerr<<"^tetgenio_to_tetmesh Error: point list is NULL\n"<<endl;
+     return false;
+   }
+   V.resize(out.numberofpoints,vector<REAL>(3));
+   // loop over points
+   for(int i = 0;i < out.numberofpoints; i++)
+   {
+     V[i][0] = out.pointlist[i*3+0];
+     V[i][1] = out.pointlist[i*3+1];
+     V[i][2] = out.pointlist[i*3+2];
+   }
+
+   // process tets
+   if(out.tetrahedronlist == NULL)
+   {
+     cerr<<"^tetgenio_to_tetmesh Error: tet list is NULL\n"<<endl;
+     return false;
+   }
+
+   // When would this not be 4?
+   assert(out.numberofcorners == 4);
+   T.resize(out.numberoftetrahedra,vector<int>(out.numberofcorners));
+   int min_index = 1e7;
+   int max_index = -1e7;
+   // loop over tetrahedra
+   for(int i = 0; i < out.numberoftetrahedra; i++)
+   {
+     for(int j = 0; j<out.numberofcorners; j++)
+     {
+       int index = out.tetrahedronlist[i * out.numberofcorners + j];
+       T[i][j] = index;
+       min_index = (min_index > index ? index : min_index);
+       max_index = (max_index < index ? index : max_index);
+     }
+   }
+   assert(min_index >= 0);
+   assert(max_index >= 0);
+   assert(max_index < (int)V.size());
+ 
+   cout<<out.numberoftrifaces<<endl;
+
+   // When would this not be 4?
+   F.clear();
+   // loop over tetrahedra
+   for(int i = 0; i < out.numberoftrifaces; i++)
+   {
+     if(out.trifacemarkerlist[i]>=0)
+     {
+       vector<int> face(3);
+       for(int j = 0; j<3; j++)
+       {
+         face[j] = out.trifacelist[i * 3 + j];
+       }
+       F.push_back(face);
+     }
+   }
+
+   
+   // extract region marks
+   nR = out.numberofregions;
+   R = new REAL[out.numberoftetrahedra];
+   for(size_t i = 0; i < out.numberoftetrahedra; i++)
+     R[i] = out.tetrahedronattributelist[i];
+   
+   return true;
+}
+
+
+IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
+  const tetgenio & out,
   std::vector<std::vector<REAL > > & V, 
   std::vector<std::vector<int> > & T,
   std::vector<std::vector<int> > & F)

--- a/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
+++ b/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
@@ -18,14 +18,13 @@ IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
   std::vector<std::vector<REAL > > & V,
   std::vector<std::vector<int> > & T,
   std::vector<std::vector<int > > & F,
-  std::vector<std::vector<REAL > >&  R, // region marks for tetrahedron
+  std::vector<std::vector<REAL > >&  R, 
   std::vector<std::vector<int > >& N,
   std::vector<std::vector<int > >& PT,
   std::vector<std::vector<int > >& FT,
   size_t & nR ) 
 {
    using namespace std;
-   cout << "inside tetgeniototetmesh!!" << flush << endl;	
    // process points
    if(out.pointlist == NULL)
    {
@@ -91,45 +90,39 @@ IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
    unordered_map<REAL, REAL> hashUniqueRegions;
    for(size_t i = 0; i < out.numberoftetrahedra; i++)
    {
-//	for (size_t tetAttributeID = 0; tetAttributeID < 1; tetAttributeID++)
-		R[i][0] = out.tetrahedronattributelist[i];
-   		hashUniqueRegions[R[i][0]] = i;
+	R[i][0] = out.tetrahedronattributelist[i];
+	hashUniqueRegions[R[i][0]] = i;
    }
-  // extract region marks
+   // extract region marks
    nR = hashUniqueRegions.size();
-
-   cout << "Number of regions in library: " << nR << endl << flush;
 
    // extract neighbor list 
    N.resize(out.numberoftetrahedra, vector<int>(4));   
    for (size_t i = 0; i < out.numberoftetrahedra; i++)
    {
-	for (size_t j = 0; j < 4; j++)
-		N[i][j] = out.neighborlist[i * 4 + j];
+     for (size_t j = 0; j < 4; j++)
+       N[i][j] = out.neighborlist[i * 4 + j];
    } 
   
    // extract point 2 tetrahedron list 
    PT.resize(out.numberofpoints, vector<int>(1));
-   if (out.point2tetlist != NULL)
+   for (size_t i = 0; i < out.numberofpoints; i++)
    {
-	for (size_t i = 0; i < out.numberofpoints; i++)
-	   {
-		PT[i][0] = out.point2tetlist[i]; 
-	   }	
-   	cout << "No probs!!" << endl << flush;
-   }
-   else
-	{
-		cout << "NULL11" << endl << flush;
-	}
+     PT[i][0] = out.point2tetlist[i]; 
+   }	
  
    //extract face to tetrahedron list
-/*   FT.resize(out.numberoftrifaces, vector<int>(1));
+   FT.resize(out.numberoftrifaces, vector<int>(2)); 
+   int triface;
+   
    for (size_t i = 0; i < out.numberoftrifaces; i++)
    {
-	FT[i][0] = out.face2tetlist[i]; 
+     for (size_t j = 0; j < 2; j++)
+     {
+       FT[i][j] = out.face2tetlist[0]; 
+     }
    }
-*/
+
    return true;
 }
 

--- a/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
+++ b/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.cpp
@@ -21,6 +21,7 @@ IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
   std::vector<std::vector<REAL > >&  R, // region marks for tetrahedron
   std::vector<std::vector<int > >& N,
   std::vector<std::vector<int > >& PT,
+  std::vector<std::vector<int > >& FT,
   size_t nR ) 
 {
    using namespace std;
@@ -94,17 +95,22 @@ IGL_INLINE bool igl::copyleft::tetgen::tetgenio_to_tetmesh(
 		R[i][tetAttributeID] = out.tetrahedronattributelist[i * out.numberoftetrahedronattributes + tetAttributeID];
    }
 
-   // extract neighbor list TODO
+   // extract neighbor list 
    for (size_t i = 0; i < out.numberoftetrahedra; i++)
    {
 	for (size_t j = 0; j < 4; j++)
 		N[i][j] = out.neighborlist[i * 4 + j];
    } 
    
-   // extract point 2 tetrahedron list TODO
+   // extract point 2 tetrahedron list 
    for (size_t i = 0; i < out.numberofpoints; i++)
    {
 	PT[i][0] = out.point2tetlist[i]; 
+   }
+   //extract face to tetrahedron list
+   for (size_t i = 0; i < out.numberoftrifaces; i++)
+   {
+	FT[i][0] = out.face2tetlist[i]; 
    }
 
    return true;

--- a/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.h
+++ b/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.h
@@ -61,8 +61,9 @@ namespace igl
 	std::vector<std::vector<REAL > > & V,
 	std::vector<std::vector<int> > & T,
         std::vector<std::vector<int> > & F, 
-	size_t nR, // number of regions
-	std::vector<std::vector<REAL> > & R); // region marks for tetrahedrons	
+	std::vector<std::vector<REAL> > & R,// region marks for tetrahedrons	
+	size_t nR // number of regions
+);    
     }
   }
 }

--- a/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.h
+++ b/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.h
@@ -14,6 +14,7 @@
 #endif
 #include "tetgen.h" // Defined tetgenio, REAL
 #include <vector>
+#include <unordered_map>
 #include <Eigen/Core>
 namespace igl
 {
@@ -55,7 +56,19 @@ namespace igl
         Eigen::PlainObjectBase<DerivedV>& V,
         Eigen::PlainObjectBase<DerivedT>& T);
     
-      // Support for region marking for each tetrahedron
+      // Extract a tetrahedral mesh from a tetgenio object
+      // Inputs:
+      //   out tetgenio output object
+      // Outputs:
+      //   V  #V by 3 vertex position list
+      //   T  #T by 4 list of tetrahedra indices into V
+      //   F  #F by 3 list of marked facets
+      //   R  #T list of region IDs for tetrahedra
+      //   N  #T by 2 list of neighbors for each tetrahedron
+      //   PT #V list of incident tetrahedron for each vertex
+      //   FT #F by 2 list of tetrahedra sharing each face 
+      //   nR number of regions in output mesh
+      // Returns true on success, false on error
       IGL_INLINE bool tetgenio_to_tetmesh(
         const tetgenio & out,
 	std::vector<std::vector<REAL > > & V,
@@ -65,23 +78,9 @@ namespace igl
 	std::vector<std::vector<int > > &N, // neighborlist per tet
 	std::vector<std::vector<int > >	&PT, // Point to tet list per point
 	std::vector<std::vector<int > > &FT, // face to tet list
-	size_t nR); // number of regions    
+	size_t & nR); // number of regions    
 
-      // Wrapper with Eigen types
-      // Templates:
-      //   DerivedV  real-value: i.e. from MatrixXd
-      //   DerivedT  integer-value: i.e. from MatrixXi
-      template <typename DerivedV, typename DerivedT, typename DerivedF>
-      IGL_INLINE bool tetgenio_to_tetmesh(
-        const tetgenio & out,
-        Eigen::PlainObjectBase<DerivedV>& V,
-        Eigen::PlainObjectBase<DerivedT>& T,
-        Eigen::PlainObjectBase<DerivedF>& F,
-	Eigen::PlainObjectBase<DerivedT>& N,
-	Eigen::PlainObjectBase<DerivedT>& PT,
-	Eigen::PlainObjectBase<DerivedT>& FT, 
-	size_t nR);
-    }
+  }
   }
 }
 

--- a/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.h
+++ b/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.h
@@ -64,6 +64,7 @@ namespace igl
 	std::vector<std::vector<REAL> > & R,// region marks for tetrahedrons
 	std::vector<std::vector<int > > &N, // neighborlist per tet
 	std::vector<std::vector<int > >	&PT, // Point to tet list per point
+	std::vector<std::vector<int > > &FT, // face to tet list
 	size_t nR); // number of regions    
 
       // Wrapper with Eigen types
@@ -78,6 +79,7 @@ namespace igl
         Eigen::PlainObjectBase<DerivedF>& F,
 	Eigen::PlainObjectBase<DerivedT>& N,
 	Eigen::PlainObjectBase<DerivedT>& PT,
+	Eigen::PlainObjectBase<DerivedT>& FT, 
 	size_t nR);
     }
   }

--- a/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.h
+++ b/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.h
@@ -54,6 +54,15 @@ namespace igl
         const tetgenio & out,
         Eigen::PlainObjectBase<DerivedV>& V,
         Eigen::PlainObjectBase<DerivedT>& T);
+    
+      // Support for region marking for each tetrahedron
+      IGL_INLINE bool tetgenio_to_tetmesh(
+        const tetgenio & out,
+	std::vector<std::vector<REAL > > & V,
+	std::vector<std::vector<int> > & T,
+        std::vector<std::vector<int> > & F, 
+	size_t nR, // number of regions
+	std::vector<std::vector<REAL> > & R); // region marks for tetrahedrons	
     }
   }
 }

--- a/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.h
+++ b/include/igl/copyleft/tetgen/tetgenio_to_tetmesh.h
@@ -61,9 +61,24 @@ namespace igl
 	std::vector<std::vector<REAL > > & V,
 	std::vector<std::vector<int> > & T,
         std::vector<std::vector<int> > & F, 
-	std::vector<std::vector<REAL> > & R,// region marks for tetrahedrons	
-	size_t nR // number of regions
-);    
+	std::vector<std::vector<REAL> > & R,// region marks for tetrahedrons
+	std::vector<std::vector<int > > &N, // neighborlist per tet
+	std::vector<std::vector<int > >	&PT, // Point to tet list per point
+	size_t nR); // number of regions    
+
+      // Wrapper with Eigen types
+      // Templates:
+      //   DerivedV  real-value: i.e. from MatrixXd
+      //   DerivedT  integer-value: i.e. from MatrixXi
+      template <typename DerivedV, typename DerivedT, typename DerivedF>
+      IGL_INLINE bool tetgenio_to_tetmesh(
+        const tetgenio & out,
+        Eigen::PlainObjectBase<DerivedV>& V,
+        Eigen::PlainObjectBase<DerivedT>& T,
+        Eigen::PlainObjectBase<DerivedF>& F,
+	Eigen::PlainObjectBase<DerivedT>& N,
+	Eigen::PlainObjectBase<DerivedT>& PT,
+	size_t nR);
     }
   }
 }

--- a/include/igl/copyleft/tetgen/tetrahedralize.cpp
+++ b/include/igl/copyleft/tetgen/tetrahedralize.cpp
@@ -22,8 +22,8 @@
 IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   const std:vector<std::vector<REAL > > & V,
   const std::vector<std::vector<int> > & F,
-  const std::vector<std::vector<REAL> > & H.
-  const std::vector<std::vector<REAL>>
+  const std::vector<std::vector<REAL > > & H,
+  const std::vector<std::vector<REAL > >,
   const std::string switches,
   std::vector<std::vector<REAL > > & TV)
 {

--- a/include/igl/copyleft/tetgen/tetrahedralize.cpp
+++ b/include/igl/copyleft/tetgen/tetrahedralize.cpp
@@ -25,7 +25,37 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   const std::vector<std::vector<REAL> > & H.
   const std::vector<std::vector<REAL>>
   const std::string switches,
-  std::vector<std::vector<REAL > > & TV
+  std::vector<std::vector<REAL > > & TV)
+{
+	using namespace std;
+	tetgenio in,out;
+	bool success;
+	success = mesh_to_tetgenio(V, F, in);
+	if(!success)
+	{
+		return -1;
+	}
+	try 
+	{
+	  char * cswitches = new char[switches.size() + 1];
+  	  strcpy(cswitches, switches.c_str());	  
+	}catch(int e)
+	{
+		cerr <<"^"<<__FUNCTION__<<": tetgen failed!!"<<endl;
+		return 1;
+	}
+	if(out.numberoftetrahedra == 0)
+	{
+	  cerr<<"^"<<__FUNCTION__<<": Tetgen failed to create tets"<<endl;
+          return 2;	  
+	}
+	success = tetgenio_to_tetmesh(out, TV, TT, TF);
+	if(!success)
+	{
+  	  return -1;
+	}
+	return 0;
+}
 
 
 

--- a/include/igl/copyleft/tetgen/tetrahedralize.cpp
+++ b/include/igl/copyleft/tetgen/tetrahedralize.cpp
@@ -30,7 +30,8 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   std::vector<std::vector<int > > & TF,
   std::vector<std::vector<REAL > > &TR,
   std::vector<std::vector<int > > & TN, 
-  std::vector<std::vector<int > > & TP,
+  std::vector<std::vector<int > > & PT,
+  std::vector<std::vector<int > > & FT,
   size_t numRegions)
 {
   using namespace std;
@@ -57,7 +58,7 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
     cerr<<"^"<<__FUNCTION__<<": Tetgen failed to create tets"<<endl;
     return 2;	  
   }
-  success = tetgenio_to_tetmesh(out, TV, TT, TF, TR, TN, TP, numRegions);
+  success = tetgenio_to_tetmesh(out, TV, TT, TF, TR, TN, PT, FT, numRegions);
   if(!success)
   {
     return -1;
@@ -85,17 +86,18 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   Eigen::PlainObjectBase<DerivedTF>& TF,
   Eigen::PlainObjectBase<DerivedTR>& TR,
   Eigen::PlainObjectBase<DerivedTT>& TN,
-  Eigen::PlainObjectBase<DerivedTT>& TP,
+  Eigen::PlainObjectBase<DerivedTT>& PT,
+  Eigen::PlainObjectBase<DerivedTT>& FT,
   size_t numRegions)
 {
   using namespace std;
   vector<vector<REAL> > vV, vH, vR, vTV, vTR;
-  vector<vector<int> > vF,vTT,vTF, vTN, vTP;
+  vector<vector<int> > vF,vTT,vTF, vTN, vPT, vFT;
   matrix_to_list(V,vV);
   matrix_to_list(F,vF);
   matrix_to_list(H, vH);
   matrix_to_list(R, vR);
-  int e = tetrahedralize(vV,vF,vH,vR,switches,vTV,vTT,vTF,vTR,vTN,VTP,numRegions);
+  int e = tetrahedralize(vV,vF,vH,vR,switches,vTV,vTT,vTF,vTR,vTN,vPT,vFT, numRegions);
   if(e == 0)
   {
     bool TV_rect = list_to_matrix(vTV,TV);
@@ -123,8 +125,13 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
     {
       return 3;	
     }	    
-    bool TP_rect = list_to_matrix(vTP, TP);
-    if(!TP_rect)
+    bool PT_rect = list_to_matrix(vPT, PT);
+    if(!PT_rect)
+    {
+      return 3;	    
+    }	    
+    bool FT_rect = list_to_matrix(vFT, FT);
+    if(!FT_rect)
     {
       return 3;	    
     }	    

--- a/include/igl/copyleft/tetgen/tetrahedralize.cpp
+++ b/include/igl/copyleft/tetgen/tetrahedralize.cpp
@@ -20,14 +20,16 @@
 
 
 IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
-  const std:vector<std::vector<REAL > > & V,
+  const std::vector<std::vector<REAL > > & V,
   const std::vector<std::vector<int> > & F,
   const std::vector<std::vector<REAL > > & H,
-  const std::vector<std::vector<REAL > >,
+  const std::vector<std::vector<REAL > > & R,
   const std::string switches,
   std::vector<std::vector<REAL > > & TV,
   std::vector<std::vector<int > > & TT,
-   std::vector<std::vector<int > > & TF)
+  std::vector<std::vector<int > > & TF,
+  std::vector<std::vector<REAL > > &TR,
+  size_t numRegions)
 {
   using namespace std;
   tetgenio in,out;
@@ -53,7 +55,7 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
     cerr<<"^"<<__FUNCTION__<<": Tetgen failed to create tets"<<endl;
     return 2;	  
   }
-  success = tetgenio_to_tetmesh(out, TV, TT, TF);
+  success = tetgenio_to_tetmesh(out, TV, TT, TF, TR, numRegions);
   if(!success)
   {
     return -1;
@@ -61,7 +63,60 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
     return 0;
 }
 
-
+template <
+  typename DerivedV, 
+  typename DerivedF, 
+  typename DerivedH,
+  typename DerivedR,
+  typename DerivedTV, 
+  typename DerivedTT, 
+  typename DerivedTF,
+  typename DerivedTR>
+IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
+  const Eigen::PlainObjectBase<DerivedV>& V,
+  const Eigen::PlainObjectBase<DerivedF>& F,
+  const Eigen::PlainObjectBase<DerivedH>& H,
+  const Eigen::PlainObjectBase<DerivedR>& R,
+  const std::string switches,
+  Eigen::PlainObjectBase<DerivedTV>& TV,
+  Eigen::PlainObjectBase<DerivedTT>& TT,
+  Eigen::PlainObjectBase<DerivedTF>& TF,
+  Eigen::PlainObjectBase<DerivedTR>& TR,
+  size_t numRegions)
+{
+  using namespace std;
+  vector<vector<REAL> > vV, vH, vR, vTV, vTR;
+  vector<vector<int> > vF,vTT,vTF;
+  matrix_to_list(V,vV);
+  matrix_to_list(F,vF);
+  matrix_to_list(H, vH);
+  matrix_to_list(R, vR);
+  int e = tetrahedralize(vV,vF,vH,vR,switches,vTV,vTT,vTF,vTR,numRegions);
+  if(e == 0)
+  {
+    bool TV_rect = list_to_matrix(vTV,TV);
+    if(!TV_rect)
+    {
+      return 3;
+    }
+    bool TT_rect = list_to_matrix(vTT,TT);
+    if(!TT_rect)
+    {
+      return 3;
+    }
+    bool TF_rect = list_to_matrix(vTF,TF);
+    if(!TF_rect)
+    {
+      return 3;
+    }
+    bool TR_rect = list_to_matrix(vTR, TR);
+    if(!TR_rect)
+    {
+      return 3;	    
+    }
+  }
+  return e;
+}
 
 IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   const std::vector<std::vector<REAL > > & V, 

--- a/include/igl/copyleft/tetgen/tetrahedralize.cpp
+++ b/include/igl/copyleft/tetgen/tetrahedralize.cpp
@@ -29,6 +29,8 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   std::vector<std::vector<int > > & TT,
   std::vector<std::vector<int > > & TF,
   std::vector<std::vector<REAL > > &TR,
+  std::vector<std::vector<int > > & TN, 
+  std::vector<std::vector<int > > & TP,
   size_t numRegions)
 {
   using namespace std;
@@ -55,7 +57,7 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
     cerr<<"^"<<__FUNCTION__<<": Tetgen failed to create tets"<<endl;
     return 2;	  
   }
-  success = tetgenio_to_tetmesh(out, TV, TT, TF, TR, numRegions);
+  success = tetgenio_to_tetmesh(out, TV, TT, TF, TR, TN, TP, numRegions);
   if(!success)
   {
     return -1;
@@ -82,16 +84,18 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   Eigen::PlainObjectBase<DerivedTT>& TT,
   Eigen::PlainObjectBase<DerivedTF>& TF,
   Eigen::PlainObjectBase<DerivedTR>& TR,
+  Eigen::PlainObjectBase<DerivedTT>& TN,
+  Eigen::PlainObjectBase<DerivedTT>& TP,
   size_t numRegions)
 {
   using namespace std;
   vector<vector<REAL> > vV, vH, vR, vTV, vTR;
-  vector<vector<int> > vF,vTT,vTF;
+  vector<vector<int> > vF,vTT,vTF, vTN, vTP;
   matrix_to_list(V,vV);
   matrix_to_list(F,vF);
   matrix_to_list(H, vH);
   matrix_to_list(R, vR);
-  int e = tetrahedralize(vV,vF,vH,vR,switches,vTV,vTT,vTF,vTR,numRegions);
+  int e = tetrahedralize(vV,vF,vH,vR,switches,vTV,vTT,vTF,vTR,vTN,VTP,numRegions);
   if(e == 0)
   {
     bool TV_rect = list_to_matrix(vTV,TV);
@@ -114,6 +118,16 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
     {
       return 3;	    
     }
+    bool TN_rect = list_to_matrix(vTN, TN);
+    if(!TN_rect)
+    {
+      return 3;	
+    }	    
+    bool TP_rect = list_to_matrix(vTP, TP);
+    if(!TP_rect)
+    {
+      return 3;	    
+    }	    
   }
   return e;
 }

--- a/include/igl/copyleft/tetgen/tetrahedralize.cpp
+++ b/include/igl/copyleft/tetgen/tetrahedralize.cpp
@@ -32,7 +32,7 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   std::vector<std::vector<int > > & TN, 
   std::vector<std::vector<int > > & PT,
   std::vector<std::vector<int > > & FT,
-  size_t numRegions)
+  size_t & numRegions)
 {
   using namespace std;
   tetgenio in,out;
@@ -46,9 +46,10 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   {
     char * cswitches = new char[switches.size() + 1];
     strcpy(cswitches, switches.c_str());
+    
     ::tetrahedralize(cswitches, &in, &out); 
     delete[] cswitches;
-  }catch(int e)
+}catch(int e)
   {
     cerr <<"^"<<__FUNCTION__<<": TETGEN CRASHED...KABOOM!!"<<endl;
     return 1;
@@ -58,7 +59,8 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
     cerr<<"^"<<__FUNCTION__<<": Tetgen failed to create tets"<<endl;
     return 2;	  
   }
-  success = tetgenio_to_tetmesh(out, TV, TT, TF, TR, TN, PT, FT, numRegions);
+   success = tetgenio_to_tetmesh(out, TV, TT, TF, TR, TN, PT, FT, numRegions
+);
   if(!success)
   {
     return -1;
@@ -88,16 +90,18 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   Eigen::PlainObjectBase<DerivedTT>& TN,
   Eigen::PlainObjectBase<DerivedTT>& PT,
   Eigen::PlainObjectBase<DerivedTT>& FT,
-  size_t numRegions)
+  size_t & numRegions)
 {
   using namespace std;
   vector<vector<REAL> > vV, vH, vR, vTV, vTR;
   vector<vector<int> > vF,vTT,vTF, vTN, vPT, vFT;
   matrix_to_list(V,vV);
-  matrix_to_list(F,vF);
+  matrix_to_list(F,vF);	
   matrix_to_list(H, vH);
   matrix_to_list(R, vR);
+  
   int e = tetrahedralize(vV,vF,vH,vR,switches,vTV,vTT,vTF,vTR,vTN,vPT,vFT, numRegions);
+  
   if(e == 0)
   {
     bool TV_rect = list_to_matrix(vTV,TV);

--- a/include/igl/copyleft/tetgen/tetrahedralize.cpp
+++ b/include/igl/copyleft/tetgen/tetrahedralize.cpp
@@ -27,34 +27,36 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   const std::string switches,
   std::vector<std::vector<REAL > > & TV)
 {
-	using namespace std;
-	tetgenio in,out;
-	bool success;
-	success = mesh_to_tetgenio(V, F, in);
-	if(!success)
-	{
-		return -1;
-	}
-	try 
-	{
-	  char * cswitches = new char[switches.size() + 1];
-  	  strcpy(cswitches, switches.c_str());	  
-	}catch(int e)
-	{
-		cerr <<"^"<<__FUNCTION__<<": tetgen failed!!"<<endl;
-		return 1;
-	}
-	if(out.numberoftetrahedra == 0)
-	{
-	  cerr<<"^"<<__FUNCTION__<<": Tetgen failed to create tets"<<endl;
-          return 2;	  
-	}
-	success = tetgenio_to_tetmesh(out, TV, TT, TF);
-	if(!success)
-	{
-  	  return -1;
-	}
-	return 0;
+  using namespace std;
+  tetgenio in,out;
+  bool success;
+  success = mesh_to_tetgenio(V, F, H, R, in);
+  if(!success)
+  {
+    return -1;
+  }
+  try 
+  {
+    char * cswitches = new char[switches.size() + 1];
+    strcpy(cswitches, switches.c_str());
+    ::tetrahedralize(cswitches, &in, &out); 
+    delete[] cswitches;
+  }catch(int e)
+  {
+    cerr <<"^"<<__FUNCTION__<<": TETGEN CRASHED...KABOOM!!"<<endl;
+    return 1;
+  }
+  if(out.numberoftetrahedra == 0)
+  {
+    cerr<<"^"<<__FUNCTION__<<": Tetgen failed to create tets"<<endl;
+    return 2;	  
+  }
+  success = tetgenio_to_tetmesh(out, TV, TT, TF);
+  if(!success)
+  {
+    return -1;
+  }
+    return 0;
 }
 
 

--- a/include/igl/copyleft/tetgen/tetrahedralize.cpp
+++ b/include/igl/copyleft/tetgen/tetrahedralize.cpp
@@ -25,7 +25,9 @@ IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   const std::vector<std::vector<REAL > > & H,
   const std::vector<std::vector<REAL > >,
   const std::string switches,
-  std::vector<std::vector<REAL > > & TV)
+  std::vector<std::vector<REAL > > & TV,
+  std::vector<std::vector<int > > & TT,
+   std::vector<std::vector<int > > & TF)
 {
   using namespace std;
   tetgenio in,out;

--- a/include/igl/copyleft/tetgen/tetrahedralize.cpp
+++ b/include/igl/copyleft/tetgen/tetrahedralize.cpp
@@ -18,6 +18,17 @@
 #include <cassert>
 #include <iostream>
 
+
+IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
+  const std:vector<std::vector<REAL > > & V,
+  const std::vector<std::vector<int> > & F,
+  const std::vector<std::vector<REAL> > & H.
+  const std::vector<std::vector<REAL>>
+  const std::string switches,
+  std::vector<std::vector<REAL > > & TV
+
+
+
 IGL_INLINE int igl::copyleft::tetgen::tetrahedralize(
   const std::vector<std::vector<REAL > > & V, 
   const std::vector<std::vector<int> > & F, 

--- a/include/igl/copyleft/tetgen/tetrahedralize.h
+++ b/include/igl/copyleft/tetgen/tetrahedralize.h
@@ -139,7 +139,8 @@ namespace igl
 	  std::vector<std::vector<int > >  & TF,
 	  std::vector<std::vector<REAL > > &TR,  // region marker per tet
 	  std::vector<std::vector<int > > &TN, // neighbor list per tet
-	  std::vector<std::vector<int > > &TP, // point to tet list
+	  std::vector<std::vector<int > > &PT, // point to tet list
+	  std::vector<std::vector<int > > &FT, // face to tet list
 	  size_t numRegions);	     
 
       template <
@@ -161,8 +162,9 @@ namespace igl
         Eigen::PlainObjectBase<DerivedTT>& TT,
 	Eigen::PlainObjectBase<DerivedTF>& TF,
 	Eigen::PlainObjectBase<DerivedTR>& TR, 
-	Eigen::PlainObjectBase<DerivedTN>& TN, // neighborlist per tet
-	Eigen::PlainObjectBase<DerivedTP>& TP, // point2tet list
+	Eigen::PlainObjectBase<DerivedTT>& TN, // neighborlist per tet
+	Eigen::PlainObjectBase<DerivedTT>& PT, // point2tet list
+	Eigen::PlainObjectBase<DerivedTT>& FT, // face2tet list
 	size_t numRegions);	      
 
             }

--- a/include/igl/copyleft/tetgen/tetrahedralize.h
+++ b/include/igl/copyleft/tetgen/tetrahedralize.h
@@ -126,10 +126,10 @@ namespace igl
 	
         // Define a overload which also accepts hole and region information in input and outputs region and hole tets seperately.
 	IGL_INLINE int tetrahedralize(
-	  const std::vector<std::vector<REAL> > &V,
+	  const std::vector<std::vector<REAL> > &V, 
 	  const std::vector<std::vector<int> >  &F, 
-	  const std::vector<std::vector<REAL> > &H, // input holes
-	  const std::vector<std::vector<int> > &R, // input region ids
+	  const std::vector<std::vector<REAL> > &H, 
+	  const std::vector<std::vector<REAL> > &R, 
 	  const std::vector<int> & VM,
 	  const std::vector<int> & FM,
 	  

--- a/include/igl/copyleft/tetgen/tetrahedralize.h
+++ b/include/igl/copyleft/tetgen/tetrahedralize.h
@@ -124,24 +124,44 @@ namespace igl
         Eigen::PlainObjectBase<DerivedTF>& TF,
         Eigen::PlainObjectBase<DerivedTM>& TM);
 	
-        // Define a overload which also accepts hole and region information in input and outputs region and hole tets seperately.
+
+// Define a overload which also accepts hole and region information in input and outputs region and hole tets seperately.
 	IGL_INLINE int tetrahedralize(
 	  const std::vector<std::vector<REAL> > &V, 
 	  const std::vector<std::vector<int> >  &F, 
 	  const std::vector<std::vector<REAL> > &H, 
 	  const std::vector<std::vector<REAL> > &R, 
-	  const std::vector<int> & VM,
-	  const std::vector<int> & FM,
-	  
+	  	  
 	  const std::string switches, 
 	  
 	  std::vector<std::vector<REAL > > & TV,
 	  std::vector<std::vector<int > >  & TT,
 	  std::vector<std::vector<int > >  & TF,
-	  std::vector<int> &TM
-	  std::vector<int> &TR); // region marker per tet
-	     
-    }
+	  std::vector<std::vector<REAL > > &TR,  // region marker per tet
+	  size_t numRegions);	     
+
+      template <
+        typename DerivedV,
+   	typename DerivedF,
+	typename DerivedH,
+	typename DerivedR,
+	typename DerivedTV,
+	typename DerivedTT,
+	typename DerivedTF,
+	typename DerivedTR>	
+      IGL_INLINE int tetrahedralize(
+	const Eigen::PlainObjectBase<DerivedV>& V,
+	const Eigen::PlainObjectBase<DerivedF>& F,
+	const Eigen::PlainObjectBase<DerivedH>& H,
+	const Eigen::PlainObjectBase<DerivedR>& R,
+	const std::string switches,
+	Eigen::PlainObjectBase<DerivedTV>& TV,
+        Eigen::PlainObjectBase<DerivedTT>& TT,
+	Eigen::PlainObjectBase<DerivedTF>& TF,
+	Eigen::PlainObjectBase<DerivedTR>& TR, 
+	size_t numRegions);	      
+
+            }
   }
 }
 

--- a/include/igl/copyleft/tetgen/tetrahedralize.h
+++ b/include/igl/copyleft/tetgen/tetrahedralize.h
@@ -138,6 +138,8 @@ namespace igl
 	  std::vector<std::vector<int > >  & TT,
 	  std::vector<std::vector<int > >  & TF,
 	  std::vector<std::vector<REAL > > &TR,  // region marker per tet
+	  std::vector<std::vector<int > > &TN, // neighbor list per tet
+	  std::vector<std::vector<int > > &TP, // point to tet list
 	  size_t numRegions);	     
 
       template <

--- a/include/igl/copyleft/tetgen/tetrahedralize.h
+++ b/include/igl/copyleft/tetgen/tetrahedralize.h
@@ -125,7 +125,34 @@ namespace igl
         Eigen::PlainObjectBase<DerivedTM>& TM);
 	
 
-// Define a overload which also accepts hole and region information in input and outputs region and hole tets seperately.
+      // Mesh the interior of a surface mesh (V,F) using tetgen
+      //
+      // Inputs:
+      //   V  #V by 3 vertex position list
+      //   F  #F list of polygon face indices into V (0-indexed)
+      //   H  #H by 3 list of seed points inside holes
+      //   R  #R by 5 list of region attributes		
+
+      //   switches  string of tetgen options (See tetgen documentation) e.g.
+      //     "pq1.414a0.01" tries to mesh the interior of a given surface with
+      //       quality and area constraints
+      //     "" will mesh the convex hull constrained to pass through V (ignores F)
+      // Outputs:
+      //   TV  #V by 3 vertex position list
+      //   TT  #T by 4 list of tet face indices
+      //   TF  #F by 3 list of triangle face indices
+      //   TR  #T list of region ID for each tetrahedron	
+      //   TN  #T by 4 list of indices neighbors for each tetrahedron
+      //   PT  #V list of incident tetrahedron for a vertex
+      //   FT  #F by 2 list of tetrahedrons sharing a triface	
+      //   numRegions Number of regions in output mesh
+
+      // Returns status:
+      //   0 success
+      //   1 tetgen threw exception
+      //   2 tetgen did not crash but could not create any tets (probably there are
+      //     holes, duplicate faces etc.)
+      //   -1 other error
 	IGL_INLINE int tetrahedralize(
 	  const std::vector<std::vector<REAL> > &V, 
 	  const std::vector<std::vector<int> >  &F, 
@@ -137,12 +164,17 @@ namespace igl
 	  std::vector<std::vector<REAL > > & TV,
 	  std::vector<std::vector<int > >  & TT,
 	  std::vector<std::vector<int > >  & TF,
-	  std::vector<std::vector<REAL > > &TR,  // region marker per tet
-	  std::vector<std::vector<int > > &TN, // neighbor list per tet
-	  std::vector<std::vector<int > > &PT, // point to tet list
-	  std::vector<std::vector<int > > &FT, // face to tet list
-	  size_t numRegions);	     
+	  std::vector<std::vector<REAL > > &TR,  
+	  std::vector<std::vector<int > > &TN, 
+	  std::vector<std::vector<int > > &PT, 
+	  std::vector<std::vector<int > > &FT, 
+	  size_t & numRegions);	     
 
+
+      // Wrapper with Eigen types
+      // Templates:
+      //   DerivedV  real-value: i.e. from MatrixXd
+      //   DerivedF  integer-value: i.e. from MatrixXi	
       template <
         typename DerivedV,
    	typename DerivedF,
@@ -162,12 +194,12 @@ namespace igl
         Eigen::PlainObjectBase<DerivedTT>& TT,
 	Eigen::PlainObjectBase<DerivedTF>& TF,
 	Eigen::PlainObjectBase<DerivedTR>& TR, 
-	Eigen::PlainObjectBase<DerivedTT>& TN, // neighborlist per tet
-	Eigen::PlainObjectBase<DerivedTT>& PT, // point2tet list
-	Eigen::PlainObjectBase<DerivedTT>& FT, // face2tet list
-	size_t numRegions);	      
+	Eigen::PlainObjectBase<DerivedTT>& TN, 
+	Eigen::PlainObjectBase<DerivedTT>& PT, 
+	Eigen::PlainObjectBase<DerivedTT>& FT, 
+	size_t & numRegions);	      
 
-            }
+   }
   }
 }
 

--- a/include/igl/copyleft/tetgen/tetrahedralize.h
+++ b/include/igl/copyleft/tetgen/tetrahedralize.h
@@ -159,6 +159,8 @@ namespace igl
         Eigen::PlainObjectBase<DerivedTT>& TT,
 	Eigen::PlainObjectBase<DerivedTF>& TF,
 	Eigen::PlainObjectBase<DerivedTR>& TR, 
+	Eigen::PlainObjectBase<DerivedTN>& TN, // neighborlist per tet
+	Eigen::PlainObjectBase<DerivedTP>& TP, // point2tet list
 	size_t numRegions);	      
 
             }

--- a/include/igl/copyleft/tetgen/tetrahedralize.h
+++ b/include/igl/copyleft/tetgen/tetrahedralize.h
@@ -123,6 +123,50 @@ namespace igl
         Eigen::PlainObjectBase<DerivedTT>& TT,
         Eigen::PlainObjectBase<DerivedTF>& TF,
         Eigen::PlainObjectBase<DerivedTM>& TM);
+   
+	
+	// Mesh the interior of a surface mesh (V,F) using tetgen
+      		//
+      		// Inputs:
+      		//   V  #V by 3 vertex position list
+      		//   F  #F list of polygon face indices into V (0-indexed)
+      		//   switches  string of tetgen options (See tetgen documentation) e.g.
+      		//     "pq1.414a0.01" tries to mesh the interior of a given surface with
+      		//       quality and area constraints
+      		//     "" will mesh the convex hull constrained to pass through V (ignores F)
+      		// Outputs:
+      		//   TV  #V by 3 vertex position list
+      		//   TT  #T by 4 list of tet face indices
+      		//   TF  #F by 3 list of triangle face indices
+      		// Returns status:
+      		//   0 success
+      		//   1 tetgen threw exception
+      		//   2 tetgen did not crash but could not create any tets (probably there are
+      		//     holes, duplicate faces etc.)
+      		//   -1 other error      
+    template <
+	typename DerivedV,
+	typename DerivedF,
+	typename DerivedR,
+	typename DerivedH,
+	    			typename DerivedVM,
+				typename DerivedFM,
+	typename DerivedTV,
+	typename DerivedTT,
+	typename DerivedTF,
+	typename DerivedTM>    
+      IGL_INLINE int tetrahedralize(
+	const Eigen::PlainObjectBase<DerivedV>& V,
+	const Eigen::PlainObjectBase<DerivedF>& F,	
+	const Eigen::PlainObjectBase<DerivedR>& R,
+	const Eigen::PlainObjectBase<DerivedH>& H,
+	const std::string switches,      
+	const Eigen::PlainObjectBase<DerivedVM>& VM,
+	const Eigen::PlainObjectBase<DerivedFM>& FM
+	const Eigen::PlainObjectBase<DerivedTV>& TV,
+	const Eigen::PlainObjectBase<DerivedTT>& TT,
+	const Eigen::PlainObjectBase<DerivedTF>& TF
+      )
     }
   }
 }

--- a/include/igl/copyleft/tetgen/tetrahedralize.h
+++ b/include/igl/copyleft/tetgen/tetrahedralize.h
@@ -123,50 +123,24 @@ namespace igl
         Eigen::PlainObjectBase<DerivedTT>& TT,
         Eigen::PlainObjectBase<DerivedTF>& TF,
         Eigen::PlainObjectBase<DerivedTM>& TM);
-   
-				
-	// Mesh the interior of a surface mesh (V,F) using tetgen
-      		//
-      		// Inputs:
-      		//   V  #V by 3 vertex position list
-      		//   F  #F list of polygon face indices into V (0-indexed)
-	    	//   R  #R by 3 region vertex position list
-	        //   H  #H by 3 hole vertex position list
-      		//   switches  string of tetgen options (See tetgen documentation) e.g.
-      		//     "pq1.414a0.01" tries to mesh the interior of a given surface with
-      		//       quality and area constraints
-      		//     "" will mesh the convex hull constrained to pass through V (ignores F)
-      		// Outputs:
-      		//   TV  #V by 3 vertex position list
-      		//   TT  #T by 4 list of tet face indices
-      		//   TF  #F by 3 list of triangle face indices
-      		// Returns status:
-      		//   0 success
-      		//   1 tetgen threw exception
-      		//   2 tetgen did not crash but could not create any tets (probably there are
-      		//     holes, duplicate faces etc.)
-      		//   -1 other error      
-    template <
-	typename DerivedV,
-	typename DerivedF,
-	typename DerivedR,
-	typename DerivedH,
-	typename DerivedTV,
-	typename DerivedTT,
-	typename DerivedTF,
-	typename DerivedTM>    
-      IGL_INLINE int tetrahedralize(
-	const Eigen::PlainObjectBase<DerivedV>& V,
-	const Eigen::PlainObjectBase<DerivedF>& F,	
-	const Eigen::PlainObjectBase<DerivedR>& R,
-	const Eigen::PlainObjectBase<DerivedH>& H,
-							const Eigen::PlainObjectBase<DerivedVM>& VM,
-							const Eigen::PlainObjectBase<DerivedFM>& FM,	      						
-	const std::string switches,      
-	const Eigen::PlainObjectBase<DerivedTV>& TV,
-	const Eigen::PlainObjectBase<DerivedTT>& TT,
-							const Eigen::PlainObjectBase<DerivedTM>& TM,
-	const Eigen::PlainObjectBase<DerivedTF>& TF);
+	
+        // Define a overload which also accepts hole and region information in input and outputs region and hole tets seperately.
+	IGL_INLINE int tetrahedralize(
+	  const std::vector<std::vector<REAL> > &V,
+	  const std::vector<std::vector<int> >  &F, 
+	  const std::vector<std::vector<REAL> > &H, // input holes
+	  const std::vector<std::vector<int> > &R, // input region ids
+	  const std::vector<int> & VM,
+	  const std::vector<int> & FM,
+	  
+	  const std::string switches, 
+	  
+	  std::vector<std::vector<REAL > > & TV,
+	  std::vector<std::vector<int > >  & TT,
+	  std::vector<std::vector<int > >  & TF,
+	  std::vector<int> &TM
+	  std::vector<int> &TR); // region marker per tet
+	     
     }
   }
 }

--- a/include/igl/copyleft/tetgen/tetrahedralize.h
+++ b/include/igl/copyleft/tetgen/tetrahedralize.h
@@ -124,12 +124,14 @@ namespace igl
         Eigen::PlainObjectBase<DerivedTF>& TF,
         Eigen::PlainObjectBase<DerivedTM>& TM);
    
-	
+				
 	// Mesh the interior of a surface mesh (V,F) using tetgen
       		//
       		// Inputs:
       		//   V  #V by 3 vertex position list
       		//   F  #F list of polygon face indices into V (0-indexed)
+	    	//   R  #R by 3 region vertex position list
+	        //   H  #H by 3 hole vertex position list
       		//   switches  string of tetgen options (See tetgen documentation) e.g.
       		//     "pq1.414a0.01" tries to mesh the interior of a given surface with
       		//       quality and area constraints
@@ -149,8 +151,6 @@ namespace igl
 	typename DerivedF,
 	typename DerivedR,
 	typename DerivedH,
-	    			typename DerivedVM,
-				typename DerivedFM,
 	typename DerivedTV,
 	typename DerivedTT,
 	typename DerivedTF,
@@ -160,13 +160,13 @@ namespace igl
 	const Eigen::PlainObjectBase<DerivedF>& F,	
 	const Eigen::PlainObjectBase<DerivedR>& R,
 	const Eigen::PlainObjectBase<DerivedH>& H,
+							const Eigen::PlainObjectBase<DerivedVM>& VM,
+							const Eigen::PlainObjectBase<DerivedFM>& FM,	      						
 	const std::string switches,      
-	const Eigen::PlainObjectBase<DerivedVM>& VM,
-	const Eigen::PlainObjectBase<DerivedFM>& FM
 	const Eigen::PlainObjectBase<DerivedTV>& TV,
 	const Eigen::PlainObjectBase<DerivedTT>& TT,
-	const Eigen::PlainObjectBase<DerivedTF>& TF
-      )
+							const Eigen::PlainObjectBase<DerivedTM>& TM,
+	const Eigen::PlainObjectBase<DerivedTF>& TF);
     }
   }
 }


### PR DESCRIPTION
igl::copyleft::tetgen::tetrahedralize() can now return mesh holes, regions, point2tet mapping, face2tet mapping, tetrahedron neighbor list and number of regions(or zones) in the output tetrahedral mesh.