### PR TITLE
fix min_quad_with_fixed to work for non-double template types

### DIFF
--- a/include/igl/min_quad_with_fixed.cpp
+++ b/include/igl/min_quad_with_fixed.cpp
@@ -294,7 +294,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
     SparseMatrix<T> AeqTR,AeqTQ;
     AeqTR = data.AeqTQR.matrixR();
     // This shouldn't be necessary
-    AeqTR.prune(0.0);
+    AeqTR.prune(static_cast<T>(0.0));
 #ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
     cout<<"    matrixQ"<<endl;
 #endif
@@ -306,7 +306,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
     cout<<"      nnz: "<<AeqTQ.nonZeros()<<endl;
 #endif
     // This shouldn't be necessary
-    AeqTQ.prune(0.0);
+    AeqTQ.prune(static_cast<T>(0.0));
     //cout<<"AeqTQ: "<<AeqTQ.rows()<<" "<<AeqTQ.cols()<<endl;
     //cout<<matlab_format(AeqTQ,"AeqTQ")<<endl;
     //cout<<"    perms"<<endl;
@@ -314,7 +314,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
     cout<<"      nnz: "<<AeqTQ.nonZeros()<<endl;
     cout<<"    perm"<<endl;
 #endif
-    SparseMatrix<double> I(neq,neq);
+    SparseMatrix<T> I(neq,neq);
     I.setIdentity();
     data.AeqTE = data.AeqTQR.colsPermutation() * I;
     data.AeqTET = data.AeqTQR.colsPermutation().transpose() * I;


### PR DESCRIPTION
I was working on a project, and I noticed I couldn't compile something like this when all the variables had `float` template types:
```
Eigen::SparseMatrix<float> Q, Aeq;
Eigen::VectorXi b;
Eigen::VectorXf bc, B, Beq, Z;
...
igl::min_quad_with_fixed_data<float> mqwf;
igl::min_quad_with_fixed_precompute(Q, b, Aeq, true, mqwf);
igl::min_quad_with_fixed_solve(mqwf, B, bc, Beq, Z);
```
This PR fixes the compile errors I encountered.

I'm not exactly how to unit test this, unless you'd like me to upload some code and verify that it compiles.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
