### PR TITLE
allow specification of alternate pybind11 directory

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -48,7 +48,8 @@ endif()
 include_directories(${PYTHON_INCLUDE_DIR} include)
 
 ## include pybind
-include_directories(${PROJECT_SOURCE_DIR}/../external/nanogui/ext/pybind11/include)
+set(PYBIND11_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/../external/nanogui/ext/pybind11/include CACHE PATH "Path to pybind11/include")
+include_directories(${PYBIND11_INCLUDE_DIR})
 
 ## include libigl
 option(LIBIGL_USE_STATIC_LIBRARY "Use LibIGL as static library" OFF)


### PR DESCRIPTION
This PR allows the user to specify their own pybind11 directory at CMake time via the PYBIND11_INCLUDE_DIR cmake variable.   This allows users to avoid problems when importing multiple libraries that use different pybind11 versions, as discussed in #467 

The default value is the included version, so users shouldn't notice any change if they don't manually specify a new pybind11 location.