### PR TITLE
Bug fix on incorrect malloc(0) of pointmarkerlist struct when VM.size…

### DIFF
--- a/include/igl/triangle/triangulate.cpp
+++ b/include/igl/triangle/triangulate.cpp
@@ -109,8 +109,8 @@ IGL_INLINE void igl::triangle::triangulate(
   }
 
   in.numberofpointattributes = 0;
-  in.pointmarkerlist = (int*)calloc(VM.size(),sizeof(int));
-  for(unsigned i=0;i<VM.rows();++i) in.pointmarkerlist[i] = VM.size()?VM(i):1;
+  in.pointmarkerlist = (int*)calloc(V.size(),sizeof(int)) ;
+  for(unsigned i=0;i<V.rows();++i) in.pointmarkerlist[i] = VM.size()?VM(i):1;
 
   in.trianglelist = NULL;
   in.numberoftriangles = 0;


### PR DESCRIPTION
Fix that causes Delunay triangualtion to crash by correctly allocating the pointmarker list matrix