### PR TITLE
Bump version of glfw.

### DIFF
--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -77,7 +77,7 @@ endfunction()
 function(igl_download_glfw)
 	igl_download_project(glfw
 		GIT_REPOSITORY https://github.com/glfw/glfw.git
-		GIT_TAG        58cc4b2c5c2c9a245e09451437dd6f5af4d60c84
+		GIT_TAG        5afcd0981bf2fe9b9550f24ba298857aac6c35c2
 	)
 endfunction()
 

--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -77,7 +77,7 @@ endfunction()
 function(igl_download_glfw)
 	igl_download_project(glfw
 		GIT_REPOSITORY https://github.com/glfw/glfw.git
-		GIT_TAG        5afcd0981bf2fe9b9550f24ba298857aac6c35c2
+		GIT_TAG        53c8c72c676ca97c10aedfe3d0eb4271c5b23dba
 	)
 endfunction()
 


### PR DESCRIPTION
Current version of glfw produces the following warning with recent versions of CMake:

```
CMake Deprecation Warning at external/glfw/CMakeLists.txt:10 (cmake_policy):
  The OLD behavior for policy CMP0042 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
```

The new version has CMake 3.0 as minimum version instead of 2.8.12, but that's ok since our CMake requires 3.1.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [x] This is a minor change.
