### PR TITLE
Python bindings for shape_diameter_function

### DIFF
--- a/include/igl/shape_diameter_function.cpp
+++ b/include/igl/shape_diameter_function.cpp
@@ -7,7 +7,10 @@
 // obtain one at http://mozilla.org/MPL/2.0/.
 #include "shape_diameter_function.h"
 #include "random_dir.h"
+#include "barycenter.h"
 #include "ray_mesh_intersect.h"
+#include "per_vertex_normals.h"
+#include "per_face_normals.h"
 #include "EPS.h"
 #include "Hit.h"
 #include "parallel_for.h"
@@ -141,11 +144,39 @@ IGL_INLINE void igl::shape_diameter_function(
   return shape_diameter_function(aabb,V,F,P,N,num_samples,S);
 }
 
+template <
+  typename DerivedV,
+  typename DerivedF,
+  typename DerivedS>
+IGL_INLINE void igl::shape_diameter_function(
+  const Eigen::PlainObjectBase<DerivedV> & V,
+  const Eigen::PlainObjectBase<DerivedF> & F,
+  const bool per_face,
+  const int num_samples,
+  Eigen::PlainObjectBase<DerivedS> & S)
+{
+  if (per_face)
+  {
+    Eigen::PlainObjectBase<DerivedV> N;
+    igl::per_face_normals(V, F, N);
+    Eigen::PlainObjectBase<DerivedV> P;
+    igl::barycenter(V, F, P);
+    return igl::shape_diameter_function(V, F, P, N, num_samples, S);
+  }
+  else
+  {
+    Eigen::PlainObjectBase<DerivedV> N;
+    igl::per_vertex_normals(V, F, N);
+    return igl::shape_diameter_function(V, F, V, N, num_samples, S);
+  }
+}
+
 #ifdef IGL_STATIC_LIBRARY
 // Explicit template instantiation
 template void igl::shape_diameter_function<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, 1, 0, -1, 1> >(std::function<double (Eigen::Matrix<float, 3, 1, 0, 3, 1> const&, Eigen::Matrix<float, 3, 1, 0, 3, 1> const&)> const&, Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&, Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&, int, Eigen::PlainObjectBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >&);
 template void igl::shape_diameter_function<Eigen::Matrix<double, -1, 3, 0, -1, 3>, Eigen::Matrix<double, -1, 3, 0, -1, 3>, Eigen::Matrix<double, -1, 1, 0, -1, 1> >(std::function<double (Eigen::Matrix<float, 3, 1, 0, 3, 1> const&, Eigen::Matrix<float, 3, 1, 0, 3, 1> const&)> const&, Eigen::PlainObjectBase<Eigen::Matrix<double, -1, 3, 0, -1, 3> > const&, Eigen::PlainObjectBase<Eigen::Matrix<double, -1, 3, 0, -1, 3> > const&, int, Eigen::PlainObjectBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >&);
 template void igl::shape_diameter_function<Eigen::Matrix<double, 1, 3, 1, 1, 3>, Eigen::Matrix<double, 1, 3, 1, 1, 3>, Eigen::Matrix<double, -1, 1, 0, -1, 1> >(std::function<double (Eigen::Matrix<float, 3, 1, 0, 3, 1> const&, Eigen::Matrix<float, 3, 1, 0, 3, 1> const&)> const&, Eigen::PlainObjectBase<Eigen::Matrix<double, 1, 3, 1, 1, 3> > const&, Eigen::PlainObjectBase<Eigen::Matrix<double, 1, 3, 1, 1, 3> > const&, int, Eigen::PlainObjectBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >&);
 template void igl::shape_diameter_function<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, -1, 0, -1, -1> >(std::function<double (Eigen::Matrix<float, 3, 1, 0, 3, 1> const&, Eigen::Matrix<float, 3, 1, 0, 3, 1> const&)> const&, Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&, Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&, int, Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> >&);
+template void igl::shape_diameter_function<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, -1, 0, -1, -1> >(Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&, Eigen::PlainObjectBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, bool, int, Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> >&);
 #endif
 

--- a/include/igl/shape_diameter_function.cpp
+++ b/include/igl/shape_diameter_function.cpp
@@ -157,15 +157,15 @@ IGL_INLINE void igl::shape_diameter_function(
 {
   if (per_face)
   {
-    Eigen::PlainObjectBase<DerivedV> N;
+    DerivedV N;
     igl::per_face_normals(V, F, N);
-    Eigen::PlainObjectBase<DerivedV> P;
+    DerivedV P;
     igl::barycenter(V, F, P);
     return igl::shape_diameter_function(V, F, P, N, num_samples, S);
   }
   else
   {
-    Eigen::PlainObjectBase<DerivedV> N;
+    DerivedV N;
     igl::per_vertex_normals(V, F, N);
     return igl::shape_diameter_function(V, F, V, N, num_samples, S);
   }

--- a/python/py_doc.cpp
+++ b/python/py_doc.cpp
@@ -1196,6 +1196,20 @@ const char *__doc_igl_setdiff = R"igl_Qu8mg5v7(// Set difference of elements of 
   //   C  (k<=m)-long vector of unique elements appearing in A but not in B
   //   IA  (k<=m)-long list of indices into A so that C = A(IA)
   //)igl_Qu8mg5v7";
+const char *__doc_igl_shape_diameter_function = R"igl_Qu8mg5v7(// Compute shape diamater function per given point. In the parlence of the
+  // paper "Consistent Mesh Partitioning and Skeletonisation using the Shape
+  // Diameter Function" [Shapiro et al. 2008], this implementation uses a 180°
+  // cone and a _uniform_ average (_not_ a average weighted by inverse angles).
+  //
+  // Inputs:
+  //    shoot_ray  function handle that outputs hits of a given ray against a
+  //      mesh (embedded in function handles as captured variable/data)
+  //    P  #P by 3 list of origin points
+  //    N  #P by 3 list of origin normals
+  // Outputs:
+  //    S  #P list of shape diamater function values between bounding box
+  //    diagonal (perfect sphere) and 0 (perfect needle hook)
+  //)igl_Qu8mg5v7";
 const char *__doc_igl_signed_distance = R"igl_Qu8mg5v7(// Computes signed distance to a mesh
   //
   // Inputs:

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -101,6 +101,7 @@ extern const char *__doc_igl_remove_duplicate_vertices;
 extern const char *__doc_igl_rotate_vectors;
 extern const char *__doc_igl_seam_edges;
 extern const char *__doc_igl_setdiff;
+extern const char *__doc_igl_shape_diameter_function;
 extern const char *__doc_igl_signed_distance;
 extern const char *__doc_igl_signed_distance_pseudonormal;
 extern const char *__doc_igl_signed_distance_winding_number;

--- a/python/py_igl.cpp
+++ b/python/py_igl.cpp
@@ -86,6 +86,7 @@
 #include <igl/remove_duplicate_vertices.h>
 #include <igl/rotate_vectors.h>
 #include <igl/setdiff.h>
+#include <igl/shape_diameter_function.h>
 #include <igl/signed_distance.h>
 #include <igl/slice.h>
 #include <igl/slice_into.h>
@@ -183,6 +184,7 @@ void python_export_igl(py::module &m)
 #include "py_igl/py_remove_duplicate_vertices.cpp"
 #include "py_igl/py_rotate_vectors.cpp"
 #include "py_igl/py_setdiff.cpp"
+#include "py_igl/py_shape_diameter_function.cpp"
 #include "py_igl/py_signed_distance.cpp"
 #include "py_igl/py_slice.cpp"
 #include "py_igl/py_slice_into.cpp"

--- a/python/py_igl/py_shape_diameter_function.cpp
+++ b/python/py_igl/py_shape_diameter_function.cpp
@@ -1,0 +1,35 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
+
+m.def("shape_diameter_function", []
+(
+  const Eigen::MatrixXd& V,
+  const Eigen::MatrixXi& F,
+  const Eigen::MatrixXd& P,
+  const Eigen::MatrixXd& N,
+  const int num_samples,
+  Eigen::MatrixXd& S
+)
+{
+  return igl::shape_diameter_function(V, F, P, N, num_samples, S);
+}, __doc_igl_shape_diameter_function,
+py::arg("V"), py::arg("F"), py::arg("P"), py::arg("N"), py::arg("num_samples"), py::arg("S"));
+
+m.def("shape_diameter_function", []
+(
+  const Eigen::MatrixXd& V,
+  const Eigen::MatrixXi& F,
+  const bool per_face,
+  const int num_samples,
+  Eigen::MatrixXd& S
+)
+{
+  return igl::shape_diameter_function(V, F, per_face, num_samples, S);
+}, __doc_igl_shape_diameter_function,
+py::arg("V"), py::arg("F"), py::arg("per_face"), py::arg("num_samples"), py::arg("S"));
+


### PR DESCRIPTION
This adds Python bindings for two overloads of `shape_diameter_function`.

On the C++ side, this also implements the missing overload for the `shape_diameter_function(V, F, per_face, num_samples, S)` signature.