### PR TITLE
Misc. typos

### DIFF
--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -37,7 +37,7 @@ Version | Short description
 0.3.1   | Linearly dependent constraints in min_quad_with_fixed, SparseQR buggy
 0.3.0   | Better active set method support
 0.2.3   | More explicits, active set method, opengl/anttweakbar guards
-0.2.2   | More explicit instanciations, faster sorts and uniques
+0.2.2   | More explicit instantiations, faster sorts and uniques
 0.2.1   | Bug fixes in barycenter and doublearea found by Martin Bisson
 0.2.0   | XML serializer more stable and fixed bug in remove_duplicate_vertices
 0.1.8   | Embree and xml (windows only) extras

--- a/external/AntTweakBar/examples/TwAdvanced1.cpp
+++ b/external/AntTweakBar/examples/TwAdvanced1.cpp
@@ -12,7 +12,7 @@
 //              GLFW:        http://www.glfw.org
 //  
 //
-//              This example draws a simple scene that can be re-tesselated 
+//              This example draws a simple scene that can be re-tessellated 
 //              interactively, and illuminated dynamically by an adjustable 
 //              number of moving lights.
 //
@@ -175,7 +175,7 @@ void Scene::Init(bool changeLights)
     glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
     glLightModeli(GL_LIGHT_MODEL_TWO_SIDE, GL_FALSE);
 
-    // Create objects display list using the current Subdiv parameter to control the tesselation
+    // Create objects display list using the current Subdiv parameter to control the tessellation
     if( objList>0 )
         glDeleteLists(objList, 1);      // delete previously created display list
     objList = glGenLists(1);

--- a/external/AntTweakBar/src/TwMgr.cpp
+++ b/external/AntTweakBar/src/TwMgr.cpp
@@ -1623,7 +1623,7 @@ void CQuaternionExt::MouseLeaveCB(void *structExtValue, void *clientData, TwBar 
 
 
 //  ---------------------------------------------------------------------------
-//  Convertion between VC++ Debug/Release std::string
+//  Conversion between VC++ Debug/Release std::string
 //  (Needed because VC++ adds some extra info to std::string in Debug mode!)
 //  And resolve binary std::string incompatibility between VS2010 and other VS versions
 //  ---------------------------------------------------------------------------

--- a/external/AntTweakBar/src/TwMgr.h
+++ b/external/AntTweakBar/src/TwMgr.h
@@ -246,7 +246,7 @@ struct CTwMgr
         static void ANT_CALL GetCB(void *_Value, void *_ClientData);
     };
     std::list<CCDStdString>  m_CDStdStrings;
-    struct CClientStdString  // Convertion between VC++ Debug/Release std::string
+    struct CClientStdString  // Conversion between VC++ Debug/Release std::string
     {
                         CClientStdString();
         void            FromLib(const char *libStr);
@@ -255,7 +255,7 @@ struct CTwMgr
         char            m_Data[sizeof(std::string)+2*sizeof(void *)];
         std::string     m_LibStr;
     };
-    struct CLibStdString   // Convertion between VC++ Debug/Release std::string
+    struct CLibStdString   // Conversion between VC++ Debug/Release std::string
     {
                         CLibStdString();
         void            FromClient(const std::string& clientStr);

--- a/file-formats/dmat.html
+++ b/file-formats/dmat.html
@@ -12,7 +12,7 @@
     <p>
 A .dmat file contains a dense matrix in column major order. It can contain
 ASCII or binary data. Note that it is uncompressed so binary only reduces the
-file size by 50%. But writing and reading binary is usualy faster. In MATLAB,
+file size by 50%. But writing and reading binary is usually faster. In MATLAB,
 binary is almost 100x faster.
     </p>
     <h2>ASCII</h2>

--- a/file-formats/dmat.html
+++ b/file-formats/dmat.html
@@ -33,7 +33,7 @@ Then there should be another header containing the size of the binary part:
     </p>
     <pre><code>[#cols] [#rows]</code></pre>
     <p>
-Then coefficents are written in column-major order in Little-endian 8-byte
+Then coefficients are written in column-major order in Little-endian 8-byte
 double precision IEEE floating point format.
     </p>
     <p><strong>Note:</strong> Line endings must be <code>'\n'</code> aka char(10) aka line feeds.</p>

--- a/file-formats/index.html
+++ b/file-formats/index.html
@@ -20,7 +20,7 @@
     <li><a href=http://tetgen.berlios.de/fformats.face.html
     class=missing>.face</a> TetGen's file format for simplicial facets.</li>
     <li><a href="http://www.ann.jussieu.fr/frey/publications/RT-0253.pdf#page=33">.mesh</a> Medit's triangle surface mesh + tetrahedral volume mesh file format, see page 33, section 7.2.1</li>
-    <li><i>.node</i> List of points (vertices). Described indentically (upto
+    <li><i>.node</i> List of points (vertices). Described identically (upto
         accepted dimensions, use of attributes and boundary markers) by <a
     href="https://www.cs.cmu.edu/~quake/triangle.node.html">Triangle</a>, <a
     href=http://tetgen.berlios.de/fformats.node.html>TetGen</a>, and <a
@@ -37,7 +37,7 @@
     href=https://en.wikipedia.org/wiki/Portable_Network_Graphics>.png</a>
     Portable Network Graphics image file. IGLLIB (in the libiglpng extra)
   supports png image files via the <a href=https://github.com/yig/yimg>yimg</a>
-  library. Alpha channels and compression are suppported.</li>
+  library. Alpha channels and compression are supported.</li>
     <li><i>.poly</i> Piecewise-linear complex. This format comes in many similar but importantly different flavors: 
       <a href="https://www.cs.cmu.edu/~quake/triangle.poly.html">triangle's</a>, <a href="http://tetgen.berlios.de/fformats.poly.html">tetgen's</a>, <a href="http://sparse-meshing.com/svr/0.2.1/format-poly.html">pyramid/SVR's</a></li>
     <li><a href=./rbr.html>.rbr</a> ASCII files for saving state of ReAntTweakBar</li>

--- a/file-formats/tgf.html
+++ b/file-formats/tgf.html
@@ -11,7 +11,7 @@
     <hr>
     <p>
 A .tgf file contains a graph of describing a set of control handles/structures:
-point controls, bones of a skelton and cages made of "cage edges".
+point controls, bones of a skeleton and cages made of "cage edges".
     </p>
     <p>
 The first part of the file consists of lines regarding each vertex of the graph. Each line reads:

--- a/file-formats/xml.html
+++ b/file-formats/xml.html
@@ -31,7 +31,7 @@ STL containers: <b>std::array, std::vector, std::pair</b><br/>
 Eigen types: <b>Eigen::Matrix, Eigen::SparseMatrix</b><br/>
 User defined types: <b>XMLSerializable*.</b><br/>
 <br/>
-There can also be a hierachical structure like vector&lt;int&gt;, this will result in the following serialization:
+There can also be a hierarchical structure like vector&lt;int&gt;, this will result in the following serialization:
     </p>
     <pre><code>&lt;group&gt;
   &lt;vector size="3"&gt;

--- a/include/igl/AABB.cpp
+++ b/include/igl/AABB.cpp
@@ -584,7 +584,7 @@ IGL_INLINE typename igl::AABB<DerivedV,DIM>::Scalar
     return sqr_d;
   }
 
-  //// Exact minimum squared distance between arbitary primitives inside this and
+  //// Exact minimum squared distance between arbitrary primitives inside this and
   //// othre's bounding boxes
   //const auto & min_squared_distance = [&](
   //  const AABB<DerivedV,DIM> * A,

--- a/include/igl/Camera.h
+++ b/include/igl/Camera.h
@@ -23,7 +23,7 @@ namespace igl
 
   // A simple camera class. The camera stores projection parameters (field of
   // view angle, aspect ratio, near and far clips) as well as a rigid
-  // tranformation *of the camera as if it were also a scene object*. Thus, the
+  // transformation *of the camera as if it were also a scene object*. Thus, the
   // **inverse** of this rigid transformation is the modelview transformation.
   class Camera
   {

--- a/include/igl/REDRUM.h
+++ b/include/igl/REDRUM.h
@@ -13,7 +13,7 @@
 // A: I guess the right way is to not use a macro but a proper function with
 // streams as input and output.
 
-// ANSI color codes for formating iostream style output
+// ANSI color codes for formatting iostream style output
 
 #ifdef IGL_REDRUM_NOOP
 

--- a/include/igl/SortableRow.h
+++ b/include/igl/SortableRow.h
@@ -15,7 +15,7 @@
 namespace igl
 {
   // Templates:
-  //   T  should be a matrix that implments .size(), and operator(int i)
+  //   T  should be a matrix that implements .size(), and operator(int i)
   template <typename T>
   class SortableRow
   {

--- a/include/igl/WindingNumberTree.h
+++ b/include/igl/WindingNumberTree.h
@@ -52,7 +52,7 @@ namespace igl
       MatrixXS SV;
       // Facets in this bounding volume
       MatrixXF F;
-      // Tesselated boundary curve
+      // Tessellated boundary curve
       MatrixXF cap;
       // Upper Bound on radius of enclosing ball
       typename DerivedV::Scalar radius;
@@ -97,7 +97,7 @@ namespace igl
       // Same as above, but always computes winding number using exact method
       // (sum over every facet)
       inline typename DerivedV::Scalar winding_number_all(const Point & p) const;
-      // Same as above, but always computes using sum over tesslated boundary
+      // Same as above, but always computes using sum over tessllated boundary
       inline typename DerivedV::Scalar winding_number_boundary(const Point & p) const;
       //// Same as winding_number above, but if max_simple_abs_winding_number is
       //// less than some threshold min_max_w just return 0 (colloquially the "fast

--- a/include/igl/WindingNumberTree.h
+++ b/include/igl/WindingNumberTree.h
@@ -493,7 +493,7 @@ igl::WindingNumberTree<Point,DerivedV,DerivedF>::cached_winding_number(
   return 0;
 }
 
-// Explicit instanciation of static variable
+// Explicit instantiation of static variable
 template <
   typename Point,
   typename DerivedV, 

--- a/include/igl/arap_dof.cpp
+++ b/include/igl/arap_dof.cpp
@@ -34,7 +34,7 @@
 // defined if no early exit is supported, i.e., always take a fixed number of iterations
 #define IGL_ARAP_DOF_FIXED_ITERATIONS_COUNT
 
-// A carefull derivation of this implementation is given in the corresponding
+// A careful derivation of this implementation is given in the corresponding
 // matlab function arap_dof.m
 template <typename LbsMatrixType, typename SSCALAR>
 IGL_INLINE bool igl::arap_dof_precomputation(
@@ -339,7 +339,7 @@ namespace igl
   }
   
   // converts CSM_M_SSCALAR[0], CSM_M_SSCALAR[1], CSM_M_SSCALAR[2] into one
-  // "condensed" matrix CSM while checking we're not loosing any information by
+  // "condensed" matrix CSM while checking we're not losing any information by
   // this process; specifically, returns maximal difference from scaled 3x3
   // identity blocks, which should be pretty small number
   template <typename MatrixXS>
@@ -449,7 +449,7 @@ namespace igl
   }
   
   // converts "Solve1" the "rotations" part of FullSolve matrix (the first part)
-  // into one "condensed" matrix CSolve1 while checking we're not loosing any
+  // into one "condensed" matrix CSolve1 while checking we're not losing any
   // information by this process; specifically, returns maximal difference from
   // scaled 3x3 identity blocks, which should be pretty small number
   template <typename MatrixXS>

--- a/include/igl/arap_dof.h
+++ b/include/igl/arap_dof.h
@@ -127,7 +127,7 @@ namespace igl
   //   L0  #handles * dim * dim+1 list of initial guess transformation entries,
   //     also holds fixed transformation entries for fixed handles
   //   max_iters  maximum number of iterations
-  //   tol  stopping critera parameter. If variables (linear transformation
+  //   tol  stopping criteria parameter. If variables (linear transformation
   //     matrix entries) change by less than 'tol' the optimization terminates,
   //       0.75 (weak tolerance)
   //       0.0 (extreme tolerance)

--- a/include/igl/bbw.h
+++ b/include/igl/bbw.h
@@ -49,7 +49,7 @@ namespace igl
   //   Ele  #Elements by simplex-size list of element indices
   //   b  #b boundary indices into V
   //   bc #b by #W list of boundary values
-  //   data  object containing options, intial guess --> solution and results
+  //   data  object containing options, initial guess --> solution and results
   // Outputs:
   //   W  #V by #W list of *unnormalized* weights to normalize use
   //    igl::normalize_row_sums(W,W);

--- a/include/igl/bijective_composite_harmonic_mapping.h
+++ b/include/igl/bijective_composite_harmonic_mapping.h
@@ -46,8 +46,8 @@ namespace igl
     Eigen::PlainObjectBase<DerivedU> & U);
   //
   // Inputs:
-  //   min_steps  mininum number of steps to take from V(b,:) to bc
-  //   max_steps  mininum number of steps to take from V(b,:) to bc (if
+  //   min_steps  minimum number of steps to take from V(b,:) to bc
+  //   max_steps  minimum number of steps to take from V(b,:) to bc (if
   //     max_steps == min_steps then no further number of steps will be tried)
   //   num_inner_iters  number of iterations of harmonic solves to run after
   //     for each morph step (to try to push flips back in)

--- a/include/igl/bijective_composite_harmonic_mapping.h
+++ b/include/igl/bijective_composite_harmonic_mapping.h
@@ -29,7 +29,7 @@ namespace igl
   //   bc  #b by 2 list of boundary conditions corresponding to b
   // Outputs:
   //   U  #V by 2 list of output mesh vertex locations
-  // Returns true if and only if U contains a successfull bijectie mapping
+  // Returns true if and only if U contains a successful bijectie mapping
   //
   // 
   template <
@@ -51,7 +51,7 @@ namespace igl
   //     max_steps == min_steps then no further number of steps will be tried)
   //   num_inner_iters  number of iterations of harmonic solves to run after
   //     for each morph step (to try to push flips back in)
-  //   test_for_flips  wether to check if flips occured (and trigger more
+  //   test_for_flips  whether to check if flips occurred (and trigger more
   //     steps). if test_for_flips = false then this function always returns
   //     true
   // 

--- a/include/igl/boundary_conditions.cpp
+++ b/include/igl/boundary_conditions.cpp
@@ -146,7 +146,7 @@ IGL_INLINE bool igl::boundary_conditions(
     bc(bim[bci[i]],bcj[i]) = bcv[i];
   }
 
-  // Normalize accross rows so that conditions sum to one
+  // Normalize across rows so that conditions sum to one
   for(i = 0;i<bc.rows();i++)
   {
     double sum = bc.row(i).sum();

--- a/include/igl/cat.h
+++ b/include/igl/cat.h
@@ -25,7 +25,7 @@ namespace igl
   // Template:
   //   Scalar  scalar data type for sparse matrices like double or int
   //   Mat  matrix type for all matrices (e.g. MatrixXd, SparseMatrix)
-  //   MatC  matrix type for ouput matrix (e.g. MatrixXd) needs to support
+  //   MatC  matrix type for output matrix (e.g. MatrixXd) needs to support
   //     resize
   // Inputs:
   //   A  first input matrix

--- a/include/igl/connect_boundary_to_infinity.h
+++ b/include/igl/connect_boundary_to_infinity.h
@@ -11,7 +11,7 @@
 #include <Eigen/Core>
 namespace igl
 {
-  // Connect all boundary edges to a ficticious point at infinity.
+  // Connect all boundary edges to a fictitious point at infinity.
   //
   // Inputs:
   //   F  #F by 3 list of face indices into some V

--- a/include/igl/copyleft/cgal/SelfIntersectMesh.h
+++ b/include/igl/copyleft/cgal/SelfIntersectMesh.h
@@ -236,7 +236,7 @@ namespace igl
 // a 2-manifold.
 // A: But! It seems we could use CGAL::Triangulation_3. Though it won't be easy
 // to take advantage of functions like insert_in_facet because we want to
-// constrain segments. Hmmm. Actualy Triangulation_3 doesn't look right...
+// constrain segments. Hmmm. Actually Triangulation_3 doesn't look right...
 
 // CGAL's box_self_intersection_d uses C-style function callbacks without
 // userdata. This is a leapfrog method for calling a member function. It should

--- a/include/igl/copyleft/cgal/cell_adjacency.h
+++ b/include/igl/copyleft/cgal/cell_adjacency.h
@@ -27,7 +27,7 @@ namespace igl
       //   num_cells        number of cells.
       //
       // Outputs:
-      //   adjacency_list  #C array of list of adjcent cell informations.  If
+      //   adjacency_list  #C array of list of adjcent cell information.  If
       //                   cell i and cell j are adjacent via patch x, where i
       //                   is on the positive side of x, and j is on the
       //                   negative side.  Then,

--- a/include/igl/copyleft/cgal/closest_facet.cpp
+++ b/include/igl/copyleft/cgal/closest_facet.cpp
@@ -124,7 +124,7 @@ IGL_INLINE void igl::copyleft::cgal::closest_facet(
       case CGAL::COPLANAR:
         // Warning:
         // This can only happen if fid contains a boundary edge.
-        // Catergorized this ambiguous case as negative side.
+        // Categorized this ambiguous case as negative side.
         return false;
       default:
         throw std::runtime_error("Unknown CGAL state.");

--- a/include/igl/copyleft/cgal/order_facets_around_edge.h
+++ b/include/igl/copyleft/cgal/order_facets_around_edge.h
@@ -31,7 +31,7 @@ namespace igl
       //   V  #V by 3 list of vertices.
       //   F  #F by 3 list of faces
       //   s  Index of source vertex.
-      //   d  Index of desination vertex.
+      //   d  Index of destination vertex.
       //   adj_faces  List of adjacent face signed indices.
       // Output:
       //   order  List of face indices that orders adjacent faces around edge

--- a/include/igl/copyleft/cgal/order_facets_around_edge.h
+++ b/include/igl/copyleft/cgal/order_facets_around_edge.h
@@ -50,7 +50,7 @@ namespace igl
           Eigen::PlainObjectBase<DerivedI>& order,
           bool debug=false);
 
-      // This funciton is a wrapper around the one above.  Since the ordering
+      // This function is a wrapper around the one above.  Since the ordering
       // is circular, the pivot point is used to define a starting point.  So
       // order[0] is the index into adj_face that is immediately after the
       // pivot face (s, d, pivot point) in clockwise order.

--- a/include/igl/copyleft/cgal/outer_facet.h
+++ b/include/igl/copyleft/cgal/outer_facet.h
@@ -26,7 +26,7 @@ namespace igl
         // See cgal::remesh_self_intersections.h for how to obtain such input.
         //
         // This function differ from igl::outer_facet() in the fact this
-        // funciton is more robust because it does not rely on facet normals.
+        // function is more robust because it does not rely on facet normals.
         //
         // Inputs:
         //   V  #V by 3 list of vertex positions

--- a/include/igl/copyleft/cgal/point_mesh_squared_distance.cpp
+++ b/include/igl/copyleft/cgal/point_mesh_squared_distance.cpp
@@ -81,7 +81,7 @@ IGL_INLINE void igl::copyleft::cgal::point_mesh_squared_distance_precompute(
   // accelerate_distance_queries doesn't seem actually to do _all_ of the
   // precomputation. the tree (despite being const) will still do more
   // precomputation and reorganizing on the first call of `closest_point` or
-  // `closest_point_and_primitive`. Therefor, call it once here.
+  // `closest_point_and_primitive`. Therefore, call it once here.
   tree.closest_point_and_primitive(Point_3(0,0,0));
 }
 

--- a/include/igl/copyleft/cgal/points_inside_component.cpp
+++ b/include/igl/copyleft/cgal/points_inside_component.cpp
@@ -321,7 +321,7 @@ IGL_INLINE void igl::copyleft::cgal::points_inside_component(
                 inside(i,0) = determine_point_face_orientation(V, F, I, query, fid);
                 break;
             default:
-                throw "Unknow closest element type!";
+                throw "Unknown closest element type!";
         }
     }
 }

--- a/include/igl/copyleft/cgal/remesh_intersections.cpp
+++ b/include/igl/copyleft/cgal/remesh_intersections.cpp
@@ -449,7 +449,7 @@ IGL_INLINE void igl::copyleft::cgal::remesh_intersections(
           FF.data(), [&vv_to_unique](const typename DerivedFF::Scalar& a)
           { return vv_to_unique[a]; });
       IM.resize(unique_vv.rows());
-      // Have to use << instead of = becasue Eigen's PlainObjectBase is annoying
+      // Have to use << instead of = because Eigen's PlainObjectBase is annoying
       IM << igl::LinSpaced<
         Eigen::Matrix<typename DerivedIM::Scalar, Eigen::Dynamic,1 >
         >(unique_vv.rows(), 0, unique_vv.rows()-1);

--- a/include/igl/copyleft/cgal/remesh_intersections.h
+++ b/include/igl/copyleft/cgal/remesh_intersections.h
@@ -30,7 +30,7 @@ namespace igl
       //   offending #offending map taking face indices into F to pairs of order
       //     of first finding and list of intersection objects from all
       //     intersections
-      //   stitch_all  if true, merge all vertices with thte same coordiante.
+      //   stitch_all  if true, merge all vertices with the same coordinate.
       // Outputs:
       //   VV  #VV by 3 list of vertex positions, if stitch_all = false then
       //     first #V vertices will always be V

--- a/include/igl/copyleft/cgal/trim_with_solid.cpp
+++ b/include/igl/copyleft/cgal/trim_with_solid.cpp
@@ -56,7 +56,7 @@ IGL_INLINE void igl::copyleft::cgal::trim_with_solid(
   igl::slice_mask(Eigen::MatrixXi(F),A,1,F);
   igl::slice_mask(Eigen::VectorXi(P),A,1,P);
   igl::slice_mask(Eigen::VectorXi(J),A,1,J);
-  // Agregate representative query points for each patch
+  // Aggregate representative query points for each patch
   std::vector<bool> flag(num_patches);
   std::vector<std::vector<CGAL::Epeck::FT> > vQ;
   Eigen::VectorXi P2Q(num_patches);

--- a/include/igl/copyleft/comiso/miq.h
+++ b/include/igl/copyleft/comiso/miq.h
@@ -43,7 +43,7 @@ namespace igl
     //   UV             #UV by 2 list of vertices in 2D
     //   FUV            #FUV by 3 list of face indices in UV
     //
-    // TODO: rename the parameters name in the cpp consistenly
+    // TODO: rename the parameters name in the cpp consistently
     //       improve the handling of hard_features, right now it might fail in difficult cases
 
     template <typename DerivedV, typename DerivedF, typename DerivedU>

--- a/include/igl/copyleft/comiso/nrosy.h
+++ b/include/igl/copyleft/comiso/nrosy.h
@@ -32,7 +32,7 @@ namespace igl
     //   w_soft  #S by 1 weight for the soft constraints (0-1)
     //   bc_soft #S by 3 bc for soft constraints
     //   N       the degree of the N-RoSy vector field
-    //   soft    the strength of the soft contraints w.r.t. smoothness
+    //   soft    the strength of the soft constraints w.r.t. smoothness
     //           (0 -> smoothness only, 1->constraints only)
     // Outputs:
     //   R       #F by 3 the representative vectors of the interpolated field

--- a/include/igl/copyleft/comiso/nrosy.h
+++ b/include/igl/copyleft/comiso/nrosy.h
@@ -32,7 +32,7 @@ namespace igl
     //   w_soft  #S by 1 weight for the soft constraints (0-1)
     //   bc_soft #S by 3 bc for soft constraints
     //   N       the degree of the N-RoSy vector field
-    //   soft    the strenght of the soft contraints w.r.t. smoothness
+    //   soft    the strength of the soft contraints w.r.t. smoothness
     //           (0 -> smoothness only, 1->constraints only)
     // Outputs:
     //   R       #F by 3 the representative vectors of the interpolated field

--- a/include/igl/copyleft/offset_surface.h
+++ b/include/igl/copyleft/offset_surface.h
@@ -8,7 +8,7 @@ namespace igl
 {
   namespace copyleft
   {
-    // Compute a triangulated offset surface using maching cubes on a gride of
+    // Compute a triangulated offset surface using matching cubes on a grid of
     // signed distance values from the input triangle mesh.
     //
     // Inputs:

--- a/include/igl/copyleft/opengl2/render_to_tga.h
+++ b/include/igl/copyleft/opengl2/render_to_tga.h
@@ -20,7 +20,7 @@ namespace igl
     //   width  width of scene and resulting image
     //   height height of scene and resulting image
     ///  alpha  whether to include alpha channel
-    // Returns true only if no errors occured
+    // Returns true only if no errors occurred
     //
     // See also: png/render_to_png which is slower but writes .png files
     IGL_INLINE bool render_to_tga(

--- a/include/igl/copyleft/tetgen/cdt.h
+++ b/include/igl/copyleft/tetgen/cdt.h
@@ -34,7 +34,7 @@ namespace igl
         // Flags to tetgen. Do not include the "c" flag here! {"Y"}
         std::string flags = "Y";
       };
-      // Create a constrained delaunay tesselation containing convex hull of the
+      // Create a constrained delaunay tessellation containing convex hull of the
       // given **non-selfintersecting** mesh.
       //
       // Inputs:

--- a/include/igl/copyleft/tetgen/read_into_tetgenio.h
+++ b/include/igl/copyleft/tetgen/read_into_tetgenio.h
@@ -30,7 +30,7 @@ namespace igl
       //   .medit
       //   .vtk
       //   etc.
-      // Noteably it does not support .obj which is loaded by hand here (also
+      // Notably it does not support .obj which is loaded by hand here (also
       // demonstrating how to load points/faces programatically)
       //
       // If the file extension is not recognized the filename is assumed to be

--- a/include/igl/copyleft/tetgen/read_into_tetgenio.h
+++ b/include/igl/copyleft/tetgen/read_into_tetgenio.h
@@ -31,7 +31,7 @@ namespace igl
       //   .vtk
       //   etc.
       // Notably it does not support .obj which is loaded by hand here (also
-      // demonstrating how to load points/faces programatically)
+      // demonstrating how to load points/faces programmatically)
       //
       // If the file extension is not recognized the filename is assumed to be
       // the basename of a collection describe a tetmesh, (of which at least

--- a/include/igl/cotmatrix.h
+++ b/include/igl/cotmatrix.h
@@ -16,7 +16,7 @@
 //  Used const references rather than copying the entire mesh 
 //    Alec 9 October 2011
 //  removed cotan (uniform weights) optional parameter it was building a buggy
-//    half of the uniform laplacian, please see adjacency_matrix istead 
+//    half of the uniform laplacian, please see adjacency_matrix instead 
 //    Alec 9 October 2011
 
 namespace igl 

--- a/include/igl/cotmatrix_entries.cpp
+++ b/include/igl/cotmatrix_entries.cpp
@@ -35,10 +35,10 @@ IGL_INLINE void igl::cotmatrix_entries(
     case 3:
     {
       // Triangles
-      //Compute Squared Edge lenghts 
+      //Compute Squared Edge lengths 
       Matrix<typename DerivedC::Scalar,Dynamic,3> l2;
       igl::squared_edge_lengths(V,F,l2);
-      //Compute Edge lenghts 
+      //Compute Edge lengths 
       Matrix<typename DerivedC::Scalar,Dynamic,3> l;
       l = l2.array().sqrt();
       

--- a/include/igl/crouzeix_raviart_cotmatrix.cpp
+++ b/include/igl/crouzeix_raviart_cotmatrix.cpp
@@ -19,7 +19,7 @@ void igl::crouzeix_raviart_cotmatrix(
   Eigen::PlainObjectBase<DerivedE> & E,
   Eigen::PlainObjectBase<DerivedEMAP> & EMAP)
 {
-  // All occurances of directed "facets"
+  // All occurrences of directed "facets"
   Eigen::MatrixXi allE;
   oriented_facets(F,allE);
   Eigen::VectorXi _1;

--- a/include/igl/crouzeix_raviart_massmatrix.cpp
+++ b/include/igl/crouzeix_raviart_massmatrix.cpp
@@ -24,7 +24,7 @@ void igl::crouzeix_raviart_massmatrix(
     Eigen::PlainObjectBase<DerivedE> & E,
     Eigen::PlainObjectBase<DerivedEMAP> & EMAP)
 {
-  // All occurances of directed "facets"
+  // All occurrences of directed "facets"
   Eigen::MatrixXi allE;
   oriented_facets(F,allE);
   Eigen::VectorXi _1;

--- a/include/igl/cut_mesh.cpp
+++ b/include/igl/cut_mesh.cpp
@@ -70,11 +70,11 @@ namespace igl {
     IGL_INLINE void FindInitialPos(const int vert, int &edge, int &face);
 
 
-    // intialize the mapping given an initial pos
+    // initialize the mapping given an initial pos
     // whih must be initialized with FindInitialPos
     IGL_INLINE void MapIndexes(const int  vert, const int edge_init, const int f_init);
 
-    // intialize the mapping for a given vertex
+    // initialize the mapping for a given vertex
     IGL_INLINE void InitMappingSeam(const int vert);
 
   };
@@ -187,7 +187,7 @@ FindInitialPos(const int vert,
 
 
 
-///intialize the mapping given an initial pos
+///initialize the mapping given an initial pos
 ///whih must be initialized with FindInitialPos
 template <typename DerivedV, typename DerivedF, typename VFType, typename DerivedTT, typename DerivedC>
 IGL_INLINE void igl::MeshCutterMini<DerivedV, DerivedF, VFType, DerivedTT, DerivedC>::

--- a/include/igl/directed_edge_parents.h
+++ b/include/igl/directed_edge_parents.h
@@ -13,7 +13,7 @@
 
 namespace igl
 {
-  // Recover "parents" (preceeding edges) in a tree given just directed edges.
+  // Recover "parents" (preceding edges) in a tree given just directed edges.
   //
   // Inputs:
   //   E  #E by 2 list of directed edges

--- a/include/igl/embree/EmbreeIntersector.h
+++ b/include/igl/embree/EmbreeIntersector.h
@@ -209,7 +209,7 @@ inline void igl::embree::EmbreeIntersector::global_init()
   {
     rtcInit();
     if(rtcGetError() != RTC_NO_ERROR)
-      std::cerr << "Embree: An error occured while initialiting embree core!" << std::endl;
+      std::cerr << "Embree: An error occurred while initializing embree core!" << std::endl;
 #ifdef IGL_VERBOSE
     else
       std::cerr << "Embree: core initialized." << std::endl;
@@ -324,7 +324,7 @@ inline void igl::embree::EmbreeIntersector::init(
   rtcCommit(scene);
 
   if(rtcGetError() != RTC_NO_ERROR)
-      std::cerr << "Embree: An error occured while initializing the provided geometry!" << endl;
+      std::cerr << "Embree: An error occurred while initializing the provided geometry!" << endl;
 #ifdef IGL_VERBOSE
   else
     std::cerr << "Embree: geometry added." << endl;
@@ -348,7 +348,7 @@ void igl::embree::EmbreeIntersector::deinit()
 
     if(rtcGetError() != RTC_NO_ERROR)
     {
-        std::cerr << "Embree: An error occured while resetting!" << std::endl;
+        std::cerr << "Embree: An error occurred while resetting!" << std::endl;
     }
 #ifdef IGL_VERBOSE
     else
@@ -374,7 +374,7 @@ inline bool igl::embree::EmbreeIntersector::intersectRay(
   rtcIntersect(scene,ray);
 #ifdef IGL_VERBOSE
   if(rtcGetError() != RTC_NO_ERROR)
-      std::cerr << "Embree: An error occured while resetting!" << std::endl;
+      std::cerr << "Embree: An error occurred while resetting!" << std::endl;
 #endif
 
   if((unsigned)ray.geomID != RTC_INVALID_GEOMETRY_ID)

--- a/include/igl/exterior_edges.cpp
+++ b/include/igl/exterior_edges.cpp
@@ -67,7 +67,7 @@ IGL_INLINE void igl::exterior_edges(
   {
     int e = 0;
     const size_t nue = uE.rows();
-    // Append each unique edge with a non-zero amount of signed occurances
+    // Append each unique edge with a non-zero amount of signed occurrences
     for(size_t ue = 0; ue<nue; ue++)
     {
       const int count = counts(ue);

--- a/include/igl/exterior_edges.h
+++ b/include/igl/exterior_edges.h
@@ -12,7 +12,7 @@
 namespace igl
 {
   // EXTERIOR_EDGES Determines boundary "edges" and also edges with an
-  // odd number of occurances where seeing edge (i,j) counts as +1 and seeing
+  // odd number of occurrences where seeing edge (i,j) counts as +1 and seeing
   // the opposite edge (j,i) counts as -1
   //
   // Inputs:

--- a/include/igl/facet_components.h
+++ b/include/igl/facet_components.h
@@ -16,7 +16,7 @@ namespace igl
   //
   // Inputs:
   //   F  #F by 3 list of triangle indices
-  // Ouputs:
+  // Outputs:
   //   C  #F list of connected component ids
   template <typename DerivedF, typename DerivedC>
   IGL_INLINE void facet_components(
@@ -25,7 +25,7 @@ namespace igl
   // Inputs:
   //   TT  #TT by 3 list of list of adjacency triangles (see
   //   triangle_triangle_adjacency.h)
-  // Ouputs:
+  // Outputs:
   //   C  #F list of connected component ids
   //   counts #C list of number of facets in each components
   template <

--- a/include/igl/hausdorff.h
+++ b/include/igl/hausdorff.h
@@ -59,7 +59,7 @@ namespace igl
   //   V   3 by 3 list of corner positions so that V.row(i) is the position of the
   //     ith corner
   //   dist_to_B  function taking the x,y,z coordinate of a query position and
-  //     outputing the closest-point distance to some point-set B
+  //     outputting the closest-point distance to some point-set B
   // Outputs:
   //   l  lower bound on Hausdorff distance 
   //   u  upper bound on Hausdorff distance

--- a/include/igl/histc.h
+++ b/include/igl/histc.h
@@ -13,7 +13,7 @@
 
 namespace igl
 {
-  // Like matlab's histc. Count occurances of values in X between consecutive
+  // Like matlab's histc. Count occurrences of values in X between consecutive
   // entries in E
   //
   // Inputs:

--- a/include/igl/integrable_polyvector_fields.h
+++ b/include/igl/integrable_polyvector_fields.h
@@ -51,7 +51,7 @@ namespace igl {
                                                     igl::IntegrableFieldSolverData<DerivedV, DerivedF, DerivedFF, DerivedC> &data);
 
 
-  // Given the current estimate of the field, performes one round of optimization
+  // Given the current estimate of the field, performs one round of optimization
   // iterations and updates the current estimate. The intermediate data is saved
   // and returned for the next iteration.
   // Inputs:

--- a/include/igl/integrable_polyvector_fields.h
+++ b/include/igl/integrable_polyvector_fields.h
@@ -15,7 +15,7 @@
 
 namespace igl {
   // Compute a curl-free frame field from user constraints, optionally starting
-  // from a gived frame field (assumed to be interpolating the constraints).
+  // from a given frame field (assumed to be interpolating the constraints).
   // Implementation of the paper "Integrable PolyVector Fields", SIGGRAPH 2015.
 
   // Set of parameters used during solve

--- a/include/igl/is_boundary_edge.cpp
+++ b/include/igl/is_boundary_edge.cpp
@@ -47,14 +47,14 @@ void igl::is_boundary_edge(
   MatrixXi uE;
   VectorXi EMAP;
   unique_rows(sorted_EallE,uE,_,EMAP);
-  // Counts of occurances
+  // Counts of occurrences
   VectorXi N = VectorXi::Zero(uE.rows());
   for(int e = 0;e<EMAP.rows();e++)
   {
     N(EMAP(e))++;
   }
   B.resize(E.rows());
-  // Look of occurances of 2: one for original and another for boundary
+  // Look of occurrences of 2: one for original and another for boundary
   for(int e = 0;e<E.rows();e++)
   {
     B(e) = (N(EMAP(e)) == 2);
@@ -97,14 +97,14 @@ void igl::is_boundary_edge(
   sort(allE,2,true,sorted_allE,_);
   // Determine unique undirected edges E and map to directed edges EMAP
   unique_rows(sorted_allE,E,_,EMAP);
-  // Counts of occurances
+  // Counts of occurrences
   VectorXi N = VectorXi::Zero(E.rows());
   for(int e = 0;e<EMAP.rows();e++)
   {
     N(EMAP(e))++;
   }
   B.resize(E.rows());
-  // Look of occurances of 1
+  // Look of occurrences of 1
   for(int e = 0;e<E.rows();e++)
   {
     B(e) = N(e) == 1;

--- a/include/igl/is_planar.h
+++ b/include/igl/is_planar.h
@@ -13,7 +13,7 @@
 
 namespace igl
 {
-  // Determin if a set of points lies on the XY plane
+  // Determine if a set of points lies on the XY plane
   //
   // Inputs:
   //   V  #V by dim list of vertex positions

--- a/include/igl/lim/lim.h
+++ b/include/igl/lim/lim.h
@@ -59,7 +59,7 @@ namespace igl
     //--------------------------------------------------------------------------
     // Return values:
     //  Succeeded : Successful optimization with fulfilled tolerance
-    //  LocalMinima : Convergenged to a local minima / tolerance not fullfilled
+    //  LocalMinima : Convergenged to a local minima / tolerance not fulfilled
     //  IterationLimit : Max iteration reached before tolerance was fulfilled
     //  Infeasible : not feasible -> has inverted elements (decrease eps?)
   

--- a/include/igl/matlab/validate_arg.h
+++ b/include/igl/matlab/validate_arg.h
@@ -16,9 +16,9 @@ namespace igl
     // Throw an error if arg i+1 is not a scalar
     //
     // Inputs:
-    //   i  index of current arguement
+    //   i  index of current argument
     //   nrhs  total number of arguments
-    //   prhs  pointer to arguements array
+    //   prhs  pointer to arguments array
     //   name   name of current argument
     IGL_INLINE void validate_arg_scalar(
       const int i, const int nrhs, const mxArray * prhs[], const char * name);

--- a/include/igl/matlab_format.h
+++ b/include/igl/matlab_format.h
@@ -22,9 +22,9 @@ namespace igl
   // Templates:
   //   DerivedM  e.g. derived from MatrixXd
   // Input:
-  //   input  some matrix to be formated
+  //   input  some matrix to be formatted
   //   name  name of matrix
-  // Returns  Formated matrix
+  // Returns  Formatted matrix
   //
   // Example:
   // // M := [1 2 3;4 5 6];
@@ -44,7 +44,7 @@ namespace igl
   IGL_INLINE const Eigen::WithFormat< DerivedM > matlab_format(
     const Eigen::DenseBase<DerivedM> & M,
     const std::string name = "");
-  // Same but for sparse matrices. Print IJV format into an auxillary variable
+  // Same but for sparse matrices. Print IJV format into an auxiliary variable
   // and then print a call to sparse which will construct the sparse matrix
   // Example:
   // // S := [0 2 3;4 5 0];

--- a/include/igl/min_quad_with_fixed.cpp
+++ b/include/igl/min_quad_with_fixed.cpp
@@ -204,7 +204,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
       data.preY.resize(data.unknown_lagrange.size(),0);
     }
 
-    // Positive definite and no equality constraints (Postive definiteness
+    // Positive definite and no equality constraints (Positive definiteness
     // implies symmetric)
 #ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
     cout<<"    factorize"<<endl;

--- a/include/igl/mosek/bbw.h
+++ b/include/igl/mosek/bbw.h
@@ -30,7 +30,7 @@ namespace igl
     //   Ele  #Elements by simplex-size list of element indices
     //   b  #b boundary indices into V
     //   bc #b by #W list of boundary values
-    //   data  object containing options, intial guess --> solution and results
+    //   data  object containing options, initial guess --> solution and results
     //   mosek_data  object containing mosek options
     // Outputs:
     //   W  #V by #W list of *unnormalized* weights to normalize use

--- a/include/igl/mosek/mosek_quadprog.cpp
+++ b/include/igl/mosek/mosek_quadprog.cpp
@@ -53,7 +53,7 @@ igl::mosek::MosekData::MosekData()
   //   choose the right ordering method when really any of them are
   //   instantaneous
   intparam[MSK_IPAR_INTPNT_ORDER_METHOD] = MSK_ORDER_METHOD_NONE;
-  // 1.0 means optimizer is very leniant about declaring model infeasible
+  // 1.0 means optimizer is very lenient about declaring model infeasible
   douparam[MSK_DPAR_INTPNT_TOL_INFEAS] = 1e-8;
   // Hard to say if this is doing anything, probably nothing dramatic
   douparam[MSK_DPAR_INTPNT_TOL_PSAFE]= 1e2;

--- a/include/igl/mosek/mosek_quadprog.cpp
+++ b/include/igl/mosek/mosek_quadprog.cpp
@@ -31,7 +31,7 @@ igl::mosek::MosekData::MosekData()
 #if MSK_VERSION_MAJOR >= 8
   douparam[MSK_DPAR_INTPNT_QO_TOL_REL_GAP]=1e-12;
 #endif
-  // Force using multiple threads, not sure if MOSEK is properly destorying
+  // Force using multiple threads, not sure if MOSEK is properly destroying
   //extra threads...
 #if MSK_VERSION_MAJOR >= 7
   intparam[MSK_IPAR_NUM_THREADS] = 6;

--- a/include/igl/opengl/glfw/background_window.cpp
+++ b/include/igl/opengl/glfw/background_window.cpp
@@ -25,7 +25,7 @@ IGL_INLINE bool igl::opengl::glfw::background_window(GLFWwindow* & window)
       /* Problem: glewInit failed, something is seriously wrong. */
      fprintf(stderr, "Error: %s\n", glewGetErrorString(err));
     }
-    glGetError(); // pull and savely ignonre unhandled errors like GL_INVALID_ENUM
+    glGetError(); // pull and safely ignore unhandled errors like GL_INVALID_ENUM
   #endif
   return true;
 }

--- a/include/igl/opengl2/MouseController.h
+++ b/include/igl/opengl2/MouseController.h
@@ -24,7 +24,7 @@ namespace igl
     {
       public:
         typedef Eigen::VectorXi VectorXb;
-        // Propogate selection to descendants so that selected bones and their
+        // Propagate selection to descendants so that selected bones and their
         // subtrees are all selected.
         //
         // Input:
@@ -495,7 +495,7 @@ inline void igl::opengl2::MouseController::set_selection(
   // Combine upward, group rigid parts, repeat
   while(true)
   {
-    // Spread selection accross rigid pieces
+    // Spread selection across rigid pieces
     VectorXb SRP(VectorXb::Zero(RP.maxCoeff()+1));
     for(int e = 0;e<BE.rows();e++)
     {

--- a/include/igl/opengl2/lens_flare.cpp
+++ b/include/igl/opengl2/lens_flare.cpp
@@ -115,7 +115,7 @@ IGL_INLINE void igl::opengl2::lens_flare_draw(
   using namespace Eigen;
   using namespace std;
 
-  //// view_dir  direction from eye to position is is looking at
+  //// view_dir  direction from eye to position it is looking at
   //const Vector3f view_dir =  (at - from).normalized();
 
   //// near_clip  distance from eye to near clipping plane along view_dir

--- a/include/igl/opengl2/lens_flare.h
+++ b/include/igl/opengl2/lens_flare.h
@@ -21,7 +21,7 @@ namespace igl
     struct Flare{
       int type;             /* flare texture index, 0..5 */
       float scale;
-      float loc;            /* postion on axis */
+      float loc;            /* position on axis */
       float color[3];
       Flare():
         type(-1),

--- a/include/igl/opengl2/unproject_to_zero_plane.h
+++ b/include/igl/opengl2/unproject_to_zero_plane.h
@@ -14,7 +14,7 @@ namespace igl
   namespace opengl2
   {
   // Wrapper for gluUnproject that uses the current GL_MODELVIEW_MATRIX,
-    // GL_PROJECTION_MATRIX, and GL_VIEWPORT to unproject a screen postion
+    // GL_PROJECTION_MATRIX, and GL_VIEWPORT to unproject a screen position
     // (winX,winY) to a 3d location at same depth as the current origin.
     // Inputs:
     //   win*  screen space x, y, and z coordinates respectively

--- a/include/igl/parallel_for.h
+++ b/include/igl/parallel_for.h
@@ -31,7 +31,7 @@ namespace igl
   //
   // Inputs:
   //   loop_size  number of iterations. I.e. for(int i = 0;i<loop_size;i++) ...
-  //   func  function handle taking iteration index as only arguement to compute
+  //   func  function handle taking iteration index as only argument to compute
   //     inner block of for loop I.e. for(int i ...){ func(i); }
   //   min_parallel  min size of loop_size such that parallel (non-serial)
   //     thread pooling should be attempted {0}
@@ -65,7 +65,7 @@ namespace igl
   //   prep_func function handle taking n >= number of threads as only
   //     argument 
   //   func  function handle taking iteration index i and thread id t as only
-  //     arguements to compute inner block of for loop I.e. 
+  //     arguments to compute inner block of for loop I.e. 
   //     for(int i ...){ func(i,t); }
   //   accum_func  function handle taking thread index as only argument, to be
   //     called after all calls of func, e.g., for serial accumulation across

--- a/include/igl/pathinfo.cpp
+++ b/include/igl/pathinfo.cpp
@@ -9,7 +9,7 @@
 
 #include "dirname.h"
 #include "basename.h"
-// Verbose should be removed once everythings working correctly
+// Verbose should be removed once everything working correctly
 #include "verbose.h"
 #include <algorithm>
 

--- a/include/igl/per_edge_normals.cpp
+++ b/include/igl/per_edge_normals.cpp
@@ -35,7 +35,7 @@ IGL_INLINE void igl::per_edge_normals(
   assert(F.cols() == 3 && "Faces must be triangles");
   // number of faces
   const int m = F.rows();
-  // All occurances of directed edges
+  // All occurrences of directed edges
   MatrixXi allE;
   oriented_facets(F,allE);
   // Find unique undirected edges and mapping

--- a/include/igl/ply.h
+++ b/include/igl/ply.h
@@ -2249,7 +2249,7 @@ inline char **get_words(FILE *fp, int *nwords, char **orig_line)
   }
 
   /* convert line-feed and tabs into spaces */
-  /* (this guarentees that there will be a space before the */
+  /* (this guarantees that there will be a space before the */
   /*  null character at the end of the string) */
 
   str[BIG_STRING-2] = ' ';
@@ -2349,7 +2349,7 @@ char **get_words(FILE *fp, int *nwords, char **orig_line)
   }
 
   // convert line-feed and tabs into spaces  
-  // (this guarentees that there will be a space before the  
+  // (this guarantees that there will be a space before the  
   //  null character at the end of the string)  
 
   str[BIG_STRING-2] = ' ';

--- a/include/igl/ply.h
+++ b/include/igl/ply.h
@@ -2368,7 +2368,7 @@ char **get_words(FILE *fp, int *nwords, char **orig_line)
     }
     else if (*ptr == '\r') {
       *ptr = '\0';
-      *ptr2 = '\0'; //note dont break yet, on a pc \r is followed by \n
+      *ptr2 = '\0'; //note don't break yet, on a pc \r is followed by \n
     }
   }
 

--- a/include/igl/png/render_to_png.h
+++ b/include/igl/png/render_to_png.h
@@ -22,7 +22,7 @@ namespace igl
     //   height height of scene and resulting image
     //   alpha  whether to include alpha channel
     //   fast  sacrifice compression ratio for speed
-    // Returns true only if no errors occured
+    // Returns true only if no errors occurred
     //
     // See also: igl/render_to_tga which is faster but writes .tga files
     IGL_INLINE bool render_to_png(

--- a/include/igl/png/render_to_png_async.h
+++ b/include/igl/png/render_to_png_async.h
@@ -26,7 +26,7 @@ namespace igl
     //   height height of scene and resulting image
     //   alpha  whether to include alpha channel
     //   fast  sacrifice compression ratio for speed
-    // Returns true only if no errors occured
+    // Returns true only if no errors occurred
     //
     // See also: igl/render_to_tga which is faster but writes .tga files
     IGL_INLINE std::thread render_to_png_async(

--- a/include/igl/png/writePNG.cpp
+++ b/include/igl/png/writePNG.cpp
@@ -21,7 +21,7 @@ IGL_INLINE bool igl::png::writePNG(
   assert((R.cols() == G.cols()) && (G.cols() == B.cols()) && (B.cols() == A.cols()));
 
   const int comp = 4;                                  // 4 Channels Red, Green, Blue, Alpha
-  const int stride_in_bytes = R.rows()*comp;           // Lenght of one row in bytes
+  const int stride_in_bytes = R.rows()*comp;           // Length of one row in bytes
   std::vector<unsigned char> data(R.size()*comp,0);     // The image itself;
 
   for (unsigned i = 0; i<R.rows();++i)

--- a/include/igl/polyvector_field_matchings.cpp
+++ b/include/igl/polyvector_field_matchings.cpp
@@ -26,7 +26,7 @@ IGL_INLINE void igl::polyvector_field_matching(
   // make sure the matching preserve ccw order of the vectors across the edge
   // 1) order vectors in a, ccw  e.g. (0,1,2,3)_a not ccw --> (0,3,2,1)_a ccw
   // 2) order vectors in b, ccw  e.g. (0,1,2,3)_b not ccw --> (0,2,1,3)_b ccw
-  // 3) the vectors in b that match the ordered vectors in a (in this case  (0,3,2,1)_a ) must be a circular shift of the ccw ordered vectors in b  - so we need to explicitely check only these matchings to find the best ccw one, there are N of them
+  // 3) the vectors in b that match the ordered vectors in a (in this case  (0,3,2,1)_a ) must be a circular shift of the ccw ordered vectors in b  - so we need to explicitly check only these matchings to find the best ccw one, there are N of them
   int hN = _ua.cols()/3;
   int N;
   if (is_symmetric)

--- a/include/igl/principal_curvature.h
+++ b/include/igl/principal_curvature.h
@@ -27,7 +27,7 @@ namespace igl
   // Inputs:
   //   V       eigen matrix #V by 3
   //   F       #F by 3 list of mesh faces (must be triangles)
-  //   radius  controls the size of the neighbourhood used, 1 = average edge lenght
+  //   radius  controls the size of the neighbourhood used, 1 = average edge length
   //
   // Outputs:
   //   PD1 #V by 3 maximal curvature direction for each vertex.

--- a/include/igl/project_to_line.h
+++ b/include/igl/project_to_line.h
@@ -12,7 +12,7 @@
 
 namespace igl
 {
-  // PROJECT_TO_LINE  project points onto vectors, that is find the paramter
+  // PROJECT_TO_LINE  project points onto vectors, that is find the parameter
   // t for a point p such that proj_p = (y-x).*t, additionally compute the
   // squared distance from p to the line of the vector, such that 
   // |p - proj_p|² = sqr_d

--- a/include/igl/project_to_line_segment.h
+++ b/include/igl/project_to_line_segment.h
@@ -12,7 +12,7 @@
 
 namespace igl
 {
-  // PROJECT_TO_LINE_SEGMENT project points onto vectors, that is find the paramter
+  // PROJECT_TO_LINE_SEGMENT project points onto vectors, that is find the parameter
   // t for a point p such that proj_p = (y-x).*t, additionally compute the
   // squared distance from p to the line of the vector, such that 
   // |p - proj_p|² = sqr_d

--- a/include/igl/raytri.c
+++ b/include/igl/raytri.c
@@ -129,7 +129,7 @@ inline int intersect_triangle1(double orig[3], double dir[3],
       if (*v > 0.0 || *u + *v < det)
 	 return 0;
    }
-   else return 0;  /* ray is parallell to the plane of the triangle */
+   else return 0;  /* ray is parallel to the plane of the triangle */
 
 
    inv_det = 1.0 / det;
@@ -196,7 +196,7 @@ inline int intersect_triangle2(double orig[3], double dir[3],
       if (*v > 0.0 || *u + *v < det)
 	 return 0;
    }
-   else return 0;  /* ray is parallell to the plane of the triangle */
+   else return 0;  /* ray is parallel to the plane of the triangle */
 
    /* calculate t, ray intersects triangle */
    *t = IGL_RAY_TRI_DOT(edge2, qvec) * inv_det;
@@ -256,7 +256,7 @@ inline int intersect_triangle3(double orig[3], double dir[3],
       if (*v > 0.0 || *u + *v < det)
 	 return 0;
    }
-   else return 0;  /* ray is parallell to the plane of the triangle */
+   else return 0;  /* ray is parallel to the plane of the triangle */
 
    *t = IGL_RAY_TRI_DOT(edge2, qvec) * inv_det;
    (*u) *= inv_det;

--- a/include/igl/readOBJ.cpp
+++ b/include/igl/readOBJ.cpp
@@ -48,7 +48,7 @@ IGL_INLINE bool igl::readOBJ(
   std::vector<std::vector<Index > > & FTC,
   std::vector<std::vector<Index > > & FN)
 {
-  // File open was succesfull so clear outputs
+  // File open was successful so clear outputs
   V.clear();
   TC.clear();
   N.clear();
@@ -56,7 +56,7 @@ IGL_INLINE bool igl::readOBJ(
   FTC.clear();
   FN.clear();
 
-  // variables an constants to assist parsing the .obj file
+  // variables and constants to assist parsing the .obj file
   // Constant strings to compare against
   std::string v("v");
   std::string vn("vn");

--- a/include/igl/readTGF.h
+++ b/include/igl/readTGF.h
@@ -25,7 +25,7 @@ namespace igl
   //
   // Input:
   //  filename  .tgf file name
-  // Ouput:
+  // Output:
   //  V  # vertices by 3 list of vertex positions
   //  E  # edges by 2 list of edge indices
   //  P  # point-handles list of point handle indices

--- a/include/igl/setdiff.cpp
+++ b/include/igl/setdiff.cpp
@@ -42,7 +42,7 @@ IGL_INLINE void igl::setdiff(
       }
     }
     assert(k == C.size());
-    // Have to use << instead of = becasue Eigen's PlainObjectBase is annoying
+    // Have to use << instead of = because Eigen's PlainObjectBase is annoying
     IA << igl::LinSpaced<Eigen::Matrix<typename DerivedIA::Scalar,Eigen::Dynamic,1> >(
       C.size(),0,C.size()-1);
   }

--- a/include/igl/sort_angles.cpp
+++ b/include/igl/sort_angles.cpp
@@ -18,7 +18,7 @@ IGL_INLINE void igl::sort_angles(
     assert(num_cols >= 2);
 
     R.resize(num_rows);
-    // Have to use << instead of = becasue Eigen's PlainObjectBase is annoying
+    // Have to use << instead of = because Eigen's PlainObjectBase is annoying
     R << igl::LinSpaced<
       Eigen::Matrix<typename DerivedR::Scalar, Eigen::Dynamic, 1> >
       (num_rows, 0, num_rows-1);

--- a/include/igl/sort_triangles.cpp
+++ b/include/igl/sort_triangles.cpp
@@ -390,7 +390,7 @@ IGL_INLINE void igl::sort_triangles(
 //  assert(false && 
 //    "THIS WILL NEVER WORK because depth sorting is not a numerical sort where"
 //    "pairwise comparisons of triangles are transitive.  Rather it is a"
-//    "topological sort on a dependecy graph. Dependency encodes 'This triangle"
+//    "topological sort on a dependency graph. Dependency encodes 'This triangle"
 //    "must be drawn before that one'");
 //  using namespace std;
 //  using namespace Eigen;

--- a/include/igl/triangle_fan.h
+++ b/include/igl/triangle_fan.h
@@ -11,13 +11,13 @@
 #include <Eigen/Dense>
 namespace igl
 {
-  // Given a list of faces tesselate all of the "exterior" edges forming another
+  // Given a list of faces tessellate all of the "exterior" edges forming another
   // list of 
   //
   // Inputs:
   //   E  #E by simplex_size-1  list of exterior edges (see exterior_edges.h)
   // Outputs:
-  //   cap  #cap by simplex_size  list of "faces" tessleating the boundary edges
+  //   cap  #cap by simplex_size  list of "faces" tessellating the boundary edges
   IGL_INLINE void triangle_fan(
     const Eigen::MatrixXi & E,
     Eigen::MatrixXi & cap);

--- a/include/igl/unique_edge_map.cpp
+++ b/include/igl/unique_edge_map.cpp
@@ -25,7 +25,7 @@ IGL_INLINE void igl::unique_edge_map(
 {
   using namespace Eigen;
   using namespace std;
-  // All occurances of directed edges
+  // All occurrences of directed edges
   oriented_facets(F,E);
   const size_t ne = E.rows();
   // This is 2x faster to create than a map from pairs to lists of edges and 5x

--- a/include/igl/viewer/Viewer.cpp
+++ b/include/igl/viewer/Viewer.cpp
@@ -937,7 +937,7 @@ namespace viewer
         /* Problem: glewInit failed, something is seriously wrong. */
        fprintf(stderr, "Error: %s\n", glewGetErrorString(err));
       }
-      glGetError(); // pull and savely ignonre unhandled errors like GL_INVALID_ENUM
+      glGetError(); // pull and safely ignore unhandled errors like GL_INVALID_ENUM
       fprintf(stdout, "Status: Using GLEW %s\n", glewGetString(GLEW_VERSION));
     #endif
 

--- a/include/igl/viewer/Viewer.cpp
+++ b/include/igl/viewer/Viewer.cpp
@@ -946,7 +946,7 @@ namespace viewer
       major = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MAJOR);
       minor = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MINOR);
       rev = glfwGetWindowAttrib(window, GLFW_CONTEXT_REVISION);
-      printf("OpenGL version recieved: %d.%d.%d\n", major, minor, rev);
+      printf("OpenGL version received: %d.%d.%d\n", major, minor, rev);
       printf("Supported OpenGL is %s\n", (const char*)glGetString(GL_VERSION));
       printf("Supported GLSL is %s\n", (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION));
     #endif

--- a/include/igl/viewer/ViewerCore.h
+++ b/include/igl/viewer/ViewerCore.h
@@ -119,7 +119,7 @@ public:
   float model_zoom;
   Eigen::Vector3f model_translation;
 
-  // Model viewing paramters (uv coordinates)
+  // Model viewing parameters (uv coordinates)
   float model_zoom_uv;
   Eigen::Vector3f model_translation_uv;
 

--- a/include/igl/viewer/ViewerData.h
+++ b/include/igl/viewer/ViewerData.h
@@ -44,7 +44,7 @@ public:
     DIRTY_ALL            = 0x03FF
   };
 
-  // Empy all fields
+  // Empty all fields
   IGL_INLINE void clear();
 
   // Change the visualization mode, invalidating the cache if necessary

--- a/include/igl/xml/writeDAE.cpp
+++ b/include/igl/xml/writeDAE.cpp
@@ -25,7 +25,7 @@ IGL_INLINE bool igl::xml::writeDAE(
 
   const auto & ele = [&doc](
     const std::string tag,
-    // Can't just use `{}` as the default arguement because of a clang-bug
+    // Can't just use `{}` as the default argument because of a clang-bug
     // http://stackoverflow.com/questions/17264067/
     const std::map<std::string,std::string> attribs =
       std::map<std::string,std::string>(),

--- a/optional/README.md
+++ b/optional/README.md
@@ -232,7 +232,7 @@ Alternatively, you can also compress everything into a single header file:
 
 * **Hard to debug/edit**: The compressed files are
   automatically generated. They're huge and should not be edited. Thus
-  debugging and editting are near impossible.
+  debugging and editing are near impossible.
 
 * **Compounded dependencies**:
   An immediate disadvantage of this
@@ -241,7 +241,7 @@ Alternatively, you can also compress everything into a single header file:
   `igl.cpp` will require linking to all of `libigl`'s
   dependencies (`OpenGL`, `GLUT`,
   `AntTweakBar`, `BLAS`). However, because all
-  depencies other than Eigen should be encapsulated between
+  dependencies other than Eigen should be encapsulated between
   `#ifndef` guards (e.g. `#ifndef IGL_NO_OPENGL`, it
   is possible to ignore certain functions that have such dependencies.
 

--- a/optional/index.html
+++ b/optional/index.html
@@ -283,7 +283,7 @@ exposing templated functions.</li>
 <ul>
 <li><p><strong>Hard to debug/edit</strong>: The compressed files are
  automatically generated. They&#8217;re huge and should not be edited. Thus
- debugging and editting are near impossible.</p></li>
+ debugging and editing are near impossible.</p></li>
 <li><p><strong>Compounded dependencies</strong>:
  An immediate disadvantage of this
  seems to be that even to use a single function (e.g.
@@ -291,7 +291,7 @@ exposing templated functions.</li>
  <code>igl.cpp</code> will require linking to all of <code>libigl</code>&#8217;s
  dependencies (<code>OpenGL</code>, <code>GLUT</code>,
  <code>AntTweakBar</code>, <code>BLAS</code>). However, because all
- depencies other than Eigen should be encapsulated between
+ dependencies other than Eigen should be encapsulated between
  <code>#ifndef</code> guards (e.g. <code>#ifndef IGL_NO_OPENGL</code>, it
  is possible to ignore certain functions that have such dependencies.</p></li>
 <li><p><strong>Long compile</strong>:

--- a/python/README.md
+++ b/python/README.md
@@ -122,11 +122,11 @@ viewer.launch()
 
 ### Remote viewer
 
-Whe using the viewer from an interactive python shell (iPython), it is
+When using the viewer from an interactive python shell (iPython), it is
 inconvenient to let the viewer take control of the main thread for rendering
 purposes. We provide a simple wrapper for the viewer that allows to launch
 a remote process and send meshes to it via a TCP/IP socket. For more
-informations on how to use it see the documentation in [tcpviewer.py](tcpviewer.py)
+information on how to use it see the documentation in [tcpviewer.py](tcpviewer.py)
 
 ## Matlab
 

--- a/python/modules/py_vector.cpp
+++ b/python/modules/py_vector.cpp
@@ -100,7 +100,7 @@ py::class_<Type> bind_eigen_2(py::module &m, const char *name) {
         .def("rows", [](const Type &m) { return m.rows(); })
         .def("shape", [](const Type &m) { return std::tuple<int,int>(m.rows(), m.cols()); })
 
-        /* Extract rows and colums */
+        /* Extract rows and columns */
         .def("col", [](const Type &m, int i) {
             if (i<0 || i>=m.cols())
               throw std::runtime_error("Column index out of bound.");

--- a/python/py_doc.cpp
+++ b/python/py_doc.cpp
@@ -322,7 +322,7 @@ const char *__doc_igl_copyleft_comiso_miq = R"igl_Qu8mg5v7(// Inputs:
     //   UV             #UV by 2 list of vertices in 2D
     //   FUV            #FUV by 3 list of face indices in UV
     //
-    // TODO: rename the parameters name in the cpp consistenly
+    // TODO: rename the parameters name in the cpp consistently
     //       improve the handling of hard_features, right now it might fail in difficult cases)igl_Qu8mg5v7";
 const char *__doc_igl_copyleft_comiso_nrosy = R"igl_Qu8mg5v7(// Generate a N-RoSy field from a sparse set of constraints
     //
@@ -336,7 +336,7 @@ const char *__doc_igl_copyleft_comiso_nrosy = R"igl_Qu8mg5v7(// Generate a N-RoS
     //   w_soft  #S by 1 weight for the soft constraints (0-1)
     //   bc_soft #S by 3 bc for soft constraints
     //   N       the degree of the N-RoSy vector field
-    //   soft    the strength of the soft contraints w.r.t. smoothness
+    //   soft    the strength of the soft constraints w.r.t. smoothness
     //           (0 -> smoothness only, 1->constraints only)
     // Outputs:
     //   R       #F by 3 the representative vectors of the interpolated field

--- a/python/py_doc.cpp
+++ b/python/py_doc.cpp
@@ -126,7 +126,7 @@ const char *__doc_igl_bbw = R"igl_Qu8mg5v7(// Compute Bounded Biharmonic Weights
   //   Ele  #Elements by simplex-size list of element indices
   //   b  #b boundary indices into V
   //   bc #b by #W list of boundary values
-  //   data  object containing options, intial guess --> solution and results
+  //   data  object containing options, initial guess --> solution and results
   // Outputs:
   //   W  #V by #W list of *unnormalized* weights to normalize use
   //    igl::normalize_row_sums(W,W);
@@ -182,7 +182,7 @@ const char *__doc_igl_cat = R"igl_Qu8mg5v7(// Perform concatenation of a two mat
   // Template:
   //   Scalar  scalar data type for sparse matrices like double or int
   //   Mat  matrix type for all matrices (e.g. MatrixXd, SparseMatrix)
-  //   MatC  matrix type for ouput matrix (e.g. MatrixXd) needs to support
+  //   MatC  matrix type for output matrix (e.g. MatrixXd) needs to support
   //     resize
   // Inputs:
   //   A  first input matrix
@@ -336,7 +336,7 @@ const char *__doc_igl_copyleft_comiso_nrosy = R"igl_Qu8mg5v7(// Generate a N-RoS
     //   w_soft  #S by 1 weight for the soft constraints (0-1)
     //   bc_soft #S by 3 bc for soft constraints
     //   N       the degree of the N-RoSy vector field
-    //   soft    the strenght of the soft contraints w.r.t. smoothness
+    //   soft    the strength of the soft contraints w.r.t. smoothness
     //           (0 -> smoothness only, 1->constraints only)
     // Outputs:
     //   R       #F by 3 the representative vectors of the interpolated field
@@ -473,7 +473,7 @@ const char *__doc_igl_directed_edge_orientations = R"igl_Qu8mg5v7(// Determine r
   // Outputs:
   //   Q  #E list of quaternions 
   //)igl_Qu8mg5v7";
-const char *__doc_igl_directed_edge_parents = R"igl_Qu8mg5v7(// Recover "parents" (preceeding edges) in a tree given just directed edges.
+const char *__doc_igl_directed_edge_parents = R"igl_Qu8mg5v7(// Recover "parents" (preceding edges) in a tree given just directed edges.
   //
   // Inputs:
   //   E  #E by 2 list of directed edges
@@ -1040,7 +1040,7 @@ const char *__doc_igl_principal_curvature = R"igl_Qu8mg5v7(// Compute the princi
   // Inputs:
   //   V       eigen matrix #V by 3
   //   F       #F by 3 list of mesh faces (must be triangles)
-  //   radius  controls the size of the neighbourhood used, 1 = average edge lenght
+  //   radius  controls the size of the neighbourhood used, 1 = average edge length
   //
   // Outputs:
   //   PD1 #V by 3 maximal curvature direction for each vertex.
@@ -1123,7 +1123,7 @@ const char *__doc_igl_readTGF = R"igl_Qu8mg5v7(// READTGF
   //
   // Input:
   //  filename  .tgf file name
-  // Ouput:
+  // Output:
   //  V  # vertices by 3 list of vertex positions
   //  E  # edges by 2 list of edge indices
   //  P  # point-handles list of point handle indices

--- a/python/tutorial/301_Slice.py
+++ b/python/tutorial/301_Slice.py
@@ -22,11 +22,11 @@ F = igl.eigen.MatrixXi()
 
 igl.readOFF(TUTORIAL_SHARED_PATH + "decimated-knight.off", V, F)
 
-# 100 random indicies into rows of F
+# 100 random indices into rows of F
 I = igl.eigen.MatrixXi()
 igl.floor((0.5 * (igl.eigen.MatrixXd.Random(100, 1) + 1.) * F.rows()), I)
 
-# 50 random indicies into rows of I
+# 50 random indices into rows of I
 J = igl.eigen.MatrixXi()
 igl.floor((0.5 * (igl.eigen.MatrixXd.Random(50, 1) + 1.) * I.rows()), J)
 

--- a/python/tutorial/403_BoundedBiharmonicWeights.py
+++ b/python/tutorial/403_BoundedBiharmonicWeights.py
@@ -27,7 +27,7 @@ def pre_draw(viewer):
         for e in range(len(pose)):
             anim_pose[e] = pose[e].slerp(anim_t, igl.eigen.Quaterniond.Identity())
 
-        # Propogate relative rotations via FK to retrieve absolute transformations
+        # Propagate relative rotations via FK to retrieve absolute transformations
         vQ = igl.RotationList()
         vT = []
         igl.forward_kinematics(C, BE, P, anim_pose, vQ, vT)

--- a/python/tutorial/404_DualQuaternionSkinning.py
+++ b/python/tutorial/404_DualQuaternionSkinning.py
@@ -34,7 +34,7 @@ def pre_draw(viewer):
         for e in range(len(poses[begin])):
             anim_pose.append(poses[begin][e].slerp(t, poses[end][e]))
 
-        # Propogate relative rotations via FK to retrieve absolute transformations
+        # Propagate relative rotations via FK to retrieve absolute transformations
         vQ = igl.RotationList()
         vT = []
         igl.forward_kinematics(C, BE, P, anim_pose, vQ, vT)

--- a/python/tutorial/505_MIQ.py
+++ b/python/tutorial/505_MIQ.py
@@ -226,7 +226,7 @@ S = igl.eigen.MatrixXd()
 
 igl.comiso.nrosy(V, F, b, bc, igl.eigen.MatrixXi(), igl.eigen.MatrixXd(), igl.eigen.MatrixXd(), 4, 0.5, X1, S)
 
-# Find the the orthogonal vector
+# Find the orthogonal vector
 B1 = igl.eigen.MatrixXd()
 B2 = igl.eigen.MatrixXd()
 B3 = igl.eigen.MatrixXd()

--- a/scripts/clone-and-build.sh
+++ b/scripts/clone-and-build.sh
@@ -64,7 +64,7 @@ The command produced the following standard output/error before failing:
   echo -e "$html_content" | mail -s "$subject" $recipients
 } 
 
-# Runs the arguements as a command as usual, but if the command fails send an
+# Runs the arguments as a command as usual, but if the command fails send an
 # email using `report_error` and exit without continuing
 #
 #     guard command arg1 arg2 ...

--- a/scripts/h2pair.sh
+++ b/scripts/h2pair.sh
@@ -37,7 +37,7 @@ do
 
   if [[ `grep -c "^\#endif" "$i"` > 1 ]];
   then
-    echo "Warning $i contains multple matches to ^#endif"
+    echo "Warning $i contains multiple matches to ^#endif"
   fi
 
   before=`sed -n '/^\/\/ Implementation$/q;p' "$i"`;

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -23,7 +23,7 @@ The following files contain the offensive \"std::__1\" namespace:
 
 ${RED}$STD1${NC}
 
-Consider issueing:
+Consider issuing:
 
     sed -i '' -e \"s/std::__1/std/g\"" $STD1
 

--- a/shared/cmake/CXXFeatures.cmake
+++ b/shared/cmake/CXXFeatures.cmake
@@ -76,7 +76,7 @@ set(CXX17_FEATURES
 # cxx_thread_local                      Thread-local variables, as defined in N2659.
 # cxx_trailing_return_types             Automatic function return type, as defined in N2541.
 # cxx_unicode_literals                  Unicode string literals, as defined in N2442.
-# cxx_uniform_initialization            Uniform intialization, as defined in N2640.
+# cxx_uniform_initialization            Uniform initialization, as defined in N2640.
 # cxx_unrestricted_unions               Unrestricted unions, as defined in N2544.
 # cxx_user_literals                     User-defined literals, as defined in N2765.
 # cxx_variable_templates                Variable templates, as defined in N3651.

--- a/style-guidelines.html
+++ b/style-guidelines.html
@@ -274,7 +274,7 @@ to mean a list of faces/triangles.</p>
 <p>Classes should be avoided. When naming a class use CamelCase (e.g.
 SortableRow.h).</p>
 
-<h2 id="enumnamingconvertion">Enum naming convertion</h2>
+<h2 id="enumnamingconvertion">Enum naming conversion</h2>
 
 <p>Enums types should be placed in the appropriate <code>igl::</code> namespace and should be
 named in CamelCase (e.g. <code>igl::SolverStatus</code>) and instances should be named in

--- a/style-guidelines.md
+++ b/style-guidelines.md
@@ -270,7 +270,7 @@ to mean a list of faces/triangles.
 Classes should be avoided. When naming a class use CamelCase (e.g.
 SortableRow.h).
 
-## Enum naming convertion
+## Enum naming conversion
 
 Enums types should be placed in the appropriate `igl::` namespace and should be
 named in CamelCase (e.g. `igl::SolverStatus`) and instances should be named in

--- a/tutorial/301_Slice/main.cpp
+++ b/tutorial/301_Slice/main.cpp
@@ -14,11 +14,11 @@ int main(int argc, char *argv[])
   MatrixXi F;
   igl::readOFF(TUTORIAL_SHARED_PATH "/decimated-knight.off",V,F);
 
-  // 100 random indicies into rows of F
+  // 100 random indices into rows of F
   VectorXi I;
   igl::floor((0.5*(VectorXd::Random(100,1).array()+1.)*F.rows()).eval(),I);
   
-  // 50 random indicies into rows of I
+  // 50 random indices into rows of I
   VectorXi J;
   igl::floor((0.5*(VectorXd::Random(50,1).array()+1.)*I.rows()).eval(),J);
   

--- a/tutorial/403_BoundedBiharmonicWeights/main.cpp
+++ b/tutorial/403_BoundedBiharmonicWeights/main.cpp
@@ -54,7 +54,7 @@ bool pre_draw(igl::viewer::Viewer & viewer)
     {
       anim_pose[e] = pose[e].slerp(anim_t,Quaterniond::Identity());
     }
-    // Propogate relative rotations via FK to retrieve absolute transformations
+    // Propagate relative rotations via FK to retrieve absolute transformations
     RotationList vQ;
     vector<Vector3d> vT;
     igl::forward_kinematics(C,BE,P,anim_pose,vQ,vT);

--- a/tutorial/404_DualQuaternionSkinning/main.cpp
+++ b/tutorial/404_DualQuaternionSkinning/main.cpp
@@ -49,7 +49,7 @@ bool pre_draw(igl::viewer::Viewer & viewer)
     {
       anim_pose[e] = poses[begin][e].slerp(t,poses[end][e]);
     }
-    // Propogate relative rotations via FK to retrieve absolute transformations
+    // Propagate relative rotations via FK to retrieve absolute transformations
     RotationList vQ;
     vector<Vector3d> vT;
     igl::forward_kinematics(C,BE,P,anim_pose,vQ,vT);

--- a/tutorial/505_MIQ/main.cpp
+++ b/tutorial/505_MIQ/main.cpp
@@ -257,7 +257,7 @@ int main(int argc, char *argv[])
     VectorXd S;
     igl::copyleft::comiso::nrosy(V, F, b, bc, VectorXi(), VectorXd(), MatrixXd(), 4, 0.5, X1, S);
 
-    // Find the the orthogonal vector
+    // Find the orthogonal vector
     MatrixXd B1, B2, B3;
     igl::local_basis(V, F, B1, B2, B3);
     X2 = igl::rotate_vectors(X1, VectorXd::Constant(1, M_PI / 2), B1, B2);

--- a/tutorial/510_Integrable/main.cpp
+++ b/tutorial/510_Integrable/main.cpp
@@ -474,7 +474,7 @@ void update_display(igl::viewer::Viewer& viewer)
 
   if (display_mode == 9)
   {
-    cerr<< "Displaying original field overlayed onto the current integrated field"  <<endl;
+    cerr<< "Displaying original field overlaid onto the current integrated field"  <<endl;
 
     viewer.data.set_mesh(V, F);
 
@@ -496,7 +496,7 @@ void update_display(igl::viewer::Viewer& viewer)
 
   if (display_mode == 0)
   {
-    cerr<< "Displaying current field overlayed onto the current integrated field"  <<endl;
+    cerr<< "Displaying current field overlaid onto the current integrated field"  <<endl;
 
     viewer.data.set_mesh(V, F);
 

--- a/tutorial/602_Matlab/main.cpp
+++ b/tutorial/602_Matlab/main.cpp
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
   // Extract the first 10 eigenvectors
   igl::matlab::mleval(&engine,"[EV,~] = eigs(-L,10,'sm')");
 
-  // Plot the size of EV (only for demostration purposes)
+  // Plot the size of EV (only for demonstration purposes)
   std::cerr << igl::matlab::mleval(&engine,"size(EV)") << std::endl;
 
   // Retrieve the result

--- a/tutorial/tutorial.html
+++ b/tutorial/tutorial.html
@@ -305,7 +305,7 @@ converter from OFF to OBJ format.</p>
 <h2 id="visualizingsurfaces"><a href="#visualizingsurfaces">Visualizing surfaces</a></h2>
 
 <p>Libigl provides an glfw-based OpenGL 3.2 viewer to visualize surfaces, their
-properties and additional debugging informations.</p>
+properties and additional debugging information.</p>
 
 <p>The following code (<a href="102_DrawMesh/main.cpp">Example 102</a>) is a basic skeleton
 for all the examples that will be used in the tutorial.
@@ -438,7 +438,7 @@ heavy data structures types favors simplicity, ease of use and reusability.</p>
 
 <h2 id="overlays"><a href="#overlays">Overlays</a></h2>
 
-<p>In addition to plotting the surface, the viewer supports the visualization of points, lines and text labels: these overlays can be very helpful while developing geometric processing algorithms to plot debug informations.</p>
+<p>In addition to plotting the surface, the viewer supports the visualization of points, lines and text labels: these overlays can be very helpful while developing geometric processing algorithms to plot debug information.</p>
 
 <pre><code class="cpp">viewer.data.add_points(P,Eigen::RowVector3d(r,g,b));
 </code></pre>
@@ -1419,7 +1419,7 @@ eigen value problem:</p>
 matrix. Most commonly in geometry processing, we let <span class="math">\(A=L\)</span> the cotangent
 Laplacian and <span class="math">\(B=M\)</span> the per-vertex mass matrix (e.g. <a class="citation" href="#fn:7" title="Jump to citation">[7]<span class="citekey" style="display:none">vallet_2008</span></a>).
 Typically applications will make use of the <em>low frequency</em> eigen modes.
-Analagous to the Fourier decomposition, a function <span class="math">\(f\)</span> on a surface can be
+Analogous to the Fourier decomposition, a function <span class="math">\(f\)</span> on a surface can be
 represented via its spectral decomposition of the eigen modes of the
 Laplace-Beltrami:</p>
 
@@ -2504,7 +2504,7 @@ of the parameterization functions (which are tangent vector fields on the surfac
 <h1 id="chapter6:externallibraries">Chapter 6: External libraries</h1>
 
 <p>An additional positive side effect of using matrices as basic types is that it
-is easy to exchange data between libigl and other softwares and libraries.</p>
+is easy to exchange data between libigl and other software and libraries.</p>
 
 <h2 id="stateserialization"><a href="#stateserialization">State serialization</a></h2>
 
@@ -2632,7 +2632,7 @@ before a submission deadline.</p>
 
 <p>Libigl can be interfaced with Matlab to offload numerically heavy computation
 to a Matlab script. The major advantage of this approach is that you will be
-able to develop efficient and complex user-interfaces in C++, while exploting
+able to develop efficient and complex user-interfaces in C++, while exploring
 the syntax and fast protototyping features of matlab. In particular, the use of
 an external Matlab script in a libigl application allows to change the Matlab
 code while the C++ application is running, greatly increasing coding

--- a/tutorial/tutorial.html
+++ b/tutorial/tutorial.html
@@ -998,7 +998,7 @@ functionality as common Matlab functions.</p>
 </tr>
 <tr>
 	<td style="text-align:left;"><code>igl::cumsum</code></td>
-	<td style="text-align:left;">Cummulative summation</td>
+	<td style="text-align:left;">Cumulative summation</td>
 </tr>
 <tr>
 	<td style="text-align:left;"><code>igl::dot</code></td>
@@ -1964,7 +1964,7 @@ rotation edge sets (right of middle), to the very fast subpsace method
 <h2 id="biharmoniccoordinates">Biharmonic Coordinates</h2>
 
 <p>Linear blend skinning (as <a href="#boundedbiharmonicweights">above</a>) deforms a mesh by
-propogating <em>full affine transformations</em> at handles (bones, points, regions,
+propagating <em>full affine transformations</em> at handles (bones, points, regions,
 etc.) to the rest of the shape via weights. Another deformation framework,
 called &#8220;generalized barycentric coordinates&#8221;, is a special case of linear blend
 skinning <a class="citation" href="#fn:19" title="Jump to citation">[19]<span class="citekey" style="display:none">jacobson_skinning_course_2014</span></a>: transformations are restricted to
@@ -3499,7 +3499,7 @@ motion (gold).</figcaption>
 
 <p>Picking vertices and faces using the mouse is very common in geometry
 processing applications. While this might seem a simple operation, its
-implementation is not straighforward. Libigl contains a function that solves this problem using the
+implementation is not straightforward. Libigl contains a function that solves this problem using the
 <a href="https://software.intel.com/en-us/articles/embree-photo-realistic-ray-tracing-kernels">Embree</a>
 raycaster. Its usage is demonstrated in <a href="708_Picking/main.cpp">Example 708</a>:</p>
 

--- a/tutorial/tutorial.md
+++ b/tutorial/tutorial.md
@@ -258,7 +258,7 @@ converter from OFF to OBJ format.
 ## [Visualizing surfaces](#visualizingsurfaces) [visualizingsurfaces]
 
 Libigl provides an glfw-based OpenGL 3.2 viewer to visualize surfaces, their
-properties and additional debugging informations.
+properties and additional debugging information.
 
 The following code ([Example 102](102_DrawMesh/main.cpp)) is a basic skeleton
 for all the examples that will be used in the tutorial.
@@ -389,7 +389,7 @@ heavy data structures types favors simplicity, ease of use and reusability.
 
 ## [Overlays](#overlays) [overlays]
 
-In addition to plotting the surface, the viewer supports the visualization of points, lines and text labels: these overlays can be very helpful while developing geometric processing algorithms to plot debug informations.
+In addition to plotting the surface, the viewer supports the visualization of points, lines and text labels: these overlays can be very helpful while developing geometric processing algorithms to plot debug information.
 
 ```cpp
 viewer.data.add_points(P,Eigen::RowVector3d(r,g,b));
@@ -1176,7 +1176,7 @@ where $A$ is a sparse symmetric matrix and $B$ is a sparse positive definite
 matrix. Most commonly in geometry processing, we let $A=L$ the cotangent
 Laplacian and $B=M$ the per-vertex mass matrix (e.g. [#vallet_2008][]).
 Typically applications will make use of the _low frequency_ eigen modes.
-Analagous to the Fourier decomposition, a function $f$ on a surface can be
+Analogous to the Fourier decomposition, a function $f$ on a surface can be
 represented via its spectral decomposition of the eigen modes of the
 Laplace-Beltrami:
 
@@ -2151,7 +2151,7 @@ For a complete categorization of fields used in various applications (including 
 # Chapter 6: External libraries [chapter6:externallibraries]
 
 An additional positive side effect of using matrices as basic types is that it
-is easy to exchange data between libigl and other softwares and libraries.
+is easy to exchange data between libigl and other software and libraries.
 
 ## [State serialization](#stateserialization) [stateserialization]
 
@@ -2285,7 +2285,7 @@ before a submission deadline.
 
 Libigl can be interfaced with Matlab to offload numerically heavy computation
 to a Matlab script. The major advantage of this approach is that you will be
-able to develop efficient and complex user-interfaces in C++, while exploting
+able to develop efficient and complex user-interfaces in C++, while exploring
 the syntax and fast protototyping features of matlab. In particular, the use of
 an external Matlab script in a libigl application allows to change the Matlab
 code while the C++ application is running, greatly increasing coding

--- a/tutorial/tutorial.md
+++ b/tutorial/tutorial.md
@@ -876,7 +876,7 @@ functionality as common Matlab functions.
 | `igl::components`        | Connected components of graph (cf. Matlab's `graphconncomp`) |
 | `igl::count`             | Count non-zeros in rows or columns |
 | `igl::cross`             | Cross product per-row |
-| `igl::cumsum`            | Cummulative summation |
+| `igl::cumsum`            | Cumulative summation |
 | `igl::dot`               | dot product per-row |
 | `igl::eigs`              | Solve sparse eigen value problem |
 | `igl::find`              | Find subscripts of non-zero entries |
@@ -1687,7 +1687,7 @@ rotation edge sets (right of middle), to the very fast subpsace method
 ## Biharmonic Coordinates
 
 Linear blend skinning (as [above](#boundedbiharmonicweights)) deforms a mesh by
-propogating _full affine transformations_ at handles (bones, points, regions,
+propagating _full affine transformations_ at handles (bones, points, regions,
 etc.) to the rest of the shape via weights. Another deformation framework,
 called "generalized barycentric coordinates", is a special case of linear blend
 skinning [#jacobson_skinning_course_2014][]: transformations are restricted to
@@ -3100,7 +3100,7 @@ motion (gold).](images/bunny-swept-volume.gif)
 
 Picking vertices and faces using the mouse is very common in geometry
 processing applications. While this might seem a simple operation, its
-implementation is not straighforward. Libigl contains a function that solves this problem using the
+implementation is not straightforward. Libigl contains a function that solves this problem using the
 [Embree](https://software.intel.com/en-us/articles/embree-photo-realistic-ray-tracing-kernels)
 raycaster. Its usage is demonstrated in [Example 708](708_Picking/main.cpp):
 


### PR DESCRIPTION
Most are non-user facing. Hope this is not too annoying of a PR. 

Used `codespell -d -q 3 --skip="*.po,*.ts,./.git,./external"` to locate relevant typos.