### PR TITLE
Fix build python bindings

### DIFF
--- a/cmake/libigl.cmake
+++ b/cmake/libigl.cmake
@@ -88,11 +88,6 @@ if(BUILD_SHARED_LIBS)
   set_target_properties(igl_common PROPERTIES INTERFACE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
-if(UNIX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-endif()
-
 # Eigen
 if(TARGET Eigen3::Eigen)
   # If an imported target already exists, use it

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,6 +1,19 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(pyigl)
 
+### Adding libIGL: choose the path to your local copy libIGL
+if(NOT TARGET igl::core)
+  ### Prefer header-only mode for compiling Python bindings
+  if(NOT LIBIGL_WITH_PYTHON OR NOT LIBIGL_USE_STATIC_LIBRARY)
+    message(FATAL_ERROR
+      "Trying to compile Python bindings without -DLIBIGL_WITH_PYTHON=ON. "
+      "Either enable manually all the necessary options, or compile from "
+      "the root folder with -DLIBIGL_USE_STATIC_LIBRARY=OFF")
+  endif()
+  list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/../cmake")
+  include(libigl)
+endif()
+
 # Force a specific python version
 # set(PYTHON_LIBRARIES "D:/Python34/libs/python34.lib")
 # set(PYTHON_INCLUDE_DIR "D:/Python34/include")
@@ -13,20 +26,11 @@ set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6)
 find_package(PythonInterp REQUIRED)
 find_package(PythonLibs REQUIRED)
 
-
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 if(UNIX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
   if(NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -flto")
   endif()
-endif()
-
-## libigl		
-if(NOT TARGET igl::core)		
-  list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/../cmake")		
-  include(libigl)		
 endif()
 
 ## include pybind
@@ -42,7 +46,7 @@ pybind11_add_module(pyigl
 )
 
 ## Add dependencies
-target_include_directories(pyigl PUBLIC igl::core)
+target_link_libraries(pyigl PUBLIC igl::core)
 
 ## Optional modules
 if(LIBIGL_WITH_OPENGL_GLFW)

--- a/python/tutorial/001_BasicTypes.py
+++ b/python/tutorial/001_BasicTypes.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/101_FileIO.py
+++ b/python/tutorial/101_FileIO.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/102_DrawMesh.py
+++ b/python/tutorial/102_DrawMesh.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/102_DrawMesh_TCP.py
+++ b/python/tutorial/102_DrawMesh_TCP.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/103_Events.py
+++ b/python/tutorial/103_Events.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/104_Colors.py
+++ b/python/tutorial/104_Colors.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/105_Overlays.py
+++ b/python/tutorial/105_Overlays.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/201_Normals.py
+++ b/python/tutorial/201_Normals.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/202_GaussianCurvature.py
+++ b/python/tutorial/202_GaussianCurvature.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/203_CurvatureDirections.py
+++ b/python/tutorial/203_CurvatureDirections.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/204_Gradient.py
+++ b/python/tutorial/204_Gradient.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/205_Laplacian.py
+++ b/python/tutorial/205_Laplacian.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/301_Slice.py
+++ b/python/tutorial/301_Slice.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/302_Sort.py
+++ b/python/tutorial/302_Sort.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/303_LaplaceEquation.py
+++ b/python/tutorial/303_LaplaceEquation.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/304_LinearEqualityConstraints.py
+++ b/python/tutorial/304_LinearEqualityConstraints.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/305_QuadraticProgramming.py
+++ b/python/tutorial/305_QuadraticProgramming.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/306_EigenDecomposition.py
+++ b/python/tutorial/306_EigenDecomposition.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/401_BiharmonicDeformation.py
+++ b/python/tutorial/401_BiharmonicDeformation.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/402_PolyharmonicDeformation.py
+++ b/python/tutorial/402_PolyharmonicDeformation.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/403_BoundedBiharmonicWeights.py
+++ b/python/tutorial/403_BoundedBiharmonicWeights.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/404_DualQuaternionSkinning.py
+++ b/python/tutorial/404_DualQuaternionSkinning.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/405_AsRigidAsPossible.py
+++ b/python/tutorial/405_AsRigidAsPossible.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/501_HarmonicParam.py
+++ b/python/tutorial/501_HarmonicParam.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/502_LSCMParam.py
+++ b/python/tutorial/502_LSCMParam.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/503_ARAPParam.py
+++ b/python/tutorial/503_ARAPParam.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/504_NRosyDesign.py
+++ b/python/tutorial/504_NRosyDesign.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/505_MIQ.py
+++ b/python/tutorial/505_MIQ.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/507_Planarization.py
+++ b/python/tutorial/507_Planarization.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/604_Triangle.py
+++ b/python/tutorial/604_Triangle.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/605_Tetgen.py
+++ b/python/tutorial/605_Tetgen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/606_AmbientOcclusion.py
+++ b/python/tutorial/606_AmbientOcclusion.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/607_ScreenCapture.py
+++ b/python/tutorial/607_ScreenCapture.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/609_Boolean.py
+++ b/python/tutorial/609_Boolean.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/701_Statistics.py
+++ b/python/tutorial/701_Statistics.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/702_WindingNumber.py
+++ b/python/tutorial/702_WindingNumber.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/704_SignedDistance.py
+++ b/python/tutorial/704_SignedDistance.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/705_MarchingCubes.py
+++ b/python/tutorial/705_MarchingCubes.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/706_FacetOrientation.py
+++ b/python/tutorial/706_FacetOrientation.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/707_SweptVolume.py
+++ b/python/tutorial/707_SweptVolume.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/708_Picking.py
+++ b/python/tutorial/708_Picking.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/709_VectorFieldVisualizer.py
+++ b/python/tutorial/709_VectorFieldVisualizer.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # This file is part of libigl, a simple c++ geometry processing library.
 #
 # Copyright (C) 2017 Sebastian Koch <s.koch@tu-berlin.de> and Daniele Panozzo <daniele.panozzo@gmail.com>

--- a/python/tutorial/shared.py
+++ b/python/tutorial/shared.py
@@ -9,7 +9,7 @@ import pyigl as igl
 import sys
 import os
 
-TUTORIAL_SHARED_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../tutorial/shared/")
+TUTORIAL_SHARED_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../tutorial/data/")
 
 def check_dependencies(deps):
     available = [hasattr(igl, m) for m in deps]

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -1,14 +1,17 @@
 cmake_minimum_required(VERSION 3.1)
 project(libigl_tutorials)
 
-### conditionally compile certain modules depending on libraries found on the system		
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../cmake)		
-	
-### Adding libIGL: choose the path to your local copy libIGL		
-if(NOT TARGET igl_common)		
-  include(libigl)		
-else()		
-  include(LibiglDownloadExternal)		
+### Conditionally compile certain modules depending on libraries found on the system
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../cmake)
+
+### Compile libigl in header-only mode for Python bindings
+option(LIBIGL_USE_STATIC_LIBRARY "Use LibIGL as static library" ON)
+
+### Adding libIGL: choose the path to your local copy libIGL
+if(NOT TARGET igl_common)
+  include(libigl)
+else()
+  include(LibiglDownloadExternal)
 endif()
 
 ### Download data


### PR DESCRIPTION
I know we have new python bindings in the work, but right now the ones we have are not usable anymore.
- If compiled with `LIBIGL_USE_STATIC_LIBRARY=ON`, there will be missing symbols at runtime.
- I also fixed the path of the tutorial data in `shared.py`.
- Added an error message if someone tries to run cmake from the `python/` folder without the correct options.
- Once this is merged, I'll put a big warning on the website that people should compile with `LIBIGL_USE_STATIC_LIBRARY=ON` if they want to use the python bindings.

Testing and integrating the new python bindings will take some time (a couple of weeks at least), so this needs to patched in the meantime.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [x] This is a minor change.
