### PR TITLE
Fixed undefined behavior in the SolveP3 function of flip_avoiding_lin…

### DIFF
--- a/include/igl/flip_avoiding_line_search.cpp
+++ b/include/igl/flip_avoiding_line_search.cpp
@@ -47,7 +47,7 @@ namespace igl
         {
           A =-pow(fabs(r)+sqrt(r2-q3),1./3);
           if( r<0 ) A=-A;
-          B = A==0? 0 : B=q/A;
+          B = A==0? 0 : q/A;
 
           a/=3;
           x[0] =(A+B)-a;


### PR DESCRIPTION
…e_search.

[Describe your changes and what you've already done to test it.]

#### Check all that apply (change to `[x]`)
- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [ ] This is a minor change.
