### PR TITLE
ply.h function conflicting on windows

### DIFF
--- a/include/igl/guess_extension.cpp
+++ b/include/igl/guess_extension.cpp
@@ -21,7 +21,7 @@ IGL_INLINE void igl::guess_extension(FILE * fp, std::string & guess)
   {
     int nelems;
     char ** elem_names;
-    PlyFile * in_ply = ply_read(ply_file,&nelems,&elem_names);
+    external::ply::PlyFile * in_ply = external::ply::ply_read(ply_file,&nelems,&elem_names);
     if(in_ply==NULL)
     {
       return false;

--- a/include/igl/ply.h
+++ b/include/igl/ply.h
@@ -72,9 +72,9 @@ properly to target OSs with binary files.
 #ifndef __PLY_H__
 #define __PLY_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+namespace igl {
+  namespace external {
+    namespace ply {
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -243,9 +243,9 @@ inline void ply_describe_other_properties(PlyFile *, PlyOtherProp *, int);
 inline int equal_strings(const char *, const char *);
 
 
-#ifdef __cplusplus
 }
-#endif
+}
+}
 #endif /* !__PLY_H__ */
 /*
 
@@ -322,6 +322,12 @@ properly to target OSs with binary files.
 #include <math.h>
 #include <string.h>
 //#include "ply.h"
+
+
+namespace igl {
+  namespace external {
+    namespace ply {
+
 
 // Use unnamed namespace to avoid duplicate symbols
 /*
@@ -3156,5 +3162,7 @@ inline char *my_alloc(int size, int lnum, const char *fe)
   return (ptr);
 }
 
-
+}
+}
+}
 #endif

--- a/include/igl/readPLY.cpp
+++ b/include/igl/readPLY.cpp
@@ -58,7 +58,7 @@ IGL_INLINE bool igl::readPLY(
      void *other_props;       /* other properties */
    } Face;
 
-  PlyProperty vert_props[] = { /* list of property information for a vertex */
+  external::ply::PlyProperty vert_props[] = { /* list of property information for a vertex */
     {"x", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,x), 0, 0, 0, 0},
     {"y", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,y), 0, 0, 0, 0},
     {"z", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,z), 0, 0, 0, 0},
@@ -69,14 +69,14 @@ IGL_INLINE bool igl::readPLY(
     {"t", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,t), 0, 0, 0, 0},
   };
 
-  PlyProperty face_props[] = { /* list of property information for a face */
+  external::ply::PlyProperty face_props[] = { /* list of property information for a face */
     {"vertex_indices", PLY_INT, PLY_INT, offsetof(Face,verts),
       1, PLY_UCHAR, PLY_UCHAR, offsetof(Face,nverts)},
   };
 
   int nelems;
   char ** elem_names;
-  PlyFile * in_ply = ply_read(ply_file,&nelems,&elem_names);
+  external::ply::PlyFile * in_ply = external::ply::ply_read(ply_file,&nelems,&elem_names);
   if(in_ply==NULL)
   {
     return false;
@@ -84,11 +84,11 @@ IGL_INLINE bool igl::readPLY(
 
   bool has_normals = false;
   bool has_texture_coords = false;
-  PlyProperty **plist;
+  external::ply::PlyProperty **plist;
   int nprops;
   int elem_count;
   plist = ply_get_element_description (in_ply,"vertex", &elem_count, &nprops);
-  int native_binary_type = get_native_binary_type2();
+  int native_binary_type = external::ply::get_native_binary_type2();
   if (plist != NULL)
   {
     /* set up for getting vertex elements */
@@ -97,18 +97,18 @@ IGL_INLINE bool igl::readPLY(
     ply_get_property (in_ply,"vertex",&vert_props[2]);
     for (int j = 0; j < nprops; j++)
     {
-      PlyProperty * prop = plist[j];
-      if (equal_strings ("nx", prop->name) 
-        || equal_strings ("ny", prop->name)
-        || equal_strings ("nz", prop->name))
+      external::ply::PlyProperty * prop = plist[j];
+      if (external::ply::equal_strings ("nx", prop->name) 
+        || external::ply::equal_strings ("ny", prop->name)
+        || external::ply::equal_strings ("nz", prop->name))
       {
         ply_get_property (in_ply,"vertex",&vert_props[3]);
         ply_get_property (in_ply,"vertex",&vert_props[4]);
         ply_get_property (in_ply,"vertex",&vert_props[5]);
         has_normals = true;
       }
-      if (equal_strings ("s", prop->name) ||
-        equal_strings ("t", prop->name))
+      if (external::ply::equal_strings ("s", prop->name) ||
+        external::ply::equal_strings ("t", prop->name))
       {
         ply_get_property(in_ply,"vertex",&vert_props[6]);
         ply_get_property(in_ply,"vertex",&vert_props[7]);

--- a/include/igl/writePLY.cpp
+++ b/include/igl/writePLY.cpp
@@ -56,7 +56,7 @@ IGL_INLINE bool igl::writePLY(
     FScalar *verts;              /* vertex index list */
   } Face;
 
-  PlyProperty vert_props[] =
+  external::ply::PlyProperty vert_props[] =
   { /* list of property information for a vertex */
     {"x", ply_type<VScalar>(), ply_type<VScalar>(),offsetof(Vertex,x),0,0,0,0},
     {"y", ply_type<VScalar>(), ply_type<VScalar>(),offsetof(Vertex,y),0,0,0,0},
@@ -68,7 +68,7 @@ IGL_INLINE bool igl::writePLY(
     {"t", ply_type<UVScalar>(),ply_type<UVScalar>(),offsetof(Vertex,t),0,0,0,0},
   };
 
-  PlyProperty face_props[] =
+  external::ply::PlyProperty face_props[] =
   { /* list of property information for a face */
     {"vertex_indices", ply_type<FScalar>(), ply_type<FScalar>(), 
       offsetof(Face,verts), 1, PLY_UCHAR, PLY_UCHAR, offsetof(Face,nverts)},
@@ -110,14 +110,14 @@ IGL_INLINE bool igl::writePLY(
   {
     return false;
   }
-  PlyFile * ply = ply_write(fp, 2,elem_names,
+  external::ply::PlyFile * ply = external::ply::ply_write(fp, 2,elem_names,
       (ascii ? PLY_ASCII : PLY_BINARY_LE));
   if(ply==NULL)
   {
     return false;
   }
 
-  std::vector<PlyProperty> plist;
+  std::vector<external::ply::PlyProperty> plist;
   plist.push_back(vert_props[0]);
   plist.push_back(vert_props[1]);
   plist.push_back(vert_props[2]);
@@ -137,7 +137,7 @@ IGL_INLINE bool igl::writePLY(
 
   ply_describe_element(ply, "face", F.rows(),1,&face_props[0]);
   ply_header_complete(ply);
-  int native_binary_type = get_native_binary_type2();
+  int native_binary_type = external::ply::get_native_binary_type2();
   ply_put_element_setup(ply, "vertex");
   for(const auto v : vlist)
   {


### PR DESCRIPTION
moved code of ply.h inside namespace igl::external::ply so it doesnt conflict the name with other libraries like geogram