### PR TITLE
Ensured use of internally defined constants.

### DIFF
--- a/include/igl/scaf.cpp
+++ b/include/igl/scaf.cpp
@@ -78,8 +78,8 @@ void adjusted_grad(Eigen::MatrixXd &V,
   Dz = G.bottomRows(F.rows());
 
   // handcraft uniform gradient for faces area falling below threshold.
-  double sin60 = std::sin(M_PI / 3);
-  double cos60 = std::cos(M_PI / 3);
+  double sin60 = std::sin(igl::PI / 3);
+  double cos60 = std::cos(igl::PI / 3);
   double deno = std::sqrt(sin60 * area_threshold);
   Eigen::MatrixXd standard_grad(3, 3);
   standard_grad << -sin60 / deno, sin60 / deno, 0,

--- a/tests/include/igl/cotmatrix.cpp
+++ b/tests/include/igl/cotmatrix.cpp
@@ -1,4 +1,5 @@
 #include <test_common.h>
+#include <igl/PI.h>
 #include <igl/cotmatrix.h>
 
 TEST_CASE("cotmatrix: constant_in_null_space", "[igl]")
@@ -140,7 +141,7 @@ TEST_CASE("cotmatrix: tetrahedron", "[igl]")
   {
     //Check the diagonal. Only can value 0.0 for unused vertex or -3 / tan(60)
     if (L1.coeff(f,f) < -0.1)
-        REQUIRE (L1.coeff(f,f) == Approx (-3 / tan(M_PI / 3.0)).margin( epsilon));
+        REQUIRE (L1.coeff(f,f) == Approx (-3 / tan(igl::PI / 3.0)).margin( epsilon));
     else
         REQUIRE (L1.coeff(f,f) == Approx (0.0).margin( epsilon));
 #ifdef IGL_EDGE_LENGTHS_SQUARED_H
@@ -163,7 +164,7 @@ TEST_CASE("cotmatrix: tetrahedron", "[igl]")
   {
     //Check the diagonal. Only can value 0.0 for unused vertex or -3 / tan(60)
     if (L1.coeff(f,f) < -0.1)
-        REQUIRE (L1.coeff(f,f) == Approx (-3 / tan(M_PI / 3.0)).margin( epsilon));
+        REQUIRE (L1.coeff(f,f) == Approx (-3 / tan(igl::PI / 3.0)).margin( epsilon));
     else
         REQUIRE (L1.coeff(f,f) == Approx (0.0).margin( epsilon));
     REQUIRE (L1.row(f).sum() == Approx (0.0).margin( epsilon));
@@ -179,7 +180,7 @@ TEST_CASE("cotmatrix: tetrahedron", "[igl]")
   {
     //Check the diagonal. Only can value 0.0 for unused vertex or -3 / tan(60)
     if (L1.coeff(f,f) < -0.1)
-        REQUIRE (L1.coeff(f,f) == Approx (-3 / tan(M_PI / 3.0)).margin( epsilon));
+        REQUIRE (L1.coeff(f,f) == Approx (-3 / tan(igl::PI / 3.0)).margin( epsilon));
     else
         REQUIRE (L1.coeff(f,f) == Approx (0.0).margin( epsilon));
     REQUIRE (L1.row(f).sum() == Approx (0.0).margin( epsilon));

--- a/tests/include/igl/cotmatrix_entries.cpp
+++ b/tests/include/igl/cotmatrix_entries.cpp
@@ -1,4 +1,5 @@
 #include <test_common.h>
+#include <igl/PI.h>
 #include <igl/cotmatrix_entries.h>
 #include <igl/edge_lengths.h>
 #include <igl/EPS.h>
@@ -59,9 +60,9 @@ TEST_CASE("cotmatrix_entries: simple", "[igl]")
   REQUIRE (C2.cols() == 3);
   for(int f = 0;f<C2.rows();f++)
   {
-    //Their (half)cotangent must value 0.5 / tan(M_PI / 3.0)
+    //Their (half)cotangent must value 0.5 / tan(igl::PI / 3.0)
     for(int v = 0;v<3;v++)
-       REQUIRE (C2(f,v) == Approx (0.5 / tan(M_PI / 3.0)).margin( epsilon));
+       REQUIRE (C2(f,v) == Approx (0.5 / tan(igl::PI / 3.0)).margin( epsilon));
   }
 
   //Scale the cube to have huge sides
@@ -101,9 +102,9 @@ TEST_CASE("cotmatrix_entries: simple", "[igl]")
   REQUIRE (C2.cols() == 3);
   for(int f = 0;f<C2.rows();f++)
   {
-    //Their (half)cotangent must value 0.5 / tan(M_PI / 3.0)
+    //Their (half)cotangent must value 0.5 / tan(igl::PI / 3.0)
     for(int v = 0;v<3;v++)
-       REQUIRE (C2(f,v) == Approx (0.5 / tan(M_PI / 3.0)).margin( epsilon));
+       REQUIRE (C2(f,v) == Approx (0.5 / tan(igl::PI / 3.0)).margin( epsilon));
   }
 
   //Scale the cube to have tiny sides
@@ -130,9 +131,9 @@ TEST_CASE("cotmatrix_entries: simple", "[igl]")
   REQUIRE (C2.cols() == 3);
   for(int f = 0;f<C2.rows();f++)
   {
-    //Their (half)cotangent must value 0.5 / tan(M_PI / 3.0)
+    //Their (half)cotangent must value 0.5 / tan(igl::PI / 3.0)
     for(int v = 0;v<3;v++)
-       REQUIRE (C2(f,v) == Approx (0.5 / tan(M_PI / 3.0)).margin( epsilon));
+       REQUIRE (C2(f,v) == Approx (0.5 / tan(igl::PI / 3.0)).margin( epsilon));
   }
 }// TEST_CASE("cotmatrix_entries: simple", "[igl]")
 


### PR DESCRIPTION
In my windows environment with ~~VS2010~~ (Edit: VS2017), I get build errors due to unknown constant `M_PI`. Since `igl/PI.h` defines this constant internally, I replaced all references to `M_PI` in the code with `igl::PI`. I suppose this is the intended use anyhow.
After these changes, I can successfully run the build on my machine.



- [x ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [ x] This is a minor change.
