### PR TITLE
Bump stb_image version

### DIFF
--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -116,7 +116,7 @@ endfunction()
 function(igl_download_stb)
 	igl_download_project(stb
 		GIT_REPOSITORY https://github.com/libigl/libigl-stb.git
-		GIT_TAG        edfa26e389060c21b9dd7812a0b19c00208b7224
+		GIT_TAG        cd0fa3fcd90325c83be4d697b00214e029f94ca3
 	)
 endfunction()
 


### PR DESCRIPTION
As noted in https://github.com/libigl/libigl-stb/pull/2:

Compiling igl_stb_image with gcc 7.3 (Ubuntu 18.04 LTS) with `-Wall` creates many warnings, like

```
libigl/external/stb/stb_image.h: In function ‘unsigned char* stbi__convert_format(unsigned char*, int, int, unsigned int, unsigned int)’:
libigl/external/stb/stb_image.h:1361:44: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
       #define CASE(a,b)   case COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
                                            ^
```

These warnings have been fixed upstream in stb_image and stb_image_write, thus I propose to update these files to their current versions from nothings/stb master. Compiling with these versions runs warnings-free.

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
