### PR TITLE
fix: segments_intersect bug.

### DIFF
--- a/include/igl/segment_segment_intersect.cpp
+++ b/include/igl/segment_segment_intersect.cpp
@@ -53,7 +53,7 @@ IGL_INLINE bool igl::segments_intersect(
     t = t1.norm() / rxs.norm();
     t = t * sign;
 
-    if (t < -eps || fabs(t) < eps)
+    if ((t - 1.) > eps || t < -eps)
         return false;
 
     a_t = t;


### PR DESCRIPTION
also test if t is larger than 1.

[Describe your changes and what you've already done to test it.]

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
