### PR TITLE
Making the code for AABB traversal consistent

### DIFF
--- a/include/igl/AABB.cpp
+++ b/include/igl/AABB.cpp
@@ -401,7 +401,7 @@ igl::AABB<DerivedV,DIM>::squared_distance(
     const auto & look_right = [&]()
     {
       int i_right;
-      Eigen::PlainObjectBase<RowVectorDIMS> c_right = c;
+      RowVectorDIMS c_right = c;
       Scalar sqr_d_right = 
         m_right->squared_distance(V,Ele,p,low_sqr_d,sqr_d,i_right,c_right);
       this->set_min(p,sqr_d_right,i_right,c_right,sqr_d,i,c);


### PR DESCRIPTION
Hi, I just pull the latest version of libigl and found that AABB.cpp has a compilation error below. 

```
c:\lib\n\n\extern\libigl\include\igl\AABB.cpp(404): error C2248: 'Eigen::PlainObjectBase<Eigen::Matrix<double,1,3,1,1,3>>::PlainObjectBase': cannot access protected member declared in class 'Eigen::PlainObjectBase<Eigen::Matrix<double,1,3,1,1,3>>'
```
(windows10, Visual Studio 2015, x64, WindowsSDK 8.1, libigl as header only library)

So, I edit a bit and simply remove `Eigen::PlainObjectBase<...>` in `look_right` just following `look_left`.