### PR TITLE
Corrected omission of return argument.

### DIFF
--- a/include/igl/serialize.h
+++ b/include/igl/serialize.h
@@ -502,10 +502,8 @@ namespace igl
       std::vector<char> buffer(size);
       file.read(&buffer[0],size);
  
-      deserialize(obj,objectName,buffer);
+      success = deserialize(obj, objectName, buffer);
       file.close();
- 
-      success = true;
     }
     else
     {


### PR DESCRIPTION
In the deserialization functionality of libigl, a return value indicating the success of the deserialization is ignored. As a result, the deserialization from a file always returns a success, as long as the file can be opened. With the change in this commit, a success is only returned if the file can be read **and** the variable could be deserialized.

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
