### PR TITLE
Avoid a loop

### DIFF
--- a/include/igl/copyleft/comiso/miq.cpp
+++ b/include/igl/copyleft/comiso/miq.cpp
@@ -1133,12 +1133,7 @@ template <typename DerivedV, typename DerivedF>
 IGL_INLINE void igl::copyleft::comiso::PoissonSolver<DerivedV, DerivedF>::addSharpEdgeConstraint(int fid, int vid)
 {
   // prepare constraint
-  std::vector<int> c(Handle_SystemInfo.num_vert_variables*2 + 1);
-
-  for (size_t i = 0; i < c.size(); ++i)
-  {
-    c[i] = 0;
-  }
+  std::vector<int> c(Handle_SystemInfo.num_vert_variables*2 + 1, 0);
 
   int v1 = Fcut(fid,vid);
   int v2 = Fcut(fid,(vid+1)%3);


### PR DESCRIPTION
There is no need to loop over the elements to set them up. Normally, even without giving the value (as I did) the values should be set to 0. On the other hand, std::fill() should be used instead of looping over a container.

#### Check all that apply (change to `[x]`)
- [X] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [-] Adds new .cpp file.
- [-] Adds corresponding unit test.
- [-] Adds corresponding python binding.
- [X] This is a minor change.
