### PR TITLE
Fix Eigen compile error when using setup.py

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -13,6 +13,11 @@ set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6)
 find_package(PythonInterp REQUIRED)
 find_package(PythonLibs REQUIRED)
 
+# Force setup.py to find igl headers and Eigen under external
+set(EIGEN3_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../external/eigen")
+include_directories(${EIGEN3_INCLUDE_DIR})
+set(IGL_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../include")
+include_directories(${IGL_INCLUDE_DIR})
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 if(UNIX)
@@ -23,10 +28,10 @@ if(UNIX)
   endif()
 endif()
 
-## libigl		
-if(NOT TARGET igl::core)		
-  list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/../cmake")		
-  include(libigl)		
+## libigl
+if(NOT TARGET igl::core)
+  list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/../cmake")
+  include(libigl)
 endif()
 
 ## include pybind
@@ -152,4 +157,3 @@ elseif(UNIX)
     endif()
   endif()
 endif()
-


### PR DESCRIPTION
Adding igl and Eigen include path hints so `setup.py` can find igl and Eigen headers, otherwise compiling the python bindings using `setup.py` would fail. I've tested the changes on ubuntu+python2.7, MacOS+python2.7, and MacOS+conda+python3.5.

Using `setup.py` seems to be necessary on MacOS, since the `pyigl.so` file generated by cmake build from project root is not usable due to import error:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: dlopen(./pyigl.so, 2): Symbol not found: __ZN3igl42internal_angles_using_squared_edge_lengthsIN5Eigen6MatrixIdLin1ELin1ELi0ELin1ELin1EEES3_EEvRKNS1_10MatrixBaseIT_EERNS1_15PlainObjectBaseIT0_EE
  Referenced from: ./pyigl.so
  Expected in: flat namespace
 in ./pyigl.so
```
Building the python bindings from `python` directory using cmake also works with this fix.

#### Check all that apply (change to `[x]`)
- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
