### PR TITLE
Fix Travis build + minor CMake improvements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,15 @@ matrix:
   - os: linux
     compiler: gcc # 4.8.4 by default on Trusty
     env:
-    - MATRIX_EVAL="export CONFIG=Debug && PYTHON=python3"
+    - MATRIX_EVAL="export CONFIG=Release && PYTHON=python3"
   - os: linux
     compiler: gcc-7
     env:
-    - MATRIX_EVAL="export CC=gcc-7 && CXX=g++-7 && CONFIG=Debug && PYTHON=python3"
+    - MATRIX_EVAL="export CC=gcc-7 && CXX=g++-7 && CONFIG=Release && PYTHON=python3"
   - os: linux
     compiler: gcc-7
     env:
-    - MATRIX_EVAL="export CC=gcc-7 && CXX=g++-7 && CONFIG=Debug && PYTHON=python3 CMAKE_EXTRA='-DLIBIGL_EIGEN_VERSION=3.3.7 -DLIBIGL_EIGEN_MD5=f2a417d083fe8ca4b8ed2bc613d20f07'"
+    - MATRIX_EVAL="export CC=gcc-7 && CXX=g++-7 && CONFIG=Release && PYTHON=python3 CMAKE_EXTRA='-DLIBIGL_EIGEN_VERSION=3.3.7 -DLIBIGL_EIGEN_MD5=f2a417d083fe8ca4b8ed2bc613d20f07'"
   - os: osx
     compiler: clang
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,67 +2,38 @@ dist: trusty
 sudo: true
 language: cpp
 cache: ccache
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-7
+    - gcc-7
+    - libblas-dev
+    - libboost-filesystem-dev
+    - libboost-system-dev
+    - libboost-thread-dev
+    - libglu1-mesa-dev
+    - liblapack-dev
+    - libmpfr-dev
+    - libpython3-dev
+    - python3-setuptools
+    - xorg-dev
+  homebrew:
+    packages:
+    - ccache
 matrix:
   include:
   - os: linux
     compiler: gcc # 4.8.4 by default on Trusty
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - libmpfr-dev
-        - libboost-filesystem-dev
-        - libboost-system-dev
-        - libboost-thread-dev
-        - libblas-dev
-        - liblapack-dev
-        - xorg-dev
-        - libglu1-mesa-dev
-        - python3-setuptools
-        - libpython3-dev
     env:
     - MATRIX_EVAL="export CONFIG=Debug && PYTHON=python3"
   - os: linux
     compiler: gcc-7
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - gcc-7
-        - g++-7
-        - libmpfr-dev
-        - libboost-filesystem-dev
-        - libboost-system-dev
-        - libboost-thread-dev
-        - libblas-dev
-        - liblapack-dev
-        - xorg-dev
-        - libglu1-mesa-dev
-        - python3-setuptools
-        - libpython3-dev
     env:
     - MATRIX_EVAL="export CC=gcc-7 && CXX=g++-7 && CONFIG=Debug && PYTHON=python3"
   - os: linux
     compiler: gcc-7
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - gcc-7
-        - g++-7
-        - libmpfr-dev
-        - libboost-filesystem-dev
-        - libboost-system-dev
-        - libboost-thread-dev
-        - libblas-dev
-        - liblapack-dev
-        - xorg-dev
-        - libglu1-mesa-dev
-        - python3-setuptools
-        - libpython3-dev
     env:
     - MATRIX_EVAL="export CC=gcc-7 && CXX=g++-7 && CONFIG=Debug && PYTHON=python3 CMAKE_EXTRA='-DLIBIGL_EIGEN_VERSION=3.3.7 -DLIBIGL_EIGEN_MD5=f2a417d083fe8ca4b8ed2bc613d20f07'"
   - os: osx
@@ -71,7 +42,6 @@ matrix:
     - MATRIX_EVAL="export CONFIG=Debug && PYTHON=python3"
 
 install:
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ccache; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
 - eval "${MATRIX_EVAL}"
 - ccache --max-size=5.0G

--- a/cmake/DownloadProject.CMakeLists.cmake.in
+++ b/cmake/DownloadProject.CMakeLists.cmake.in
@@ -14,5 +14,4 @@ ExternalProject_Add(${DL_ARGS_PROJ}-download
                     BUILD_COMMAND       ""
                     INSTALL_COMMAND     ""
                     TEST_COMMAND        ""
-                    TLS_VERIFY          OFF
 )

--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -15,7 +15,7 @@ function(igl_download_project_aux name source)
 	if(NOT LIBIGL_SKIP_DOWNLOAD)
 		download_project(
 			PROJ         ${name}
-			SOURCE_DIR   "${LIBIGL_EXTERNAL}/${name}"
+			SOURCE_DIR   "${source}"
 			DOWNLOAD_DIR "${LIBIGL_EXTERNAL}/.cache/${name}"
 			QUIET
 			${LIBIGL_EXTRA_OPTIONS}

--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -3,22 +3,29 @@ include(DownloadProject)
 
 # With CMake 3.8 and above, we can hide warnings about git being in a
 # detached head by passing an extra GIT_CONFIG option
+set(LIBIGL_EXTRA_OPTIONS TLS_VERIFY OFF)
 if(NOT (${CMAKE_VERSION} VERSION_LESS "3.8.0"))
-	set(LIBIGL_EXTRA_OPTIONS "GIT_CONFIG advice.detachedHead=false")
-else()
-	set(LIBIGL_EXTRA_OPTIONS "")
+	list(APPEND LIBIGL_EXTRA_OPTIONS GIT_CONFIG advice.detachedHead=false)
 endif()
 
-# Shortcut function
+option(LIBIGL_SKIP_DOWNLOAD "Skip downloading external libraries" OFF)
+
+# Shortcut functions
+function(igl_download_project_aux name source)
+	if(NOT LIBIGL_SKIP_DOWNLOAD)
+		download_project(
+			PROJ         ${name}
+			SOURCE_DIR   "${LIBIGL_EXTERNAL}/${name}"
+			DOWNLOAD_DIR "${LIBIGL_EXTERNAL}/.cache/${name}"
+			QUIET
+			${LIBIGL_EXTRA_OPTIONS}
+			${ARGN}
+		)
+	endif()
+endfunction()
+
 function(igl_download_project name)
-	download_project(
-		PROJ         ${name}
-		SOURCE_DIR   ${LIBIGL_EXTERNAL}/${name}
-		DOWNLOAD_DIR ${LIBIGL_EXTERNAL}/.cache/${name}
-		QUIET
-		${LIBIGL_EXTRA_OPTIONS}
-		${ARGN}
-	)
+	igl_download_project_aux(${name} "${LIBIGL_EXTERNAL}/${name}" ${ARGN})
 endfunction()
 
 ################################################################################
@@ -149,31 +156,19 @@ endfunction()
 
 ## Test data
 function(igl_download_test_data)
-	set(IGL_TEST_DATA ${LIBIGL_EXTERNAL}/../tests/data)
-
-	download_project(
-		PROJ         test_data
-		SOURCE_DIR   ${IGL_TEST_DATA}
-		DOWNLOAD_DIR ${LIBIGL_EXTERNAL}/.cache/test_data
-		QUIET
+	igl_download_project_aux(test_data
+		"${LIBIGL_EXTERNAL}/../tests/data"
 		GIT_REPOSITORY https://github.com/libigl/libigl-tests-data
 		GIT_TAG        adc66cabf712a0bd68ac182b4e7f8b5ba009c3dd
-		${LIBIGL_EXTRA_OPTIONS}
 	)
 endfunction()
 
 ## Tutorial data
 function(igl_download_tutorial_data)
-	set(IGL_TUTORIAL_DATA ${LIBIGL_EXTERNAL}/../tutorial/data)
-
-	download_project(
-		PROJ         tutorial_data
-		SOURCE_DIR   ${IGL_TUTORIAL_DATA}
-		DOWNLOAD_DIR ${LIBIGL_EXTERNAL}/.cache/tutorial_data
-		QUIET
+	igl_download_project_aux(tutorial_data
+		"${LIBIGL_EXTERNAL}/../tutorial/data"
 		GIT_REPOSITORY https://github.com/libigl/libigl-tutorial-data
 		GIT_TAG        5c6a1ea809c043d71e5595775709c15325a7158c
-		${LIBIGL_EXTRA_OPTIONS}
 	)
 endfunction()
 


### PR DESCRIPTION
Seems that yesterday Travis updated their macOS image or something, and as a result the `brew install ccache` command was failing. Looks like using the `homebrew` addon to install `ccahe` is a better option.

I've also simplified a bit the Travis script and added a CMake option to make @evouga happy (#1068).

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [x] This is a minor change.
