### PR TITLE
Added missing template parameters to AABB in tutorial

### DIFF
--- a/tutorial/tutorial.md
+++ b/tutorial/tutorial.md
@@ -2959,7 +2959,7 @@ it's best to reuse the AABB hierarchy that's being built during
 `igl::point_mesh_squared_distance`:
 
 ```cpp
-igl::AABB tree;
+igl::AABB<MatrixXd,3> tree;
 tree.init(V,F);
 tree.squared_distance(V,F,P,sqrD,I,C);
 ... // P changes, but (V,F) does not


### PR DESCRIPTION
This was missing - just writing `igl::AABB tree` resulted in a compiler error. (MSVC 15.7)