### PR TITLE
Fix: Wrong Eigen3 dependency when using find_package(libigl) #1100

### DIFF
--- a/cmake/libigl-config.cmake.in
+++ b/cmake/libigl-config.cmake.in
@@ -3,40 +3,26 @@
 include(${CMAKE_CURRENT_LIST_DIR}/libigl-export.cmake)
 
 # Check if Eigen3 target is avaiable, if not try to locate it
-# with find_package. On success sets LIBIGL_Eigen3_Target to
-# the located Eigen3 target. On failure the variable is empty.
-function(LIBIGL_find_Eigen3)
-  set(LIBIGL_Eigen3_Target "" PARENT_SCOPE)
-
-  if (TARGET Eigen3::Eigen)
-    set(LIBIGL_Eigen3_Target Eigen3::Eigen PARENT_SCOPE)
-  else()
-    # Try if Eigen3 can be found with find_package
-    find_package(Eigen3 CONFIG QUIET)
-    if (NOT Eigen3_FOUND)
-      message(SEND_ERROR "libigl depends on Eigen3 but Eigen3 could not be found.")
-      # run find_package again to print its error message
-      find_package(Eigen3 CONFIG REQUIRED)
-    else()
-      # find_package succeeded, link against Eigen3::Eigen
-      set(LIBIGL_Eigen3_Target Eigen3::Eigen PARENT_SCOPE)
-    endif()
-  endif()
-endfunction()
+# with find_package.
+message(STATUS "[libigl] Looking for Eigen3")
+if (NOT TARGET Eigen3::Eigen)
+  # Try if Eigen3 can be found with find_package
+  find_package(Eigen3 CONFIG REQUIRED)
+endif()
 
 
 if (TARGET igl::core)
-  LIBIGL_find_Eigen3()
-  if (TARGET ${LIBIGL_Eigen3_Target})
-    set_target_properties(igl::core PROPERTIES INTERFACE_LINK_LIBRARIES ${LIBIGL_Eigen3_Target})
+  if (TARGET Eigen3::Eigen)
+    # Inject dependency
+    set_target_properties(igl::core PROPERTIES INTERFACE_LINK_LIBRARIES Eigen3::Eigen)
     set(libigl_core_FOUND TRUE)
   endif()
 endif()
 
 if (TARGET igl::common)
-  LIBIGL_find_Eigen3()
-  if (TARGET ${LIBIGL_Eigen3_Target})
-    set_target_properties(igl::common PROPERTIES INTERFACE_LINK_LIBRARIES ${LIBIGL_Eigen3_Target})
+  if (TARGET Eigen3::Eigen)
+    # Inject dependency
+    set_target_properties(igl::common PROPERTIES INTERFACE_LINK_LIBRARIES Eigen3::Eigen)
     set(libigl_common_FOUND TRUE)
   endif()
 endif()

--- a/cmake/libigl-config.cmake.in
+++ b/cmake/libigl-config.cmake.in
@@ -2,50 +2,52 @@
 
 include(${CMAKE_CURRENT_LIST_DIR}/libigl-export.cmake)
 
-if (TARGET igl::core)
-  if (NOT TARGET Eigen3::Eigen)
+# Check if Eigen3 target is avaiable, if not try to locate it,
+# either with find_package or with PkgConfig. On success sets
+# LIBIGL_Eigen3_Target to the located Eigen3 target. Of failure
+# the variable is empty.
+function(LIBIGL_find_Eigen3)
+  set(LIBIGL_Eigen3_Target "" PARENT_SCOPE)
+
+  if (TARGET Eigen3::Eigen)
+    set(LIBIGL_Eigen3_Target Eigen3::Eigen PARENT_SCOPE)
+  else()
+    # First try if Eigen3 can be found with find_package
     find_package(Eigen3 QUIET)
     if (NOT Eigen3_FOUND)
-      # try with PkgCOnfig
+      # find_package failed, next try with PkgConfig
       find_package(PkgConfig REQUIRED)
       pkg_check_modules(Eigen3 QUIET IMPORTED_TARGET eigen3)
-    endif()
 
-    if (NOT Eigen3_FOUND)
-      message(FATAL_ERROR "Could not find required dependency Eigen3")
-      set(libigl_core_FOUND FALSE)
+      if (NOT Eigen3_FOUND)
+        # Both, find_package and PkgConfig failed to locate Eigen3
+        message(FATAL_ERROR "Could not find required dependency Eigen3")
+      else()
+        # PkgConfig succeeded, link against PkgConfig::Eigen3
+        set(LIBIGL_Eigen3_Target PkgConfig::Eigen3 PARENT_SCOPE)
+      endif()
     else()
-      set_target_properties(igl::core PROPERTIES INTERFACE_LINK_LIBRARIES PkgConfig::Eigen3)
-      set(libigl_core_FOUND TRUE)
+      # find_package succeeded, link against Eigen3::Eigen
+      set(LIBIGL_Eigen3_Target Eigen3::Eigen PARENT_SCOPE)
     endif()
-  else()
-    set_target_properties(igl::core PROPERTIES INTERFACE_LINK_LIBRARIES Eigen3::Eigen)
+  endif()
+endfunction()
+
+
+if (TARGET igl::core)
+  LIBIGL_find_Eigen3()
+  if (TARGET ${LIBIGL_Eigen3_Target})
+    set_target_properties(igl::core PROPERTIES INTERFACE_LINK_LIBRARIES ${LIBIGL_Eigen3_Target})
     set(libigl_core_FOUND TRUE)
   endif()
-
 endif()
 
 if (TARGET igl::common)
-  if (NOT TARGET Eigen3::Eigen)
-    find_package(Eigen3 QUIET)
-    if (NOT Eigen3_FOUND)
-      # try with PkgCOnfig
-      find_package(PkgConfig REQUIRED)
-      pkg_check_modules(Eigen3 QUIET IMPORTED_TARGET eigen3)
-    endif()
-
-    if (NOT Eigen3_FOUND)
-      message(FATAL_ERROR "Could not find required dependency Eigen3")
-      set(libigl_common_FOUND FALSE)
-    else()
-      set_target_properties(igl::common PROPERTIES INTERFACE_LINK_LIBRARIES PkgConfig::Eigen3)
-      set(libigl_common_FOUND TRUE)
-    endif()
-  else()
-    set_target_properties(igl::common PROPERTIES INTERFACE_LINK_LIBRARIES Eigen3::Eigen)
+  LIBIGL_find_Eigen3()
+  if (TARGET ${LIBIGL_Eigen3_Target})
+    set_target_properties(igl::common PROPERTIES INTERFACE_LINK_LIBRARIES ${LIBIGL_Eigen3_Target})
     set(libigl_common_FOUND TRUE)
   endif()
-
 endif()
 
 check_required_components(libigl)

--- a/cmake/libigl-config.cmake.in
+++ b/cmake/libigl-config.cmake.in
@@ -2,30 +2,21 @@
 
 include(${CMAKE_CURRENT_LIST_DIR}/libigl-export.cmake)
 
-# Check if Eigen3 target is avaiable, if not try to locate it,
-# either with find_package or with PkgConfig. On success sets
-# LIBIGL_Eigen3_Target to the located Eigen3 target. Of failure
-# the variable is empty.
+# Check if Eigen3 target is avaiable, if not try to locate it
+# with find_package. On success sets LIBIGL_Eigen3_Target to
+# the located Eigen3 target. On failure the variable is empty.
 function(LIBIGL_find_Eigen3)
   set(LIBIGL_Eigen3_Target "" PARENT_SCOPE)
 
   if (TARGET Eigen3::Eigen)
     set(LIBIGL_Eigen3_Target Eigen3::Eigen PARENT_SCOPE)
   else()
-    # First try if Eigen3 can be found with find_package
-    find_package(Eigen3 QUIET)
+    # Try if Eigen3 can be found with find_package
+    find_package(Eigen3 CONFIG QUIET)
     if (NOT Eigen3_FOUND)
-      # find_package failed, next try with PkgConfig
-      find_package(PkgConfig REQUIRED)
-      pkg_check_modules(Eigen3 QUIET IMPORTED_TARGET eigen3)
-
-      if (NOT Eigen3_FOUND)
-        # Both, find_package and PkgConfig failed to locate Eigen3
-        message(FATAL_ERROR "Could not find required dependency Eigen3")
-      else()
-        # PkgConfig succeeded, link against PkgConfig::Eigen3
-        set(LIBIGL_Eigen3_Target PkgConfig::Eigen3 PARENT_SCOPE)
-      endif()
+      message(SEND_ERROR "libigl depends on Eigen3 but Eigen3 could not be found.")
+      # run find_package again to print its error message
+      find_package(Eigen3 CONFIG REQUIRED)
     else()
       # find_package succeeded, link against Eigen3::Eigen
       set(LIBIGL_Eigen3_Target Eigen3::Eigen PARENT_SCOPE)


### PR DESCRIPTION
This PR fixes #1100.
Also refactored the code to locate Eigen3.

Successfully tested the following scenarios
1. Eigen3::Eigen present in the project before calling `find_package(libigl CONFIG REQUIRED)`
2. Eigen3::Eigen not present but locatable using `find_package`
3. Eigen3::Eigen not present and not locatable using `find_package` but by using `pkg-config'
3. Eigen3 cannot be found in any way -> correctly issues an error.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.