### PR TITLE
compilation error fix

### DIFF
--- a/include/igl/opengl/glfw/imgui/ImGuiTraits.h
+++ b/include/igl/opengl/glfw/imgui/ImGuiTraits.h
@@ -26,42 +26,42 @@ template<>
 class ImGuiDataTypeTraits<int>
 {
 	static constexpr ImGuiDataType value = ImGuiDataType_S32;
-	static constexpr char * format = "%d";
+	static constexpr char format [] = "%d";
 };
 
 template<>
 class ImGuiDataTypeTraits<unsigned int>
 {
 	static constexpr ImGuiDataType value = ImGuiDataType_U32;
-	static constexpr char * format = "%u";
+	static constexpr char format [] = "%u";
 };
 
 template<>
 class ImGuiDataTypeTraits<long long>
 {
 	static constexpr ImGuiDataType value = ImGuiDataType_S64;
-	static constexpr char * format = "%lld";
+	static constexpr char format [] = "%lld";
 };
 
 template<>
 class ImGuiDataTypeTraits<unsigned long long>
 {
 	static constexpr ImGuiDataType value = ImGuiDataType_U64;
-	static constexpr char * format = "%llu";
+	static constexpr char format [] = "%llu";
 };
 
 template<>
 class ImGuiDataTypeTraits<float>
 {
 	static constexpr ImGuiDataType value = ImGuiDataType_Float;
-	static constexpr char * format = "%.3f";
+	static constexpr char format [] = "%.3f";
 };
 
 template<>
 class ImGuiDataTypeTraits<double>
 {
 	static constexpr ImGuiDataType value = ImGuiDataType_Double;
-	static constexpr char * format = "%.6f";
+	static constexpr char format [] = "%.6f";
 };
 
 } // namespace ImGui


### PR DESCRIPTION
[Describe your changes and what you've already done to test it.]
Change `char * format` to `char format []` to fix compilation error when using VS2017.
#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
