### PR TITLE
fix a bug in remesh_intersections

### DIFF
--- a/include/igl/copyleft/cgal/remesh_intersections.cpp
+++ b/include/igl/copyleft/cgal/remesh_intersections.cpp
@@ -148,6 +148,8 @@ IGL_INLINE void igl::copyleft::cgal::remesh_intersections(
     std::vector<Index> source_faces;
     std::vector<Point_3> new_vertices;
     EdgeMap edge_vertices;
+    // face_vertices: Given a face Index, find vertices inside the face
+    std::unordered_map<Index, std::vector<Index>> face_vertices;
 
     // Run constraint Delaunay triangulation on the plane.
     // 
@@ -252,8 +254,15 @@ IGL_INLINE void igl::copyleft::cgal::remesh_intersections(
         }
 
         // p must be in the middle of the triangle.
+        auto & existing_face_vertices = face_vertices[ori_f];
+        for(const auto vid : existing_face_vertices) {
+          if (p == new_vertices[vid - num_base_vertices]) {
+            return vid;
+          }
+        }
         const size_t index = num_base_vertices + new_vertices.size();
         new_vertices.push_back(p);
+        existing_face_vertices.push_back(index);
         return index;
       }
     };


### PR DESCRIPTION
Hi!

I'm a student of Professor Jernej Barbic.
My new project is dependent on the mesh boolean routine in libigl and I have found a bug in remesh_intersections.cpp. I have fixed it and created a pull request here.

Previously in the function, if a new vtx is visited when stitch_all==false, it does not handle the case when the vtx is in the interior of a face. This commit fixes that.