### PR TITLE
correct the pyigl.so path given to strip command

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -188,7 +188,7 @@ elseif (UNIX)
     endif()
 
     if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
-      add_custom_command(TARGET pyigl POST_BUILD COMMAND strip -u -r ${CMAKE_CURRENT_BINARY_DIR}/../pyigl.so)
+      add_custom_command(TARGET pyigl POST_BUILD COMMAND strip -u -r ${PROJECT_SOURCE_DIR}/pyigl.so)
     endif()
   else()
 
@@ -198,7 +198,7 @@ elseif (UNIX)
     endif()
 
     if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
-      add_custom_command(TARGET pyigl POST_BUILD COMMAND strip ${CMAKE_CURRENT_BINARY_DIR}/../pyigl.so)
+      add_custom_command(TARGET pyigl POST_BUILD COMMAND strip ${PROJECT_SOURCE_DIR}/pyigl.so)
     endif()
   endif()
 endif()
@@ -209,7 +209,7 @@ if (LIBIGL_WITH_PYTHON AND LIBIGL_WITH_NANOGUI)
   add_custom_target(copy ALL)
   add_custom_command(
         TARGET copy
-        COMMAND ${CMAKE_COMMAND} -E copy ${NANOGUI_LIB} ${CMAKE_CURRENT_BINARY_DIR}/../
+        COMMAND ${CMAKE_COMMAND} -E copy ${NANOGUI_LIB} ${PROJECT_SOURCE_DIR}
         )
   add_dependencies(copy pyigl)
 


### PR DESCRIPTION
The pyigl.so library is placed in ${PROJECT_SOURCE_DIR}, but the post-build strip commands look relative to the ${CMAKE_CURRENT_BINARY_DIR}.  I suspect this isn't an issue when building in source as suggested in the README, but it fails when building in other directories.

The pyigl.so library is placed in ${PROJECT_SOURCE_DIR} via the LIBRARY_OUTPUT_DIRECTORY here: https://github.com/libigl/libigl/blob/aa114dc68cf0aac38bc99c8814ba3c79c96b5243/python/CMakeLists.txt#L140
