### PR TITLE
avoid unsafe calls to acos by fixing potential floating-point errors …

### DIFF
--- a/include/igl/copyleft/comiso/nrosy.cpp
+++ b/include/igl/copyleft/comiso/nrosy.cpp
@@ -810,7 +810,7 @@ Eigen::VectorXd igl::copyleft::comiso::NRosyField::angleDefect()
       if (norm_prod > 0.)
         t /= norm_prod;
       else
-        throw std::runtime_error ("Error in 'igl::copyleft::comiso::NRosyField::angleDefect': division by zero!");
+        throw std::runtime_error("Error in 'igl::copyleft::comiso::NRosyField::angleDefect': division by zero!");
       if (t > 1.)
         t = 1.;
       else if (t < -1.)

--- a/include/igl/copyleft/comiso/nrosy.cpp
+++ b/include/igl/copyleft/comiso/nrosy.cpp
@@ -807,13 +807,13 @@ Eigen::VectorXd igl::copyleft::comiso::NRosyField::angleDefect()
       Eigen::VectorXd b = V.row(F(i,(j+2)%3)) - V.row(F(i,j));
       double t = a.transpose() * b;
       double norm_prod = a.norm() * b.norm();
-      if ( norm_prod > 0. )
+      if (norm_prod > 0.)
         t /= norm_prod;
       else
-        throw std::runtime_error ( "Error in 'igl::copyleft::comiso::NRosyField::angleDefect': division by zero! " );
-      if ( t > 1. )
+        throw std::runtime_error ("Error in 'igl::copyleft::comiso::NRosyField::angleDefect': division by zero!");
+      if (t > 1.)
         t = 1.;
-      else if ( t < -1. )
+      else if (t < -1.)
         t = -1.;
       A(F(i,j)) += acos(t);
     }

--- a/include/igl/copyleft/comiso/nrosy.cpp
+++ b/include/igl/copyleft/comiso/nrosy.cpp
@@ -16,6 +16,8 @@
 #include <iostream>
 #include <fstream>
 
+#include <stdexcept>
+
 #include <Eigen/Geometry>
 #include <Eigen/Sparse>
 #include <queue>
@@ -803,8 +805,16 @@ Eigen::VectorXd igl::copyleft::comiso::NRosyField::angleDefect()
     {
       Eigen::VectorXd a = V.row(F(i,(j+1)%3)) - V.row(F(i,j));
       Eigen::VectorXd b = V.row(F(i,(j+2)%3)) - V.row(F(i,j));
-      double t = a.transpose()*b;
-      t /= (a.norm() * b.norm());
+      double t = a.transpose() * b;
+      double norm_prod = a.norm() * b.norm();
+      if ( norm_prod > 0. )
+        t /= norm_prod;
+      else
+        throw std::runtime_error ( "Error in 'igl::copyleft::comiso::NRosyField::angleDefect': division by zero! " );
+      if ( t > 1. )
+        t = 1.;
+      else if ( t < -1. )
+        t = -1.;
       A(F(i,j)) += acos(t);
     }
   }


### PR DESCRIPTION
Passing raw data into trigonometrical functions from the standard library is never a good thing to do.
