### PR TITLE
Fixed Python CMakeLists.txt for CMake 3.10.0

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -131,7 +131,7 @@ if(WIN32)
   # Link against the Python shared library
   # message(FATAL_ERROR ${PYTHON_LIBRARY})
   # target_link_libraries(igl ${PYTHON_LIBRARY})
-  target_link_libraries(pyigl ${PYTHON_LIBRARIES})
+  target_link_libraries(pyigl PRIVATE ${PYTHON_LIBRARIES})
 
 elseif(UNIX)
   # It's quite common to have multiple copies of the same Python version
@@ -166,7 +166,7 @@ elseif(UNIX)
   else()
 
     if(CHECK_UNDEFINED)
-      target_link_libraries(pyigl ${PYTHON_LIBRARIES})
+      target_link_libraries(pyigl PRIVATE ${PYTHON_LIBRARIES})
       set_target_properties(pyigl PROPERTIES LINK_FLAGS "-Wl,--no-undefined")
     endif()
 


### PR DESCRIPTION
`target_link_libraries` creates an error in case one do not specify PUBLIC/PRIVATE for each use of `target_link_libraries` on a target

    -- LTO enabled
    CMake Error at CMakeLists.txt:134 (target_link_libraries):
      The keyword signature for target_link_libraries has already been used with
      the target "pyigl".  All uses of target_link_libraries with a target must
      be either all-keyword or all-plain.