### PR TITLE
Fix shading for orthographic cameras + Z fighting

### DIFF
--- a/include/igl/opengl/MeshGL.cpp
+++ b/include/igl/opengl/MeshGL.cpp
@@ -136,14 +136,15 @@ IGL_INLINE void igl::opengl::MeshGL::draw_mesh(bool solid)
   glPolygonMode(GL_FRONT_AND_BACK, solid ? GL_FILL : GL_LINE);
 
   /* Avoid Z-buffer fighting between filled triangles & wireframe lines */
-  if (solid)
+  if (!solid)
   {
-    glEnable(GL_POLYGON_OFFSET_FILL);
-    glPolygonOffset(1.0, 1.0);
+    glEnable(GL_POLYGON_OFFSET_LINE);
+    glPolygonOffset(-1.0, -1.0);
   }
   glDrawElements(GL_TRIANGLES, 3*F_vbo.rows(), GL_UNSIGNED_INT, 0);
 
-  glDisable(GL_POLYGON_OFFSET_FILL);
+  if (!solid)
+    glDisable(GL_POLYGON_OFFSET_LINE);
   glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 }
 
@@ -165,77 +166,92 @@ IGL_INLINE void igl::opengl::MeshGL::init()
   }
   is_initialized = true;
   std::string mesh_vertex_shader_string =
-R"(#version 150
-  uniform mat4 view;
-  uniform mat4 proj;
-  uniform mat4 normal_matrix;
-  in vec3 position;
-  in vec3 normal;
-  out vec3 position_eye;
-  out vec3 normal_eye;
-  in vec4 Ka;
-  in vec4 Kd;
-  in vec4 Ks;
-  in vec2 texcoord;
-  out vec2 texcoordi;
-  out vec4 Kai;
-  out vec4 Kdi;
-  out vec4 Ksi;
+R"(#version 330
 
-  void main()
-  {
-    position_eye = vec3 (view * vec4 (position, 1.0));
-    normal_eye = vec3 (normal_matrix * vec4 (normal, 0.0));
-    normal_eye = normalize(normal_eye);
-    gl_Position = proj * vec4 (position_eye, 1.0); //proj * view * vec4(position, 1.0);"
-    Kai = Ka;
-    Kdi = Kd;
-    Ksi = Ks;
-    texcoordi = texcoord;
-  }
-)";
+uniform mat4 view;
+uniform mat4 proj;
+uniform mat4 normal_matrix;
+
+in vec3 position;
+in vec3 normal;
+out vec3 position_eye;
+out vec3 normal_eye;
+
+in vec4 Ka;
+in vec4 Kd;
+in vec4 Ks;
+in vec2 texcoord;
+
+out vec4 Kai;
+out vec4 Kdi;
+out vec4 Ksi;
+out vec2 texcoordi;
+
+void main()
+{
+  position_eye = vec3(view * vec4(position, 1.0));
+  normal_eye = vec3(normal_matrix * vec4(normal, 0.0));
+  normal_eye = normalize(normal_eye);
+  gl_Position = proj * vec4(position_eye, 1.0);
+  Kai = Ka;
+  Kdi = Kd;
+  Ksi = Ks;
+  texcoordi = texcoord;
+})";
 
   std::string mesh_fragment_shader_string =
-R"(#version 150
-  uniform mat4 view;
-  uniform mat4 proj;
-  uniform vec4 fixed_color;
-  in vec3 position_eye;
-  in vec3 normal_eye;
-  uniform vec3 light_position_eye;
-  vec3 Ls = vec3 (1, 1, 1);
-  vec3 Ld = vec3 (1, 1, 1);
-  vec3 La = vec3 (1, 1, 1);
-  in vec4 Ksi;
-  in vec4 Kdi;
-  in vec4 Kai;
-  in vec2 texcoordi;
-  uniform sampler2D tex;
-  uniform float specular_exponent;
-  uniform float lighting_factor;
-  uniform float texture_factor;
-  out vec4 outColor;
-  void main()
-  {
-    vec3 Ia = La * vec3(Kai);    // ambient intensity
+R"(#version 330
 
-    vec3 vector_to_light_eye = light_position_eye - position_eye;
-    vec3 direction_to_light_eye = normalize (vector_to_light_eye);
-    float dot_prod = dot (direction_to_light_eye, normalize(normal_eye));
-    float clamped_dot_prod = max (dot_prod, 0.0);
-    vec3 Id = Ld * vec3(Kdi) * clamped_dot_prod;    // Diffuse intensity
+// Camera
+uniform mat4 view;
+uniform mat4 proj;
 
-    vec3 reflection_eye = reflect (-direction_to_light_eye, normalize(normal_eye));
-    vec3 surface_to_viewer_eye = normalize (-position_eye);
-    float dot_prod_specular = dot (reflection_eye, surface_to_viewer_eye);
-    dot_prod_specular = float(abs(dot_prod)==dot_prod) * max (dot_prod_specular, 0.0);
-    float specular_factor = pow (dot_prod_specular, specular_exponent);
-    vec3 Is = Ls * vec3(Ksi) * specular_factor;    // specular intensity
-    vec4 color = vec4(lighting_factor * (Is + Id) + Ia + (1.0-lighting_factor) * vec3(Kdi),(Kai.a+Ksi.a+Kdi.a)/3);
-    outColor = mix(vec4(1,1,1,1), texture(tex, texcoordi), texture_factor) * color;
-    if (fixed_color != vec4(0.0)) outColor = fixed_color;
-  }
-)";
+// Lights
+uniform vec4 fixed_color;
+uniform vec3 light_position_eye;
+uniform bool orthographic;
+
+const vec3 Ls = vec3 (1, 1, 1);
+const vec3 Ld = vec3 (1, 1, 1);
+const vec3 La = vec3 (1, 1, 1);
+
+// Surface
+in vec3 position_eye;
+in vec3 normal_eye;
+
+in vec4 Ksi;
+in vec4 Kdi;
+in vec4 Kai;
+in vec2 texcoordi;
+
+// Misc
+uniform sampler2D tex;
+uniform float specular_exponent;
+uniform float lighting_factor;
+uniform float texture_factor;
+out vec4 outColor;
+
+void main()
+{
+  vec3 Ia = La * vec3(Kai); // ambient intensity
+
+  vec3 vector_to_light_eye = light_position_eye - position_eye;
+  vec3 direction_to_light_eye = normalize(vector_to_light_eye);
+  float dot_prod = dot(direction_to_light_eye, normalize(normal_eye));
+  float clamped_dot_prod = clamp(dot_prod, 0, 1);
+  vec3 Id = Ld * vec3(Kdi) * clamped_dot_prod; // diffuse intensity
+
+  vec3 reflection_eye = reflect(-direction_to_light_eye, normalize(normal_eye));
+  vec3 surface_to_viewer_eye = (orthographic ? vec3(0,0,-1) : normalize(-position_eye));
+  float dot_prod_specular = dot(reflection_eye, surface_to_viewer_eye);
+  dot_prod_specular = float(abs(dot_prod)==dot_prod) * max(dot_prod_specular, 0.0);
+  float specular_factor = pow(dot_prod_specular, specular_exponent);
+  vec3 Is = Ls * vec3(Ksi) * specular_factor; // specular intensity
+
+  vec4 color = vec4(lighting_factor * (Is + Id) + Ia + (1.0-lighting_factor) * vec3(Kdi),(Kai.a+Ksi.a+Kdi.a)/3);
+  outColor = mix(vec4(1,1,1,1), texture(tex, texcoordi), texture_factor) * color;
+  if (fixed_color != vec4(0.0)) outColor = fixed_color;
+})";
 
   std::string overlay_vertex_shader_string =
 R"(#version 150

--- a/include/igl/opengl/MeshGL.cpp
+++ b/include/igl/opengl/MeshGL.cpp
@@ -208,7 +208,7 @@ uniform mat4 proj;
 
 // Lights
 uniform vec4 fixed_color;
-uniform vec3 light_position_eye;
+uniform vec3 light_vector_eye;
 uniform bool orthographic;
 
 const vec3 Ls = vec3 (1, 1, 1);
@@ -235,14 +235,13 @@ void main()
 {
   vec3 Ia = La * vec3(Kai); // ambient intensity
 
-  vec3 vector_to_light_eye = light_position_eye - position_eye;
-  vec3 direction_to_light_eye = normalize(vector_to_light_eye);
+  vec3 direction_to_light_eye = (orthographic ? -light_vector_eye : normalize(light_vector_eye - position_eye));
   float dot_prod = dot(direction_to_light_eye, normalize(normal_eye));
   float clamped_dot_prod = clamp(dot_prod, 0, 1);
   vec3 Id = Ld * vec3(Kdi) * clamped_dot_prod; // diffuse intensity
 
   vec3 reflection_eye = reflect(-direction_to_light_eye, normalize(normal_eye));
-  vec3 surface_to_viewer_eye = (orthographic ? vec3(0,0,-1) : normalize(-position_eye));
+  vec3 surface_to_viewer_eye = (orthographic ? vec3(0,0,1) : normalize(-position_eye));
   float dot_prod_specular = dot(reflection_eye, surface_to_viewer_eye);
   dot_prod_specular = float(abs(dot_prod)==dot_prod) * max(dot_prod_specular, 0.0);
   float specular_factor = pow(dot_prod_specular, specular_exponent);

--- a/include/igl/opengl/MeshGL.h
+++ b/include/igl/opengl/MeshGL.h
@@ -12,7 +12,8 @@
 // compatible format The class includes a shader and the opengl calls to plot
 // the data
 
-#include <igl/igl_inline.h>
+#include "../igl_inline.h"
+#include "gl.h"
 #include <Eigen/Core>
 
 namespace igl

--- a/include/igl/opengl/ViewerCore.cpp
+++ b/include/igl/opengl/ViewerCore.cpp
@@ -131,6 +131,7 @@ IGL_INLINE void igl::opengl::ViewerCore::draw(
 
     // Set view
     look_at(camera_eye, camera_center, camera_up, view);
+    Eigen::Vector3f camera_center_eye = (view * camera_center.homogeneous()).colwise().hnormalized();
     view = view
       * (trackball_angle * Eigen::Scaling(camera_zoom * camera_base_zoom)
       * Eigen::Translation3f(camera_translation + camera_base_translation)).matrix();
@@ -143,7 +144,6 @@ IGL_INLINE void igl::opengl::ViewerCore::draw(
       float length = (camera_eye - camera_center).norm();
       float h = tan(camera_view_angle/360.0 * igl::PI) * (length);
       ortho(-h*width/height, h*width/height, -h, h, camera_dnear, camera_dfar, proj);
-      auto camera_center_eye = (view * camera_center.homogeneous()).colwise().hnormalized();
       light_vector = (camera_center_eye - light_position).normalized(); // light direction
     }
     else

--- a/include/igl/opengl/ViewerCore.cpp
+++ b/include/igl/opengl/ViewerCore.cpp
@@ -161,16 +161,18 @@ IGL_INLINE void igl::opengl::ViewerCore::draw(
   glUniformMatrix4fv(normi, 1, GL_FALSE, norm.data());
 
   // Light parameters
-  GLint specular_exponenti    = glGetUniformLocation(data.meshgl.shader_mesh,"specular_exponent");
+  GLint specular_exponenti  = glGetUniformLocation(data.meshgl.shader_mesh,"specular_exponent");
   GLint light_position_eyei = glGetUniformLocation(data.meshgl.shader_mesh,"light_position_eye");
-  GLint lighting_factori      = glGetUniformLocation(data.meshgl.shader_mesh,"lighting_factor");
-  GLint fixed_colori          = glGetUniformLocation(data.meshgl.shader_mesh,"fixed_color");
-  GLint texture_factori       = glGetUniformLocation(data.meshgl.shader_mesh,"texture_factor");
+  GLint lighting_factori    = glGetUniformLocation(data.meshgl.shader_mesh,"lighting_factor");
+  GLint fixed_colori        = glGetUniformLocation(data.meshgl.shader_mesh,"fixed_color");
+  GLint texture_factori     = glGetUniformLocation(data.meshgl.shader_mesh,"texture_factor");
+  GLint orthographici       = glGetUniformLocation(data.meshgl.shader_mesh,"orthographic");
 
   glUniform1f(specular_exponenti, data.shininess);
   glUniform3fv(light_position_eyei, 1, light_position.data());
   glUniform1f(lighting_factori, lighting_factor); // enables lighting
   glUniform4f(fixed_colori, 0.0, 0.0, 0.0, 0.0);
+  glUniform1i(orthographici, orthographic);
 
   if (data.V.rows()>0)
   {

--- a/include/igl/opengl/ViewerCore.h
+++ b/include/igl/opengl/ViewerCore.h
@@ -98,6 +98,7 @@ public:
 
   // Lighting
   Eigen::Vector3f light_position;
+  Eigen::Vector3f light_vector;
   float lighting_factor;
 
   RotationType rotation_type;

--- a/include/igl/opengl/ViewerCore.h
+++ b/include/igl/opengl/ViewerCore.h
@@ -8,10 +8,10 @@
 #ifndef IGL_OPENGL_VIEWERCORE_H
 #define IGL_OPENGL_VIEWERCORE_H
 
+#include "../igl_inline.h"
+#include "gl.h"
 #include <igl/opengl/MeshGL.h>
 #include <igl/opengl/ViewerData.h>
-
-#include <igl/igl_inline.h>
 #include <Eigen/Geometry>
 #include <Eigen/Core>
 

--- a/include/igl/opengl/ViewerData.h
+++ b/include/igl/opengl/ViewerData.h
@@ -8,11 +8,13 @@
 #ifndef IGL_VIEWERDATA_H
 #define IGL_VIEWERDATA_H
 
+
 #include "../igl_inline.h"
+#include "gl.h"
 #include "MeshGL.h"
+#include <Eigen/Core>
 #include <cassert>
 #include <cstdint>
-#include <Eigen/Core>
 #include <memory>
 #include <vector>
 

--- a/include/igl/opengl/vertex_array.h
+++ b/include/igl/opengl/vertex_array.h
@@ -1,8 +1,10 @@
 #ifndef IGL_OPENGL_VERTEX_ARRAY_H
 #define IGL_OPENGL_VERTEX_ARRAY_H
-#include <igl/opengl/../igl_inline.h>
-#include <igl/opengl/gl.h>
+
+#include "../igl_inline.h"
+#include "gl.h"
 #include <Eigen/Core>
+
 namespace igl
 {
   namespace opengl


### PR DESCRIPTION
I noticed a couple of issues with the current shading while inspecting the fandisk model in tutorial 201, or the bumpy cube in tutorial 103. Namely:

- Shading gets weird with orthographic cameras. It doesn't really make sense to have a point light anymore, since orthographic cameras do not give a very good notion of depth. E.g., if you zoom on the bumpy cube in orthographic mode, you see that it gets darker, which is weird. Well, the light source is getting closer since we move the "camera" closer, but technically an orthographic camera is at infinity so the feeling is a bit off. Thus I suggest to replace the point light with a directional light for orthographic cameras.

- The direction for the viewer for orthographic cameras (for specular lighting) was also incorrect, since the viewer is not a point at (0,0,0), but in the direction (0,0,1) (not sure about the sign of the Z axis in camera space, but this seems to work).

- There is a different issue caused by the use of `glPolygonOffset` in `MeshGL::draw_mesh()`, which causes some artefacts in how triangle are rendered. This is especially visible on the *fandisk* model in tutorial 201, if you invert the normals with <kbd>i</kbd>, you will see the backfaces on the sharp crease of the model:

![2018-08-19-145334_1280x800_scrot](https://user-images.githubusercontent.com/578702/44309767-03f76180-a3cc-11e8-984e-b37e27c4b943.png)

I'm not sure exactly how `glPolygonOffset` works, but it looks like a non-perfect hack to deal with Z-fighting. Since we have the option to either push the triangles *behind* the lines (with `glPolygonOffset(1.0, 1.0);` and `GL_POLYGON_OFFSET_FILL`), or pull the lines *in front* of the triangles (with `glPolygonOffset(-1.0, -1.0);` and `GL_POLYGON_OFFSET_LINE`), I've updated the code to use the latter. This seems to fix this Z-fighting issue, while allowing the wireframe to be correctly rendered:

![2018-08-19-145230_1280x800_scrot](https://user-images.githubusercontent.com/578702/44309831-ce9f4380-a3cc-11e8-8a4c-6c162d358b84.png)

- I have also updated the glsl version to `330` (to be consistent with `Viewer.cpp` that asks for an OpenGL 3.3 context), and fixed a couple of `#include` (most notably `MeshGL.h` was not including `gl.h`).