### PR TITLE
enable use of alternate pybind11

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -23,7 +23,8 @@ if(UNIX)
 endif()
 
 ## include pybind
-add_subdirectory(${PROJECT_SOURCE_DIR}/../external/nanogui/ext/pybind11 pybind11)
+set(PYBIND11_DIR ${PROJECT_SOURCE_DIR}/../external/nanogui/ext/pybind11 CACHE PATH "Path to pybind11")
+add_subdirectory(${PYBIND11_DIR} pybind11)
 
 ## include libigl
 option(LIBIGL_USE_STATIC_LIBRARY "Use LibIGL as static library" OFF)


### PR DESCRIPTION
This PR re-enables use of an alternate pybind11 (It was inadvertently removed in e7d5bc2).   No change unless the user manually specifies the PYBIND11_DIR CMake variable.