### PR TITLE
[knn] Fixed comparison functor in priority queue

### DIFF
--- a/include/igl/knn.cpp
+++ b/include/igl/knn.cpp
@@ -68,7 +68,7 @@ namespace igl {
                                              CN.row(right-n),
                                              W(right-n));
         }
-        return leftdistance >= rightdistance;
+        return leftdistance > rightdistance;
       };
       
       std::priority_queue<IndexType, std::vector<IndexType>,


### PR DESCRIPTION
Fixed runtime error with MSVC STL in Debug builds. Release builds do not check if the comparator is valid (needs to be a strict weak ordering, where `!comp(a, b) && !comp(b, a)` means that `a` and `b` are equivalent).

#### Check all that apply (change to `[x]`)
- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
