### PR TITLE
fix wrong reference in cotmatrix_intrinsic

### DIFF
--- a/include/igl/cotmatrix_intrinsic.h
+++ b/include/igl/cotmatrix_intrinsic.h
@@ -34,7 +34,7 @@ namespace igl
 }
 
 #ifndef IGL_STATIC_LIBRARY
-#  include "cotmatrix.cpp"
+#  include "cotmatrix_intrinsic.cpp"
 #endif
 
 #endif


### PR DESCRIPTION
Noticed a bug while looking at the new dev branch, `cotmatrix_intrinsic.h` references the wrong cpp so it gives errors in compile in header-only.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
