### PR TITLE
Make adjacency_matrix available within python by adding required bind…

### DIFF
--- a/python/py_igl.cpp
+++ b/python/py_igl.cpp
@@ -16,6 +16,7 @@
 #include <igl/SolverStatus.h>
 #include <igl/active_set.h>
 #include <igl/adjacency_list.h>
+#include <igl/adjacency_matrix.h>
 #include <igl/arap.h>
 #include <igl/avg_edge_length.h>
 #include <igl/barycenter.h>
@@ -114,6 +115,7 @@ void python_export_igl(py::module &m)
 #include "py_igl/py_SolverStatus.cpp"
 #include "py_igl/py_active_set.cpp"
 #include "py_igl/py_adjacency_list.cpp"
+#include "py_igl/py_adjacency_matrix.cpp"
 #include "py_igl/py_arap.cpp"
 #include "py_igl/py_avg_edge_length.cpp"
 #include "py_igl/py_barycenter.cpp"

--- a/python/py_igl/py_adjacency_matrix.cpp
+++ b/python/py_igl/py_adjacency_matrix.cpp
@@ -1,0 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
+m.def("adjacency_matrix", [](const Eigen::MatrixXi & F, Eigen::SparseMatrix<int>& A) {
+    igl::adjacency_matrix(F, A);
+}, py::arg("F"), py::arg("A"));


### PR DESCRIPTION
…ings.

Usage:
read mesh as always
allocate adjacency matrix (`A = igl.eigen.SparseMatrixi()`)
and then simple create the adjacency matrix: `igl.adjacency_matrix(F,A)`

