### PR TITLE
Eigen Alignment issue

### DIFF
--- a/include/igl/opengl/ViewerData.h
+++ b/include/igl/opengl/ViewerData.h
@@ -19,6 +19,14 @@
 // Alec: This is a mesh class containing a variety of data types (normals,
 // overlays, material colors, etc.)
 //
+// WARNING: Eigen data members (such as Eigen::Vector4f) should explicitly
+// disable alignment (e.g. use `Eigen::Matrix<float, 4, 1, Eigen::DontAlign>`),
+// in order to avoid alignment issues further down the line (esp. if the
+// structure are stored in a std::vector).
+//
+// See this thread for a more detailed discussion:
+// https://github.com/libigl/libigl/pull/1029
+//
 namespace igl
 {
 
@@ -103,7 +111,7 @@ public:
   //   C  #E|1 by 3 color(s)
   IGL_INLINE void set_edges (const Eigen::MatrixXd& P, const Eigen::MatrixXi& E, const Eigen::MatrixXd& C);
   // Alec: This is very confusing. Why does add_edges have a different API from
-  // set_edges? 
+  // set_edges?
   IGL_INLINE void add_edges (const Eigen::MatrixXd& P1, const Eigen::MatrixXd& P2, const Eigen::MatrixXd& C);
   IGL_INLINE void add_label (const Eigen::VectorXd& P,  const std::string& str);
 
@@ -189,7 +197,7 @@ public:
   // Point size / line width
   float point_size;
   float line_width;
-  Eigen::Vector4f line_color;
+  Eigen::Matrix<float, 4, 1, Eigen::DontAlign> line_color;
 
   // Shape material
   float shininess;
@@ -205,9 +213,6 @@ public:
     const igl::opengl::ViewerData& data,
     const bool invert_normals,
     igl::opengl::MeshGL& meshgl);
-  
-public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 } // namespace opengl

--- a/include/igl/opengl/ViewerData.h
+++ b/include/igl/opengl/ViewerData.h
@@ -205,6 +205,9 @@ public:
     const igl::opengl::ViewerData& data,
     const bool invert_normals,
     igl::opengl::MeshGL& meshgl);
+  
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 } // namespace opengl


### PR DESCRIPTION
https://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html

A memory alignment assertion fired once for the .data_list in the viewer. I'm not sure if we also need the special stl vector allocator for the data list of if this is enough to fix it. It's hard to get this assertion to fire in a reproducible way.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
