### PR TITLE
Flatten wiremesh caps when vertex on single edge.

### DIFF
--- a/include/igl/copyleft/cgal/wire_mesh.cpp
+++ b/include/igl/copyleft/cgal/wire_mesh.cpp
@@ -65,11 +65,6 @@ IGL_INLINE void igl::copyleft::cgal::wire_mesh(
 
   // Count each vertex's indicident edges.
   std::vector<int> nedges(WV.rows());
-  for(int v = 0;v<WV.rows();v++)
-  {
-    nedges[v] = 0;
-  }
-
   for(int e = 0;e<WE.rows();e++)
   {
     ++nedges[WE(e, 0)];

--- a/include/igl/copyleft/cgal/wire_mesh.cpp
+++ b/include/igl/copyleft/cgal/wire_mesh.cpp
@@ -62,6 +62,20 @@ IGL_INLINE void igl::copyleft::cgal::wire_mesh(
     v = v-c*(PV.rows());
     p = v;
   };
+
+  // Count each vertex's indicident edges.
+  std::vector<int> nedges(WV.rows());
+  for(int v = 0;v<WV.rows();v++)
+  {
+    nedges[v] = 0;
+  }
+
+  for(int e = 0;e<WE.rows();e++)
+  {
+    ++nedges[WE(e, 0)];
+    ++nedges[WE(e, 1)];
+  }
+
   // loop over all edges
   for(int e = 0;e<WE.rows();e++)
   {
@@ -88,7 +102,8 @@ IGL_INLINE void igl::copyleft::cgal::wire_mesh(
         // Start with factor of thickness;
         // Max out amount at 1/3 of edge length so that there's always some
         // amount of edge
-        Scalar dist = std::min(1.*th,len/3.0);
+        // Zero out if vertex is incident on only one edge
+        Scalar dist = std::min(1.*th,len/3.0) * (nedges[WE(e,c)] > 1);
         // Move to endpoint, offset by amount
         V.row(index(e,c,p)) = 
           qp+WV.row(WE(e,c)) + dist*dir*uv;

--- a/include/igl/copyleft/cgal/wire_mesh.cpp
+++ b/include/igl/copyleft/cgal/wire_mesh.cpp
@@ -64,7 +64,7 @@ IGL_INLINE void igl::copyleft::cgal::wire_mesh(
   };
 
   // Count each vertex's indicident edges.
-  std::vector<int> nedges(WV.rows());
+  std::vector<int> nedges(WV.rows(), 0);
   for(int e = 0;e<WE.rows();e++)
   {
     ++nedges[WE(e, 0)];


### PR DESCRIPTION
In #963, I asked about flattening the caps on any terminal vertices of wiremeshes. Following @alecjacobson's implementation suggestions, I zero out the offset when a vertex is incident on only one edge.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [ ] This is a minor change.
