### PR TITLE
Add cut to disk unittest

### DIFF
--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -153,7 +153,7 @@ function(igl_download_test_data)
 		DOWNLOAD_DIR ${LIBIGL_EXTERNAL}/.cache/test_data
 		QUIET
 		GIT_REPOSITORY https://github.com/libigl/libigl-tests-data
-        GIT_TAG        c01017b0c73734c0807c95563628ad2754efb462
+		GIT_TAG        c01017b0c73734c0807c95563628ad2754efb462
 		${LIBIGL_EXTRA_OPTIONS}
 	)
 endfunction()

--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -153,7 +153,7 @@ function(igl_download_test_data)
 		DOWNLOAD_DIR ${LIBIGL_EXTERNAL}/.cache/test_data
 		QUIET
 		GIT_REPOSITORY https://github.com/libigl/libigl-tests-data
-		GIT_TAG        c81bb3b3db4cfd78bac6d359d845c45bc1059c9a
+        GIT_TAG        c01017b0c73734c0807c95563628ad2754efb462
 		${LIBIGL_EXTRA_OPTIONS}
 	)
 endfunction()

--- a/tests/include/igl/cut_to_disk.cpp
+++ b/tests/include/igl/cut_to_disk.cpp
@@ -130,3 +130,17 @@ TEST_CASE("cut_to_disk: cube", "[igl]")
 
   cut_to_disk_helper::assert_is_disk(V, F, cuts);
 }
+
+TEST_CASE("cut_to_disk: annulus", "[igl][PR984][bug]") {
+  using namespace igl;
+  Eigen::MatrixXd V;
+  Eigen::MatrixXi F;
+  test_common::load_mesh("annulus.obj", V, F);
+
+  std::vector<std::vector<int>> cuts;
+  cut_to_disk(F, cuts);
+  REQUIRE (cuts.size() == 1);
+
+  cut_to_disk_helper::assert_is_disk(V, F, cuts);
+}
+

--- a/tests/include/igl/cut_to_disk.cpp
+++ b/tests/include/igl/cut_to_disk.cpp
@@ -139,7 +139,6 @@ TEST_CASE("cut_to_disk: annulus", "[igl][PR984][bug]") {
 
   std::vector<std::vector<int>> cuts;
   cut_to_disk(F, cuts);
-  REQUIRE (cuts.size() == 1);
 
   cut_to_disk_helper::assert_is_disk(V, F, cuts);
 }

--- a/tests/include/igl/cut_to_disk.cpp
+++ b/tests/include/igl/cut_to_disk.cpp
@@ -131,7 +131,8 @@ TEST_CASE("cut_to_disk: cube", "[igl]")
   cut_to_disk_helper::assert_is_disk(V, F, cuts);
 }
 
-TEST_CASE("cut_to_disk: annulus", "[igl][PR984][bug]") {
+TEST_CASE("cut_to_disk: annulus", "[igl]") {
+  // Unit test for https://github.com/libigl/libigl/pull/984
   using namespace igl;
   Eigen::MatrixXd V;
   Eigen::MatrixXi F;


### PR DESCRIPTION
Added a failing unit test for `igl::cut_to_disk` based on https://github.com/libigl/libigl/pull/984.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [x] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
