### PR TITLE
Update python tutorials to reflect the viewer refactor

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -91,15 +91,15 @@ def key_pressed(viewer, key, modifier):
 
     if key == ord('1'):
         # # Clear should be called before drawing the mesh
-        viewer.data.clear();
+        viewer.data().clear();
         # # Draw_mesh creates or updates the vertices and faces of the displayed mesh.
         # # If a mesh is already displayed, draw_mesh returns an error if the given V and
         # # F have size different than the current ones
-        viewer.data.set_mesh(V1, F1);
+        viewer.data().set_mesh(V1, F1);
         viewer.core.align_camera_center(V1,F1);
     elif key == ord('2'):
-        viewer.data.clear();
-        viewer.data.set_mesh(V2, F2);
+        viewer.data().clear();
+        viewer.data().set_mesh(V2, F2);
         viewer.core.align_camera_center(V2,F2);
     return False
 
@@ -111,12 +111,12 @@ igl.readOFF("../tutorial/shared/fertility.off", V2, F2);
 print("1 Switch to bump mesh")
 print("2 Switch to fertility mesh")
 
-viewer = igl.viewer.Viewer()
+viewer = igl.glfw.Viewer()
 
 # Register a keyboard callback that allows to switch between
 # the two loaded meshes
 viewer.callback_key_pressed = key_pressed
-viewer.data.set_mesh(V1, F1)
+viewer.data().set_mesh(V1, F1)
 viewer.launch()
 ```
 

--- a/python/tcpviewer.py
+++ b/python/tcpviewer.py
@@ -32,10 +32,10 @@ def worker(viewer,lock,s):
             data = ''.join(slist)
             temp = list(data)
 
-            isempty = viewer.data.V.rows() == 0
-            viewer.data.deserialize(temp)
-            if isempty and viewer.data.V.rows() != 0:
-                viewer.core.align_camera_center(viewer.data.V,viewer.data.F)
+            isempty = viewer.data().V.rows() == 0
+            viewer.data().deserialize(temp)
+            if isempty and viewer.data().V.rows() != 0:
+                viewer.core.align_camera_center(viewer.data().V,viewer.data().F)
 
             lock.release()
 
@@ -43,12 +43,12 @@ def worker(viewer,lock,s):
         s.close()
     return
 
-class TCPViewer(igl.viewer.Viewer):
+class TCPViewer(igl.glfw.Viewer):
     def launch(self):
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.connect((HOST, PORT))
-            ser = self.data.serialize()
+            ser = self.data().serialize()
             a = array.array('u', ser)
             s.sendall(a)
             s.close()
@@ -66,7 +66,7 @@ if __name__ == "__main__": # The main script is a server
         exit(1)
     s.listen(1)
 
-    viewer = igl.viewer.Viewer()
+    viewer = igl.glfw.Viewer()
 
     lock = threading.Lock()
     t = threading.Thread(target=worker, args=(viewer,lock,s,))
@@ -74,7 +74,7 @@ if __name__ == "__main__": # The main script is a server
     t.start()
 
     viewer.core.is_animating = True
-    # viewer.data.dirty = int(0x03FF)
+    # viewer.data().dirty = int(0x03FF)
 
     viewer.launch_init(True,False)
     done = False

--- a/python/tutorial/102_DrawMesh_TCP.py
+++ b/python/tutorial/102_DrawMesh_TCP.py
@@ -26,5 +26,5 @@ igl.readOFF(TUTORIAL_SHARED_PATH + "beetle.off", V, F)
 
 # Send it to the viewer
 viewer = tcpviewer.TCPViewer()
-viewer.data.set_mesh(V, F)
+viewer.data().set_mesh(V, F)
 viewer.launch()

--- a/python/tutorial/702_WindingNumber.py
+++ b/python/tutorial/702_WindingNumber.py
@@ -46,10 +46,10 @@ def update(viewer):
     elif overlay == 2:  # OVERLAY_OUTPUT
         append_mesh(C_vis, F_vis, V_vis, V, F, igl.eigen.MatrixXd([[0.8, 0.8, 0.8]]))
 
-    viewer.data.clear()
-    viewer.data.set_mesh(V_vis, F_vis)
-    viewer.data.set_colors(C_vis)
-    viewer.data.set_face_based(True)
+    viewer.data().clear()
+    viewer.data().set_mesh(V_vis, F_vis)
+    viewer.data().set_colors(C_vis)
+    viewer.data().set_face_based(True)
 
 
 def key_down(viewer, key, modifier):
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     W = (W - W.minCoeff()) / (W.maxCoeff() - W.minCoeff())
 
     # Plot the generated mesh
-    viewer = igl.viewer.Viewer()
+    viewer = igl.glfw.Viewer()
     update(viewer)
     viewer.callback_key_down = key_down
     viewer.launch()

--- a/python/tutorial/704_SignedDistance.py
+++ b/python/tutorial/704_SignedDistance.py
@@ -32,7 +32,7 @@ max_distance = 1
 slice_z = 0.5
 overlay = False
 
-viewer = igl.viewer.Viewer()
+viewer = igl.glfw.Viewer()
 
 
 def append_mesh(C_vis, F_vis, V_vis, V, F, color):
@@ -92,9 +92,9 @@ def update_visualization(viewer):
     if overlay:
         append_mesh(C_vis, F_vis, V_vis, V, F, igl.eigen.MatrixXd([[0.8, 0.8, 0.8]]))
 
-    viewer.data.clear()
-    viewer.data.set_mesh(V_vis, F_vis)
-    viewer.data.set_colors(C_vis)
+    viewer.data().clear()
+    viewer.data().set_mesh(V_vis, F_vis)
+    viewer.data().set_colors(C_vis)
     viewer.core.lighting_factor = overlay
 
 
@@ -138,5 +138,5 @@ igl.per_edge_normals(V, F, igl.PER_EDGE_NORMALS_WEIGHTING_TYPE_UNIFORM, FN, EN, 
 # Plot the generated mesh
 update_visualization(viewer)
 viewer.callback_key_down = key_down
-viewer.core.show_lines = False
+viewer.data().show_lines = False
 viewer.launch()

--- a/python/tutorial/705_MarchingCubes.py
+++ b/python/tutorial/705_MarchingCubes.py
@@ -13,20 +13,20 @@ import pyigl as igl
 
 from shared import TUTORIAL_SHARED_PATH, check_dependencies, print_usage
 
-dependencies = ["copyleft", "viewer"]
+dependencies = ["copyleft", "glfw"]
 check_dependencies(dependencies)
 
 
 def key_down(viewer, key, modifier):
     if key == ord('1'):
-        viewer.data.clear()
-        viewer.data.set_mesh(V, F)
+        viewer.data().clear()
+        viewer.data().set_mesh(V, F)
     elif key == ord('2'):
-        viewer.data.clear()
-        viewer.data.set_mesh(SV, SF)
+        viewer.data().clear()
+        viewer.data().set_mesh(SV, SF)
     elif key == ord('3'):
-        viewer.data.clear()
-        viewer.data.set_mesh(BV, BF)
+        viewer.data().clear()
+        viewer.data().set_mesh(BV, BF)
 
     return True
 
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     igl.copyleft.marching_cubes(B, GV, res[0], res[1], res[2], BV, BF)
 
     # Plot the generated mesh
-    viewer = igl.viewer.Viewer()
-    viewer.data.set_mesh(SV, SF)
+    viewer = igl.glfw.Viewer()
+    viewer.data().set_mesh(SV, SF)
     viewer.callback_key_down = key_down
     viewer.launch()

--- a/python/tutorial/706_FacetOrientation.py
+++ b/python/tutorial/706_FacetOrientation.py
@@ -13,7 +13,7 @@ import pyigl as igl
 
 from shared import TUTORIAL_SHARED_PATH, check_dependencies, print_usage
 
-dependencies = ["embree", "viewer"]
+dependencies = ["embree", "glfw"]
 check_dependencies(dependencies)
 
 
@@ -26,9 +26,9 @@ def key_down(viewer, key, modifier):
     elif key == ord(' '):
         is_showing_reoriented = ~is_showing_reoriented
 
-    viewer.data.clear()
-    viewer.data.set_mesh(V, FF[facetwise] if is_showing_reoriented else F)
-    viewer.data.set_colors(RGBcolors[facetwise])
+    viewer.data().clear()
+    viewer.data().set_mesh(V, FF[facetwise] if is_showing_reoriented else F)
+    viewer.data().set_colors(RGBcolors[facetwise])
 
     return True
 
@@ -44,7 +44,7 @@ def scramble_colors():
         HSVright.setConstant(1.0)
         HSV.setRightCols(2, HSVright)
         igl.hsv_to_rgb(HSV, RGBcolors[p])
-    viewer.data.set_colors(RGBcolors[facetwise])
+    viewer.data().set_colors(RGBcolors[facetwise])
 
 
 
@@ -77,9 +77,9 @@ if __name__ == "__main__":
                 FF[p].setRow(i, F.row(i))
 
     # Plot the generated mesh
-    viewer = igl.viewer.Viewer()
-    viewer.data.set_mesh(V, FF[facetwise] if is_showing_reoriented else F)
-    viewer.data.set_face_based(True)
+    viewer = igl.glfw.Viewer()
+    viewer.data().set_mesh(V, FF[facetwise] if is_showing_reoriented else F)
+    viewer.data().set_face_based(True)
     scramble_colors()
     viewer.callback_key_down = key_down
     viewer.launch()

--- a/python/tutorial/707_SweptVolume.py
+++ b/python/tutorial/707_SweptVolume.py
@@ -15,7 +15,7 @@ import pyigl as igl
 
 from shared import TUTORIAL_SHARED_PATH, check_dependencies, print_usage
 
-dependencies = ["copyleft", "viewer"]
+dependencies = ["copyleft", "glfw"]
 check_dependencies(dependencies)
 
 
@@ -23,16 +23,16 @@ def key_down(viewer, key, modifier):
     global show_swept_volume, SV, SF, V, F
     if key == ord(' '):
         show_swept_volume = not show_swept_volume
-        viewer.data.clear()
+        viewer.data().clear()
 
         if show_swept_volume:
-            viewer.data.set_mesh(SV, SF)
-            viewer.data.uniform_colors(igl.eigen.MatrixXd([0.2, 0.2, 0.2]), igl.eigen.MatrixXd([1.0, 1.0, 1.0]), igl.eigen.MatrixXd([1.0, 1.0, 1.0])) # TODO replace with constants from cpp
+            viewer.data().set_mesh(SV, SF)
+            viewer.data().uniform_colors(igl.eigen.MatrixXd([0.2, 0.2, 0.2]), igl.eigen.MatrixXd([1.0, 1.0, 1.0]), igl.eigen.MatrixXd([1.0, 1.0, 1.0])) # TODO replace with constants from cpp
         else:
-            viewer.data.set_mesh(V, F)
+            viewer.data().set_mesh(V, F)
 
         viewer.core.is_animating = not show_swept_volume
-        viewer.data.set_face_based(True)
+        viewer.data().set_face_based(True)
 
     return True
 
@@ -46,8 +46,8 @@ def pre_draw(viewer):
         Vtrans = igl.eigen.MatrixXd(VT.rows(), VT.cols())
         Vtrans.rowwiseSet(trans)
         VT += Vtrans
-        viewer.data.set_vertices(VT)
-        viewer.data.compute_normals()
+        viewer.data().set_vertices(VT)
+        viewer.data().compute_normals()
     return False
 
 
@@ -81,9 +81,9 @@ if __name__ == "__main__":
     print("...finished.")
 
     # Plot the generated mesh
-    viewer = igl.viewer.Viewer()
-    viewer.data.set_mesh(V, F)
-    viewer.data.set_face_based(True)
+    viewer = igl.glfw.Viewer()
+    viewer.data().set_mesh(V, F)
+    viewer.data().set_face_based(True)
     viewer.core.is_animating = not show_swept_volume
     viewer.callback_pre_draw = pre_draw
     viewer.callback_key_down = key_down

--- a/python/tutorial/708_Picking.py
+++ b/python/tutorial/708_Picking.py
@@ -10,7 +10,7 @@ import sys, os
 # Add the igl library to the modules search path
 sys.path.insert(0, os.getcwd() + "/../")
 import pyigl as igl
-
+import numpy as np
 
 from shared import TUTORIAL_SHARED_PATH, check_dependencies, print_usage
 
@@ -22,14 +22,14 @@ def mouse_down(viewer, a, b):
     bc = igl.eigen.MatrixXd()
 
     # Cast a ray in the view direction starting from the mouse position
-    fid = igl.eigen.MatrixXi([-1])
+    fid = igl.eigen.MatrixXi(np.array([-1]))
     coord = igl.eigen.MatrixXd([viewer.current_mouse_x, viewer.core.viewport[3] - viewer.current_mouse_y])
     hit = igl.unproject_onto_mesh(coord, viewer.core.view * viewer.core.model,
       viewer.core.proj, viewer.core.viewport, V, F, fid, bc)
     if hit:
         # paint hit red
         C.setRow(fid[0, 0], igl.eigen.MatrixXd([[1, 0, 0]]))
-        viewer.data.set_colors(C)
+        viewer.data().set_colors(C)
         return True
 
     return False
@@ -51,9 +51,9 @@ if __name__ == "__main__":
     C.setConstant(F.rows(), 3, 1.0)
 
     # Show mesh
-    viewer = igl.viewer.Viewer()
-    viewer.data.set_mesh(V, F)
-    viewer.data.set_colors(C)
-    viewer.core.show_lines = False
+    viewer = igl.glfw.Viewer()
+    viewer.data().set_mesh(V, F)
+    viewer.data().set_colors(C)
+    viewer.data().show_lines = False
     viewer.callback_mouse_down = mouse_down
     viewer.launch()

--- a/python/tutorial/709_VectorFieldVisualizer.py
+++ b/python/tutorial/709_VectorFieldVisualizer.py
@@ -66,7 +66,7 @@ def pre_draw(viewer):
         value = 1 - value
     value /= 0.5
     r, g, b = igl.parula(value)
-    viewer.data.add_edges(state.start_point, state.end_point, igl.eigen.MatrixXd([[r, g, b]]))
+    viewer.data().add_edges(state.start_point, state.end_point, igl.eigen.MatrixXd([[r, g, b]]))
 
     anim_t += anim_t_dir
 
@@ -100,8 +100,8 @@ def main():
     igl.streamlines_init(V, F, temp_field2, treat_as_symmetric, data, state)
 
     # Setup viewer
-    viewer = igl.viewer.Viewer()
-    viewer.data.set_mesh(V, F)
+    viewer = igl.glfw.Viewer()
+    viewer.data().set_mesh(V, F)
     viewer.callback_pre_draw = pre_draw
     viewer.callback_key_down = key_down
 
@@ -112,8 +112,8 @@ def main():
 
     # Paint mesh grayish
     C = igl.eigen.MatrixXd()
-    C.setConstant(viewer.data.V.rows(), 3, .9)
-    viewer.data.set_colors(C)
+    C.setConstant(viewer.data().V.rows(), 3, .9)
+    viewer.data().set_colors(C)
 
     # Draw vector field on sample points
     state0 = state.copy()
@@ -122,7 +122,7 @@ def main():
     v = state0.end_point - state0.start_point
     v = v.rowwiseNormalized()
 
-    viewer.data.add_edges(state0.start_point,
+    viewer.data().add_edges(state0.start_point,
                           state0.start_point + 0.059 * v,
                           igl.eigen.MatrixXd([[1.0, 1.0, 1.0]]))
 


### PR DESCRIPTION
Here I fixed some remaining files in python tutorials section, to reflect the recent libigl viewer refactoring and addressing the issue #726 

Just as a note here, 
702_WindingNumber.py is buggy in showing the results, 
704_SignedDistance.py has a segmentation fault.
The functionality in 709_VectorFieldVisualizer.py doesn't exist now.