### PR TITLE
Small fixes in CMake build script.

### DIFF
--- a/shared/cmake/libigl.cmake
+++ b/shared/cmake/libigl.cmake
@@ -74,6 +74,10 @@ else()
   target_include_directories(igl_common SYSTEM INTERFACE ${NANOGUI_DIR}/ext/eigen)
 endif()
 
+# C++11 Thread library
+find_package(Threads REQUIRED)
+target_link_libraries(igl_common INTERFACE ${CMAKE_THREAD_LIBS_INIT})
+
 ################################################################################
 
 function(compile_igl_module module_dir prefix)
@@ -93,7 +97,7 @@ function(compile_igl_module module_dir prefix)
 
   target_link_libraries(igl_${module_name} ${IGL_SCOPE} igl_common)
   if(NOT module_name STREQUAL "core")
-	  target_link_libraries(igl_${module_name} ${IGL_SCOPE} igl_core)
+    target_link_libraries(igl_${module_name} ${IGL_SCOPE} igl_core)
   endif()
 
   # Alias target because it looks nicer
@@ -286,7 +290,7 @@ if(LIBIGL_WITH_OPENGL)
       set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL " " FORCE)
       set(GLFW_BUILD_TESTS OFF CACHE BOOL " " FORCE)
       set(GLFW_BUILD_DOCS OFF CACHE BOOL " " FORCE)
-      set(GLFW_BUILD_INSTALL OFF CACHE BOOL " " FORCE)
+      set(GLFW_INSTALL OFF CACHE BOOL " " FORCE)
       add_subdirectory(${NANOGUI_DIR}/ext/glfw glfw)
     endif()
     target_include_directories(glfw ${IGL_SCOPE} ${NANOGUI_DIR}/ext/glfw/include)


### PR DESCRIPTION
Fixes two small issues:

- The option to disable before including `glfw` is called [GLFW_INSTALL](https://github.com/wjakob/glfw/blob/0ff30d648506e19a1c54a2b2a2d09c4e59b86922/CMakeLists.txt#L31), not `GLFW_BUILD_INSTALL`
- Somehow, it seems that linking with `pthread` is needed when using functions that call `parallel_for` (e.g. `igl::doublearea()`). I had a linking error only when I used libigl in header-only mode, which is weird. But asking CMake to properly link against the C++11 thread library fixed it (it links with `pthread` on Unix systems, and the native Windows thread library on Windows).