### PR TITLE
Minor improvements to the viewer (resize + 2D mode).

### DIFF
--- a/include/igl/viewer/Viewer.cpp
+++ b/include/igl/viewer/Viewer.cpp
@@ -154,7 +154,7 @@ static void glfw_window_size(GLFWwindow* window, int width, int height)
   int w = width*highdpi;
   int h = height*highdpi;
 
-  __viewer->resize_callback(w, h);
+  __viewer->post_resize(w, h);
 
   // TODO: repositioning of the nanogui
 }
@@ -847,13 +847,17 @@ namespace viewer
     if (window) {
       glfwSetWindowSize(window, w/highdpi, h/highdpi);
     } else {
-      resize_callback(w, h);
+      post_resize(w, h);
     }
   }
 
-  IGL_INLINE void Viewer::resize_callback(int w,int h)
+  IGL_INLINE void Viewer::post_resize(int w,int h)
   {
     core.viewport = Eigen::Vector4f(0,0,w,h);
+    for (unsigned int i = 0; i<plugins.size(); ++i)
+    {
+      plugins[i]->post_resize(w, h);
+    }
   }
 
   IGL_INLINE void Viewer::snap_to_canonical_quaternion()

--- a/include/igl/viewer/Viewer.cpp
+++ b/include/igl/viewer/Viewer.cpp
@@ -154,7 +154,7 @@ static void glfw_window_size(GLFWwindow* window, int width, int height)
   int w = width*highdpi;
   int h = height*highdpi;
 
-  __viewer->resize(w, h);
+  __viewer->resize_callback(w, h);
 
   // TODO: repositioning of the nanogui
 }
@@ -842,6 +842,11 @@ namespace viewer
 
   IGL_INLINE void Viewer::resize(int w,int h)
   {
+    glfwSetWindowSize(window, w/highdpi, h/highdpi);
+  }
+
+  IGL_INLINE void Viewer::resize_callback(int w,int h)
+  {
     core.viewport = Eigen::Vector4f(0,0,w,h);
   }
 
@@ -895,7 +900,11 @@ namespace viewer
     }
     else
     {
-      window = glfwCreateWindow(1280,800,"libigl viewer",nullptr,nullptr);
+      if (core.viewport.tail<2>().any()) {
+        window = glfwCreateWindow(core.viewport(2),core.viewport(3),"libigl viewer",nullptr,nullptr);
+      } else {
+        window = glfwCreateWindow(1280,800,"libigl viewer",nullptr,nullptr);
+      }
     }
 
     if (!window)

--- a/include/igl/viewer/Viewer.cpp
+++ b/include/igl/viewer/Viewer.cpp
@@ -628,7 +628,11 @@ namespace viewer
     switch (button)
     {
       case MouseButton::Left:
-        mouse_mode = MouseMode::Rotation;
+        if (core.rotation_type == ViewerCore::ROTATION_TYPE_NO_ROTATION) {
+          mouse_mode = MouseMode::Translation;
+        } else {
+          mouse_mode = MouseMode::Rotation;
+        }
         break;
 
       case MouseButton::Right:
@@ -689,6 +693,8 @@ namespace viewer
           {
             default:
               assert(false && "Unknown rotation type");
+            case ViewerCore::ROTATION_TYPE_NO_ROTATION:
+              break;
             case ViewerCore::ROTATION_TYPE_TRACKBALL:
               igl::trackball(
                 core.viewport(2),

--- a/include/igl/viewer/Viewer.cpp
+++ b/include/igl/viewer/Viewer.cpp
@@ -278,6 +278,8 @@ namespace viewer
 
   IGL_INLINE Viewer::Viewer()
   {
+    window = nullptr;
+
 #ifdef IGL_VIEWER_WITH_NANOGUI
     ngui = nullptr;
     screen = nullptr;
@@ -842,7 +844,11 @@ namespace viewer
 
   IGL_INLINE void Viewer::resize(int w,int h)
   {
-    glfwSetWindowSize(window, w/highdpi, h/highdpi);
+    if (window) {
+      glfwSetWindowSize(window, w/highdpi, h/highdpi);
+    } else {
+      resize_callback(w, h);
+    }
   }
 
   IGL_INLINE void Viewer::resize_callback(int w,int h)

--- a/include/igl/viewer/Viewer.h
+++ b/include/igl/viewer/Viewer.h
@@ -119,7 +119,8 @@ namespace viewer
     IGL_INLINE void draw();
 
     // OpenGL context resize
-    IGL_INLINE void resize(int w,int h);
+    IGL_INLINE void resize(int w,int h); // explicitly set window size
+    IGL_INLINE void resize_callback(int w,int h); // external resize due to user interaction
 
     // Helper functions
     IGL_INLINE void snap_to_canonical_quaternion();

--- a/include/igl/viewer/Viewer.h
+++ b/include/igl/viewer/Viewer.h
@@ -120,7 +120,7 @@ namespace viewer
 
     // OpenGL context resize
     IGL_INLINE void resize(int w,int h); // explicitly set window size
-    IGL_INLINE void resize_callback(int w,int h); // external resize due to user interaction
+    IGL_INLINE void post_resize(int w,int h); // external resize due to user interaction
 
     // Helper functions
     IGL_INLINE void snap_to_canonical_quaternion();

--- a/include/igl/viewer/ViewerCore.cpp
+++ b/include/igl/viewer/ViewerCore.cpp
@@ -433,6 +433,8 @@ IGL_INLINE igl::viewer::ViewerCore::ViewerCore()
   line_width = 0.5f;
   is_animating = false;
   animation_max_fps = 30.;
+
+  viewport.setZero();
 }
 
 IGL_INLINE void igl::viewer::ViewerCore::init()

--- a/include/igl/viewer/ViewerCore.h
+++ b/include/igl/viewer/ViewerCore.h
@@ -88,7 +88,8 @@ public:
   {
     ROTATION_TYPE_TRACKBALL = 0,
     ROTATION_TYPE_TWO_AXIS_VALUATOR_FIXED_UP = 1,
-    NUM_ROTATION_TYPES = 2
+    ROTATION_TYPE_NO_ROTATION = 2,
+    NUM_ROTATION_TYPES = 3
   };
   IGL_INLINE void set_rotation_type(const RotationType & value);
 

--- a/include/igl/viewer/ViewerPlugin.h
+++ b/include/igl/viewer/ViewerPlugin.h
@@ -96,6 +96,11 @@ public:
     return false;
   }
 
+  // This function is called after the window has been resized
+  IGL_INLINE virtual void post_resize(int w, int h)
+  {
+  }
+
   // This function is called when the mouse button is pressed
   // - button can be GLUT_LEFT_BUTTON, GLUT_MIDDLE_BUTTON or GLUT_RIGHT_BUTTON
   // - modifiers is a bitfield that might one or more of the following bits Preview3D::NO_KEY, Preview3D::SHIFT, Preview3D::CTRL, Preview3D::ALT;

--- a/python/tutorial/shared.py
+++ b/python/tutorial/shared.py
@@ -1,8 +1,8 @@
 import pyigl as igl
 import sys
+import os
 
-
-TUTORIAL_SHARED_PATH = "../../tutorial/shared/"
+TUTORIAL_SHARED_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../tutorial/shared/")
 
 def check_dependencies(deps):
     available = [hasattr(igl, m) for m in deps]


### PR DESCRIPTION
Right now from python there is no way to resize the libigl viewer, since the glfw `window` is not exposed. While there was a `resize()` function in the current viewer, this one was pretty much useless since it doesn't set the actual window size, but is just a callback that is run every time the user resizes the window directly.

This PR fixes this issue, and `resize()` now does what you would expect (hopefully working also for high-DPI screens).