### PR TITLE
Change CMakeLists.txt in tutorials and some fix

### DIFF
--- a/tutorial/101_FileIO/CMakeLists.txt
+++ b/tutorial/101_FileIO/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(101_FileIO)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core tutorials)

--- a/tutorial/102_DrawMesh/CMakeLists.txt
+++ b/tutorial/102_DrawMesh/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(102_DrawMesh)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/103_Events/CMakeLists.txt
+++ b/tutorial/103_Events/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(103_Events)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/104_Colors/CMakeLists.txt
+++ b/tutorial/104_Colors/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(104_Colors)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/105_Overlays/CMakeLists.txt
+++ b/tutorial/105_Overlays/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(105_Overlays)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/106_ViewerMenu/CMakeLists.txt
+++ b/tutorial/106_ViewerMenu/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(106_ViewerMenu)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw igl::opengl_glfw_imgui tutorials)

--- a/tutorial/107_MultipleMeshes/CMakeLists.txt
+++ b/tutorial/107_MultipleMeshes/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(107_MultipleMeshes)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/201_Normals/CMakeLists.txt
+++ b/tutorial/201_Normals/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(201_Normals)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/202_GaussianCurvature/CMakeLists.txt
+++ b/tutorial/202_GaussianCurvature/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(202_GaussianCurvature)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/203_CurvatureDirections/CMakeLists.txt
+++ b/tutorial/203_CurvatureDirections/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(203_CurvatureDirections)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/204_Gradient/CMakeLists.txt
+++ b/tutorial/204_Gradient/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(204_Gradient)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/205_Laplacian/CMakeLists.txt
+++ b/tutorial/205_Laplacian/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(205_Laplacian)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/206_GeodesicDistance/CMakeLists.txt
+++ b/tutorial/206_GeodesicDistance/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(206_GeodesicDistance)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/301_Slice/CMakeLists.txt
+++ b/tutorial/301_Slice/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(301_Slice)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/302_Sort/CMakeLists.txt
+++ b/tutorial/302_Sort/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(302_Sort)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/303_LaplaceEquation/CMakeLists.txt
+++ b/tutorial/303_LaplaceEquation/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(303_LaplaceEquation)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/304_LinearEqualityConstraints/CMakeLists.txt
+++ b/tutorial/304_LinearEqualityConstraints/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(304_LinearEqualityConstraints)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/305_QuadraticProgramming/CMakeLists.txt
+++ b/tutorial/305_QuadraticProgramming/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(305_QuadraticProgramming)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/306_EigenDecomposition/CMakeLists.txt
+++ b/tutorial/306_EigenDecomposition/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(306_EigenDecomposition)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/401_BiharmonicDeformation/CMakeLists.txt
+++ b/tutorial/401_BiharmonicDeformation/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(401_BiharmonicDeformation)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/402_PolyharmonicDeformation/CMakeLists.txt
+++ b/tutorial/402_PolyharmonicDeformation/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(402_PolyharmonicDeformation)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/403_BoundedBiharmonicWeights/CMakeLists.txt
+++ b/tutorial/403_BoundedBiharmonicWeights/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(403_BoundedBiharmonicWeights)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/404_DualQuaternionSkinning/CMakeLists.txt
+++ b/tutorial/404_DualQuaternionSkinning/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(404_DualQuaternionSkinning)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/405_AsRigidAsPossible/CMakeLists.txt
+++ b/tutorial/405_AsRigidAsPossible/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(405_AsRigidAsPossible)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/406_FastAutomaticSkinningTransformations/CMakeLists.txt
+++ b/tutorial/406_FastAutomaticSkinningTransformations/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(406_FastAutomaticSkinningTransformations)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/407_BiharmonicCoordinates/CMakeLists.txt
+++ b/tutorial/407_BiharmonicCoordinates/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(407_BiharmonicCoordinates)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/501_HarmonicParam/CMakeLists.txt
+++ b/tutorial/501_HarmonicParam/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(501_HarmonicParam)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/502_LSCMParam/CMakeLists.txt
+++ b/tutorial/502_LSCMParam/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(502_LSCMParam)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/503_ARAPParam/CMakeLists.txt
+++ b/tutorial/503_ARAPParam/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(503_ARAPParam)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/504_NRosyDesign/CMakeLists.txt
+++ b/tutorial/504_NRosyDesign/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(504_NRosyDesign)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw igl::comiso tutorials)

--- a/tutorial/505_MIQ/CMakeLists.txt
+++ b/tutorial/505_MIQ/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(505_MIQ)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw igl::comiso tutorials)

--- a/tutorial/506_FrameField/CMakeLists.txt
+++ b/tutorial/506_FrameField/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(506_FrameField)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw igl::comiso tutorials)

--- a/tutorial/507_Planarization/CMakeLists.txt
+++ b/tutorial/507_Planarization/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(507_Planarization)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/601_Serialization/CMakeLists.txt
+++ b/tutorial/601_Serialization/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(601_Serialization)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw igl::xml tutorials)

--- a/tutorial/602_Matlab/CMakeLists.txt
+++ b/tutorial/602_Matlab/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(602_Matlab)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw igl::matlab tutorials)

--- a/tutorial/604_Triangle/CMakeLists.txt
+++ b/tutorial/604_Triangle/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(604_Triangle)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw igl::triangle tutorials)

--- a/tutorial/605_Tetgen/CMakeLists.txt
+++ b/tutorial/605_Tetgen/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(605_Tetgen)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw igl::tetgen tutorials)

--- a/tutorial/606_AmbientOcclusion/CMakeLists.txt
+++ b/tutorial/606_AmbientOcclusion/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(606_AmbientOcclusion)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw igl::embree tutorials)

--- a/tutorial/607_ScreenCapture/CMakeLists.txt
+++ b/tutorial/607_ScreenCapture/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(607_ScreenCapture)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw igl::png tutorials)

--- a/tutorial/608_LIM/CMakeLists.txt
+++ b/tutorial/608_LIM/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(608_LIM)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::lim igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/609_Boolean/CMakeLists.txt
+++ b/tutorial/609_Boolean/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(609_Boolean)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::cgal igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/610_CSGTree/CMakeLists.txt
+++ b/tutorial/610_CSGTree/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(610_CSGTree)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::cgal igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/701_Statistics/CMakeLists.txt
+++ b/tutorial/701_Statistics/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(701_Statistics)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/702_WindingNumber/CMakeLists.txt
+++ b/tutorial/702_WindingNumber/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(702_WindingNumber)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/703_Decimation/CMakeLists.txt
+++ b/tutorial/703_Decimation/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(703_Decimation)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/704_SignedDistance/CMakeLists.txt
+++ b/tutorial/704_SignedDistance/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(704_SignedDistance)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/705_MarchingCubes/CMakeLists.txt
+++ b/tutorial/705_MarchingCubes/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(705_MarchingCubes)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/706_FacetOrientation/CMakeLists.txt
+++ b/tutorial/706_FacetOrientation/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(706_FacetOrientation)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw igl::embree tutorials)

--- a/tutorial/707_SweptVolume/CMakeLists.txt
+++ b/tutorial/707_SweptVolume/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(707_SweptVolume)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/708_Picking/CMakeLists.txt
+++ b/tutorial/708_Picking/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(708_Picking)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/710_SLIM/CMakeLists.txt
+++ b/tutorial/710_SLIM/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(710_SLIM)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/711_Subdivision/CMakeLists.txt
+++ b/tutorial/711_Subdivision/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(711_Subdivision)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/712_DataSmoothing/CMakeLists.txt
+++ b/tutorial/712_DataSmoothing/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(712_DataSmoothing)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/713_ShapeUp/CMakeLists.txt
+++ b/tutorial/713_ShapeUp/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(713_ShapeUp)
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${PROJECT_NAME})
 
 add_executable(${PROJECT_NAME}_bin main.cpp)
 target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl igl::opengl_glfw tutorials)

--- a/tutorial/tutorial.html
+++ b/tutorial/tutorial.html
@@ -475,103 +475,81 @@ using overlays.</figcaption>
 <a href="https://github.com/wjakob/nanogui">nanogui</a> with <a href="https://github.com/ocornut/imgui">Dear ImGui</a>. To extend the default menu of the
 viewer and to expose more user defined variables you have to implement a custom interface, as in <a href="106_ViewerMenu/main.cpp">Example 106</a>:</p>
 
-<pre><code class="cpp">class CustomMenu : public igl::opengl::glfw::imgui::ImGuiMenu
+<pre><code class="cpp">// Add content to the default menu window
+menu.callback_draw_viewer_menu = [&amp;]()
 {
-  float floatVariable = 0.1f; // Shared between two menus
+  // Draw parent menu content
+  menu.draw_viewer_menu();
 
-  virtual void draw_viewer_menu() override
+  // Add new group
+  if (ImGui::CollapsingHeader(&quot;New Group&quot;, ImGuiTreeNodeFlags_DefaultOpen))
   {
-    // Draw parent menu
-    ImGuiMenu::draw_viewer_menu();
+    // Expose variable directly ...
+    ImGui::InputFloat(&quot;float&quot;, &amp;floatVariable, 0, 0, 3);
 
-    // Add new group
-    if (ImGui::CollapsingHeader(&quot;New Group&quot;, ImGuiTreeNodeFlags_DefaultOpen))
+    // ... or using a custom callback
+    static bool boolVariable = true;
+    if (ImGui::Checkbox(&quot;bool&quot;, &amp;boolVariable))
     {
-      // Expose variable directly ...
-      ImGui::InputFloat(&quot;float&quot;, &amp;floatVariable, 0, 0, 3);
+      // do something
+      std::cout &lt;&lt; &quot;boolVariable: &quot; &lt;&lt; std::boolalpha &lt;&lt; boolVariable &lt;&lt; std::endl;
+    }
 
-      // ... or using a custom callback
-      static bool boolVariable = true;
-      if (ImGui::Checkbox(&quot;bool&quot;, &amp;boolVariable))
-      {
-        // do something
-        std::cout &lt;&lt; &quot;boolVariable: &quot; &lt;&lt; std::boolalpha &lt;&lt; boolVariable &lt;&lt; std::endl;
-      }
+    // Expose an enumeration type
+    enum Orientation { Up=0, Down, Left, Right };
+    static Orientation dir = Up;
+    ImGui::Combo(&quot;Direction&quot;, (int *)(&amp;dir), &quot;Up\0Down\0Left\0Right\0\0&quot;);
 
-      // Expose an enumeration type
-      enum Orientation { Up=0, Down, Left, Right };
-      static Orientation dir = Up;
-      ImGui::Combo(&quot;Direction&quot;, (int *)(&amp;dir), &quot;Up\0Down\0Left\0Right\0\0&quot;);
+    // We can also use a std::vector&lt;std::string&gt; defined dynamically
+    static int num_choices = 3;
+    static std::vector&lt;std::string&gt; choices;
+    static int idx_choice = 0;
+    if (ImGui::InputInt(&quot;Num letters&quot;, &amp;num_choices))
+    {
+      num_choices = std::max(1, std::min(26, num_choices));
+    }
+    if (num_choices != (int) choices.size())
+    {
+      choices.resize(num_choices);
+      for (int i = 0; i &lt; num_choices; ++i)
+        choices[i] = std::string(1, 'A' + i);
+      if (idx_choice &gt;= num_choices)
+        idx_choice = num_choices - 1;
+    }
+    ImGui::Combo(&quot;Letter&quot;, &amp;idx_choice, choices);
 
-      // We can also use a std::vector&lt;std::string&gt; defined dynamically
-      static int num_choices = 3;
-      static std::vector&lt;std::string&gt; choices;
-      static int idx_choice = 0;
-      if (ImGui::InputInt(&quot;Num letters&quot;, &amp;num_choices))
-      {
-        num_choices = std::max(1, std::min(26, num_choices));
-      }
-      if (num_choices != (int) choices.size())
-      {
-        choices.resize(num_choices);
-        for (int i = 0; i &lt; num_choices; ++i)
-          choices[i] = std::string(1, 'A' + i);
-        if (idx_choice &gt;= num_choices)
-          idx_choice = num_choices - 1;
-      }
-      ImGui::Combo(&quot;Letter&quot;, &amp;idx_choice, choices);
-
-      // Add a button
-      if (ImGui::Button(&quot;Print Hello&quot;, ImVec2(-1,0)))
-      {
-        std::cout &lt;&lt; &quot;Hello\n&quot;;
-      }
+    // Add a button
+    if (ImGui::Button(&quot;Print Hello&quot;, ImVec2(-1,0)))
+    {
+      std::cout &lt;&lt; &quot;Hello\n&quot;;
     }
   }
-
-  virtual void draw_custom_window() override
-  {
-    // Define next window position + size
-    ImGui::SetNextWindowPos(ImVec2(180.f * menu_scaling(), 10), ImGuiSetCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(200, 160), ImGuiSetCond_FirstUseEver);
-    ImGui::Begin(
-        &quot;New Window&quot;, nullptr,
-        ImGuiWindowFlags_NoSavedSettings
-    );
-
-    // Expose the same variable directly ...
-    ImGui::PushItemWidth(-80);
-    ImGui::DragFloat(&quot;float&quot;, &amp;floatVariable, 0.0, 0.0, 3.0);
-    ImGui::PopItemWidth();
-
-    static std::string str = &quot;bunny&quot;;
-    ImGui::InputText(&quot;Name&quot;, str);
-
-    ImGui::End();
-  }
-
 };
-
-// Init the viewer
-igl::opengl::glfw::Viewer viewer;
-
-// Attach a custom menu
-CustomMenu menu;
-viewer.plugins.push_back(&amp;menu);
-
-viewer.launch();
 </code></pre>
 
 <p>If you need a separate new menu window implement:</p>
 
-<pre><code class="cpp">class CustomMenu : public igl::opengl::glfw::imgui::ImGuiMenu
+<pre><code class="cpp">// Draw additional windows
+menu.callback_draw_custom_window = [&amp;]()
 {
-  // ... some code
-  virtual void draw_custom_window() override 
-  {
-    // ... custom window specifications
-  }
-}
+  // Define next window position + size
+  ImGui::SetNextWindowPos(ImVec2(180.f * menu.menu_scaling(), 10), ImGuiSetCond_FirstUseEver);
+  ImGui::SetNextWindowSize(ImVec2(200, 160), ImGuiSetCond_FirstUseEver);
+  ImGui::Begin(
+      &quot;New Window&quot;, nullptr,
+      ImGuiWindowFlags_NoSavedSettings
+  );
+
+  // Expose the same variable directly ...
+  ImGui::PushItemWidth(-80);
+  ImGui::DragFloat(&quot;float&quot;, &amp;floatVariable, 0.0, 0.0, 3.0);
+  ImGui::PopItemWidth();
+
+  static std::string str = &quot;bunny&quot;;
+  ImGui::InputText(&quot;Name&quot;, str);
+
+  ImGui::End();
+};
 </code></pre>
 
 <figure>

--- a/tutorial/tutorial.html
+++ b/tutorial/tutorial.html
@@ -331,7 +331,7 @@ int main(int argc, char *argv[])
 Additional properties can be plotted on the mesh (as we will see later),
 and it is possible to extend the viewer with standard OpenGL code.
 Please see the documentation in
-<a href="../include/igl/Viewer/Viewer.h">Viewer.h</a> for more details.</p>
+<a href="../include/igl/opengl/glfw/Viewer.h">Viewer.h</a> for more details.</p>
 
 <figure>
 <img src="images/102_DrawMesh.png" alt="([Example 102](102_DrawMesh/main.cpp)) loads and draws a
@@ -470,56 +470,108 @@ using overlays.</figcaption>
 
 <h2 id="viewermenu"><a href="#viewermenu">Viewer Menu</a> </h2>
 
-<p>As of version 1.2 the viewer uses a new menu and completely replaces
-<a href="http://anttweakbar.sourceforge.net/doc/">AntTweakBar</a>. It is based on the
-open-source projects <a href="https://github.com/memononen/nanovg">nanovg</a> and
-<a href="https://github.com/wjakob/nanogui">nanogui</a>. To extend the default menu of the
-viewer and to expose more user defined variables you have to define a callback
-function:</p>
+<p>As of latest version, the viewer uses a new menu and completely replaces
+<a href="http://anttweakbar.sourceforge.net/doc/">AntTweakBar</a> and
+<a href="https://github.com/wjakob/nanogui">nanogui</a> with <a href="https://github.com/ocornut/imgui">Dear ImGui</a>. To extend the default menu of the
+viewer and to expose more user defined variables you have to implement a custom interface, as in <a href="106_ViewerMenu/main.cpp">Example 106</a>:</p>
 
-<pre><code class="cpp">igl::opengl::glfw::Viewer viewer;
-
-bool boolVariable = true;
-float floatVariable = 0.1f;
-enum Orientation { Up=0,Down,Left,Right } dir = Up;
-
-// Extend viewer menu
-viewer.callback_init = [&amp;](igl::opengl::glfw::Viewer&amp; viewer)
+<pre><code class="cpp">class CustomMenu : public igl::opengl::glfw::imgui::ImGuiMenu
 {
-  // Add new group
-  viewer.ngui-&gt;addGroup(&quot;New Group&quot;);
+  float floatVariable = 0.1f; // Shared between two menus
 
-  // Expose a variable directly ...
-  viewer.ngui-&gt;addVariable(&quot;float&quot;,floatVariable);
+  virtual void draw_viewer_menu() override
+  {
+    // Draw parent menu
+    ImGuiMenu::draw_viewer_menu();
 
-  // Expose an enumaration type
-  viewer.ngui-&gt;addVariable&lt;Orientation&gt;(&quot;Direction&quot;,dir)-&gt;setItems({&quot;Up&quot;,&quot;Down&quot;,&quot;Left&quot;,&quot;Right&quot;});
+    // Add new group
+    if (ImGui::CollapsingHeader(&quot;New Group&quot;, ImGuiTreeNodeFlags_DefaultOpen))
+    {
+      // Expose variable directly ...
+      ImGui::InputFloat(&quot;float&quot;, &amp;floatVariable, 0, 0, 3);
 
-  // Add a button
-  viewer.ngui-&gt;addButton(&quot;Print Hello&quot;,[](){ std::cout &lt;&lt; &quot;Hello\n&quot;; });
+      // ... or using a custom callback
+      static bool boolVariable = true;
+      if (ImGui::Checkbox(&quot;bool&quot;, &amp;boolVariable))
+      {
+        // do something
+        std::cout &lt;&lt; &quot;boolVariable: &quot; &lt;&lt; std::boolalpha &lt;&lt; boolVariable &lt;&lt; std::endl;
+      }
 
-  // call to generate menu
-  viewer.screen-&gt;performLayout();
-  return false;
+      // Expose an enumeration type
+      enum Orientation { Up=0, Down, Left, Right };
+      static Orientation dir = Up;
+      ImGui::Combo(&quot;Direction&quot;, (int *)(&amp;dir), &quot;Up\0Down\0Left\0Right\0\0&quot;);
+
+      // We can also use a std::vector&lt;std::string&gt; defined dynamically
+      static int num_choices = 3;
+      static std::vector&lt;std::string&gt; choices;
+      static int idx_choice = 0;
+      if (ImGui::InputInt(&quot;Num letters&quot;, &amp;num_choices))
+      {
+        num_choices = std::max(1, std::min(26, num_choices));
+      }
+      if (num_choices != (int) choices.size())
+      {
+        choices.resize(num_choices);
+        for (int i = 0; i &lt; num_choices; ++i)
+          choices[i] = std::string(1, 'A' + i);
+        if (idx_choice &gt;= num_choices)
+          idx_choice = num_choices - 1;
+      }
+      ImGui::Combo(&quot;Letter&quot;, &amp;idx_choice, choices);
+
+      // Add a button
+      if (ImGui::Button(&quot;Print Hello&quot;, ImVec2(-1,0)))
+      {
+        std::cout &lt;&lt; &quot;Hello\n&quot;;
+      }
+    }
+  }
+
+  virtual void draw_custom_window() override
+  {
+    // Define next window position + size
+    ImGui::SetNextWindowPos(ImVec2(180.f * menu_scaling(), 10), ImGuiSetCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(200, 160), ImGuiSetCond_FirstUseEver);
+    ImGui::Begin(
+        &quot;New Window&quot;, nullptr,
+        ImGuiWindowFlags_NoSavedSettings
+    );
+
+    // Expose the same variable directly ...
+    ImGui::PushItemWidth(-80);
+    ImGui::DragFloat(&quot;float&quot;, &amp;floatVariable, 0.0, 0.0, 3.0);
+    ImGui::PopItemWidth();
+
+    static std::string str = &quot;bunny&quot;;
+    ImGui::InputText(&quot;Name&quot;, str);
+
+    ImGui::End();
+  }
+
 };
 
-// start viewer
+// Init the viewer
+igl::opengl::glfw::Viewer viewer;
+
+// Attach a custom menu
+CustomMenu menu;
+viewer.plugins.push_back(&amp;menu);
+
 viewer.launch();
 </code></pre>
 
-<p>If you need a separate new menu window use:</p>
+<p>If you need a separate new menu window implement:</p>
 
-<pre><code class="cpp">viewer.ngui-&gt;addWindow(Eigen::Vector2i(220,10),&quot;New Window&quot;);
-</code></pre>
-
-<p>If you do not want to expose variables directly but rather use the get/set functionality:</p>
-
-<pre><code class="cpp">// ... or using a custom callback
-viewer.ngui-&gt;addVariable&lt;bool&gt;(&quot;bool&quot;,[&amp;](bool val) {
-  boolVariable = val; // setter
-},[&amp;]() {
-  return boolVariable; // getter
-});
+<pre><code class="cpp">class CustomMenu : public igl::opengl::glfw::imgui::ImGuiMenu
+{
+  // ... some code
+  virtual void draw_custom_window() override 
+  {
+    // ... custom window specifications
+  }
+}
 </code></pre>
 
 <figure>
@@ -643,7 +695,7 @@ on a triangle mesh is via a vertex&#8217;s <em>angular deficit</em>:</p>
 at vertex <span class="math">\(i\)</span> in triangle <span class="math">\(j\)</span> <a href="#cn:1" id="cnref:1" title="see citation" class="citation">(1)</a>.</p>
 
 <p>Just like the continuous analog, our discrete Gaussian curvature reveals
-elliptic, hyperbolic and parabolic vertices on the domain, as demonstrated in <a href="202GaussianCurvature/main.cpp">Example 202</a>.</p>
+elliptic, hyperbolic and parabolic vertices on the domain, as demonstrated in <a href="202_GaussianCurvature/main.cpp">Example 202</a>.</p>
 
 <figure>
 <img src="images/bumpy-gaussian-curvature.jpg" alt="The `GaussianCurvature` example computes discrete Gaussian curvature and


### PR DESCRIPTION
This PR includes the following
- Changing the first two lines of the CMakeLists.txt with a uniform way, so switching tutorial orders or adding more, would be easier. 
```
for i in $(find . -name "CMakeLists.txt" -mindepth 2); do sed -i '1d; 2s/.*/get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)\nproject(${PROJECT_NAME})/' $i; done
```
- Some fixes in tutorial.md and html, replacing nanogui with imgui