### PR TITLE
Warning about rewritten history (fix #992).

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@
 ![](https://github.com/libigl/libigl-legacy/raw/5ff6387765fa85ca46f1a6222728e35e2b8b8961/libigl-teaser.png)
 
 Documentation, tutorial, and instructions at <https://libigl.github.io>.
+
+:exclamation: **On October 15, 2018, a new, cleaned-up history was pushed onto the main libigl repository. To learn more about the consequences of this, and troubleshooting, please read [this page](https://libigl.github.io/rewritten-history/).**


### PR DESCRIPTION
We ought to keep this warning sign for at least 6 months. It's best to have it on the github readme as well (#992), so it should be merged into `master`.