### PR TITLE
Building a CGAL polyhedron via a float-type Eigen matrix.

### DIFF
--- a/include/igl/copyleft/cgal/mesh_to_polyhedron.cpp
+++ b/include/igl/copyleft/cgal/mesh_to_polyhedron.cpp
@@ -10,9 +10,9 @@
 #include <CGAL/Polyhedron_incremental_builder_3.h>
 
 
-template <typename Polyhedron>
+template <typename Polyhedron, typename DerivedV>
 IGL_INLINE bool igl::copyleft::cgal::mesh_to_polyhedron(
-  const Eigen::MatrixXd & V,
+  const Eigen::MatrixBase<DerivedV> & V,
   const Eigen::MatrixXi & F,
   Polyhedron & poly)
 {
@@ -51,4 +51,5 @@ IGL_INLINE bool igl::copyleft::cgal::mesh_to_polyhedron(
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
 template bool igl::copyleft::cgal::mesh_to_polyhedron<CGAL::Polyhedron_3<CGAL::Simple_cartesian<double>, CGAL::Polyhedron_items_with_id_3, CGAL::HalfedgeDS_default, std::allocator<int> > >(Eigen::Matrix<double, -1, -1, 0, -1, -1> const&, Eigen::Matrix<int, -1, -1, 0, -1, -1> const&, CGAL::Polyhedron_3<CGAL::Simple_cartesian<double>, CGAL::Polyhedron_items_with_id_3, CGAL::HalfedgeDS_default, std::allocator<int> >&);
+template bool igl::copyleft::cgal::mesh_to_polyhedron<CGAL::Polyhedron_3<CGAL::Simple_cartesian<float>, CGAL::Polyhedron_items_with_id_3, CGAL::HalfedgeDS_default, std::allocator<int> > >(Eigen::Matrix<float, -1, -1, 0, -1, -1> const&, Eigen::Matrix<int, -1, -1, 0, -1, -1> const&, CGAL::Polyhedron_3<CGAL::Simple_cartesian<float>, CGAL::Polyhedron_items_with_id_3, CGAL::HalfedgeDS_default, std::allocator<int> >&);
 #endif

--- a/include/igl/copyleft/cgal/mesh_to_polyhedron.cpp
+++ b/include/igl/copyleft/cgal/mesh_to_polyhedron.cpp
@@ -9,13 +9,13 @@
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_incremental_builder_3.h>
 
-
-template <typename Polyhedron, typename DerivedV>
+template <
+	typename Polyhedron,
+	typename DerivedV,
+	typename DerivedF>
 IGL_INLINE bool igl::copyleft::cgal::mesh_to_polyhedron(
-  const Eigen::MatrixBase<DerivedV> & V,
-  const Eigen::MatrixXi & F,
-  Polyhedron & poly)
-{
+    const Eigen::MatrixBase<DerivedV>& V, const Eigen::MatrixBase<DerivedF>& F,
+    Polyhedron& poly) {
   typedef typename Polyhedron::HalfedgeDS HalfedgeDS;
   // Postcondition: hds is a valid polyhedral surface.
   CGAL::Polyhedron_incremental_builder_3<HalfedgeDS> B(poly.hds());

--- a/include/igl/copyleft/cgal/mesh_to_polyhedron.h
+++ b/include/igl/copyleft/cgal/mesh_to_polyhedron.h
@@ -27,9 +27,9 @@ namespace igl
       //   poly  cgal polyhedron
       // Returns true only if (V,F) can be converted to a valid polyhedron (i.e. if
       // (V,F) is vertex and edge manifold).
-      template <typename Polyhedron>
+      template <typename Polyhedron, typename DerivedV>
       IGL_INLINE bool mesh_to_polyhedron(
-        const Eigen::MatrixXd & V,
+        const Eigen::MatrixBase<DerivedV> & V,
         const Eigen::MatrixXi & F,
         Polyhedron & poly);
     }

--- a/include/igl/copyleft/cgal/mesh_to_polyhedron.h
+++ b/include/igl/copyleft/cgal/mesh_to_polyhedron.h
@@ -27,10 +27,13 @@ namespace igl
       //   poly  cgal polyhedron
       // Returns true only if (V,F) can be converted to a valid polyhedron (i.e. if
       // (V,F) is vertex and edge manifold).
-      template <typename Polyhedron, typename DerivedV>
+      template <
+		  typename Polyhedron,
+		  typename DerivedV,
+		  typename DerivedF>
       IGL_INLINE bool mesh_to_polyhedron(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixXi & F,
+        const Eigen::MatrixBase<DerivedF> & F,
         Polyhedron & poly);
     }
   }

--- a/include/igl/hausdorff.h
+++ b/include/igl/hausdorff.h
@@ -28,6 +28,9 @@ namespace igl
   // vertices) in 2D and its convex hull. The Hausdorff distance is defined by
   // the midpoint in the middle of the segment across the concavity and some
   // non-vertex point _on the edge_ of the V.
+  // Known issue: due to the issue above, this also means that unreferenced
+  // vertices can give unexpected results. Therefore, we assume the inputs have 
+  // no unreferenced vertices.
   //
   // Inputs:
   //   VA  #VA by 3 list of vertex positions


### PR DESCRIPTION
The origin version only accepts Eigen::MatrixXd as vertices.

Add a template parameter to `igl::copyleft::cgal::mesh_to_polyhedron` so it also accepts `Eigen::MatrixXf` as `V`

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [ ] This is a minor change.
