### PR TITLE
Make libigl targets installable only for toplevel projects by default…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 option(LIBIGL_BUILD_TESTS      "Build libigl unit test"        ${LIBIGL_TOPLEVEL_PROJECT})
 option(LIBIGL_BUILD_TUTORIALS  "Build libigl tutorial"         ${LIBIGL_TOPLEVEL_PROJECT})
 option(LIBIGL_BUILD_PYTHON     "Build libigl python bindings"  ${LIBIGL_TOPLEVEL_PROJECT})
+option(LIBIGL_EXPORT_TARGETS   "Export libigl CMake targets"   ${LIBIGL_TOPLEVEL_PROJECT})
 
 # USE_STATIC_LIBRARY speeds up the generation of multiple binaries,
 # at the cost of a longer initial compilation time
@@ -32,8 +33,8 @@ option(LIBIGL_WITH_XML               "Use XML"                      ON)
 option(LIBIGL_WITH_PYTHON            "Use Python"                   ${LIBIGL_BUILD_PYTHON})
 ### End
 
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})		
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})		
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 ### conditionally compile certain modules depending on libraries found on the system

--- a/cmake/libigl.cmake
+++ b/cmake/libigl.cmake
@@ -35,6 +35,7 @@ option(LIBIGL_WITH_TRIANGLE          "Use Triangle"                 OFF)
 option(LIBIGL_WITH_XML               "Use XML"                      OFF)
 option(LIBIGL_WITH_PYTHON            "Use Python"                   OFF)
 option(LIBIGL_WITHOUT_COPYLEFT       "Disable Copyleft libraries"   OFF)
+option(LIBIGL_EXPORT_TARGETS         "Export libigl CMake targets"  OFF)
 
 ################################################################################
 
@@ -428,6 +429,10 @@ endif()
 
 ################################################################################
 ### Install and export all modules
+
+if(NOT LIBIGL_EXPORT_TARGETS)
+  return()
+endif()
 
 function(install_dir_files dir_name)
   if (dir_name STREQUAL "core")

--- a/cmake/libigl.cmake
+++ b/cmake/libigl.cmake
@@ -323,10 +323,19 @@ endif()
 ### Compile the opengl part ###
 if(LIBIGL_WITH_OPENGL)
   # OpenGL module
-  find_package(OpenGL REQUIRED)
   compile_igl_module("opengl")
-  target_link_libraries(igl_opengl ${IGL_SCOPE} ${OPENGL_gl_LIBRARY})
-  target_include_directories(igl_opengl SYSTEM ${IGL_SCOPE} ${OPENGL_INCLUDE_DIR})
+
+  # OpenGL library
+  if (NOT CMAKE_VERSION VERSION_LESS "3.11")
+    cmake_policy(SET CMP0072 NEW)
+  endif()
+  find_package(OpenGL REQUIRED)
+  if(TARGET OpenGL::GL)
+    target_link_libraries(igl_opengl ${IGL_SCOPE} OpenGL::GL)
+  else()
+    target_link_libraries(igl_opengl ${IGL_SCOPE} ${OPENGL_gl_LIBRARY})
+    target_include_directories(igl_opengl SYSTEM ${IGL_SCOPE} ${OPENGL_INCLUDE_DIR})
+  endif()
 
   # glad module
   if(NOT TARGET glad)


### PR DESCRIPTION
Follow-up on #839.

I got an error in a project using a different target for Eigen, due to how CMake targets are exported:
```
CMake Error: install(EXPORT "igl-export" ...) includes target "igl_common" which requires target "eigen" that is not in the export set.
```

I propose to disable export by default in `libigl.cmake`, and enable it for the toplevel project (like tests, tutorials and python bindings).

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [x] This is a minor change.
