### PR TITLE
Simplify vector_area_matrix.cpp

### DIFF
--- a/include/igl/vector_area_matrix.cpp
+++ b/include/igl/vector_area_matrix.cpp
@@ -26,28 +26,26 @@ IGL_INLINE void igl::vector_area_matrix(
   // number of vertices
   const int n = F.maxCoeff()+1;
 
-	SparseMatrix<Scalar> aux (n * 2, n * 2);
-	SparseMatrix<Scalar> auxT(n * 2, n * 2);
-
-	vector<Triplet<Scalar> > auxTripletList;
-	vector<Triplet<Scalar> > auxTTripletList;
-
   MatrixXi E;
   boundary_facets(F,E);
 
-	for(int k = 0; k < E.rows(); k++)
+  //Prepare a vector of triplets to set the matrix
+  vector<Triplet<Scalar> > tripletList;
+  tripletList.reserve(4*E.rows());
+
+  for(int k = 0; k < E.rows(); k++)
   {
 		int i = E(k,0);
 		int j = E(k,1);
-		auxTripletList.push_back(Triplet<Scalar>(i+n, j, -0.5));
-		auxTripletList.push_back(Triplet<Scalar>(i, j+n, 0.5));
-		auxTTripletList.push_back(Triplet<Scalar>(j, i+n, -0.5));
-		auxTTripletList.push_back(Triplet<Scalar>(j+n, i, 0.5));
-	}
+        tripletList.push_back(Triplet<Scalar>(i+n, j, -0.25));
+        tripletList.push_back(Triplet<Scalar>(j, i+n, -0.25));
+        tripletList.push_back(Triplet<Scalar>(i, j+n, 0.25));
+        tripletList.push_back(Triplet<Scalar>(j+n, i, 0.25));
+  }
 
-	aux.setFromTriplets(auxTripletList.begin(), auxTripletList.end());
-	auxT.setFromTriplets(auxTTripletList.begin(), auxTTripletList.end());
-	A = (aux + auxT)*0.5;
+  //Set A from triplets (Eigen will sum triplets with same coordinates)
+  A.resize(n * 2, n * 2);
+  A.setFromTriplets(tripletList.begin(), tripletList.end());
 }
 
 #ifdef IGL_STATIC_LIBRARY


### PR DESCRIPTION
A small change to optimize/simplify the code of vector_area_matrix.

Instead to build two sparse matrix that have to be added and scaled,
build directly the triplets for the sparse result matrix.

Also, do a reserve() before of filling the triplets list.
