### PR TITLE
Fixed two memory leaks

### DIFF
--- a/include/igl/ply.h
+++ b/include/igl/ply.h
@@ -539,8 +539,11 @@ inline PlyFile *ply_open_for_writing(
 
   fp = fopen (name, "w");
   if (fp == NULL) {
+    free(name);
     return (NULL);
   }
+
+  free(name);
 
   /* create the actual PlyFile structure */
 
@@ -2253,6 +2256,7 @@ inline char **get_words(FILE *fp, int *nwords, char **orig_line)
   if (result == NULL) {
     *nwords = 0;
     *orig_line = NULL;
+    free(words);
     return (NULL);
   }
 
@@ -2316,7 +2320,15 @@ inline char **get_words(FILE *fp, int *nwords, char **orig_line)
     /* save pointer to beginning of word */
     if (num_words >= max_words) {
       max_words += 10;
-      words = (char **) realloc (words, sizeof (char *) * max_words);
+      char **temp = (char **) realloc (words, sizeof (char *) * max_words);
+
+      if(temp){
+          words = temp;
+      }
+      else{
+          free(words);
+          return NULL;
+      }
     }
     words[num_words++] = ptr;
 
@@ -2330,7 +2342,7 @@ inline char **get_words(FILE *fp, int *nwords, char **orig_line)
 
   /* return the list of words */
   *nwords = num_words;
-  *orig_line = str_copy;
+  *orig_line = str_copy; // ToDo: This looks like UB, returns pointer to local variable on stack.
   return (words);
 }
 

--- a/include/igl/xml/serialize_xml.cpp
+++ b/include/igl/xml/serialize_xml.cpp
@@ -124,7 +124,7 @@ namespace igl
       {
         std::cerr << "File not found!" << std::endl;
         doc->PrintError();
-        doc = NULL;
+        delete doc;
       }
       else
       {


### PR DESCRIPTION
As mentioned in #919 the ply.h implementation has several code quality issues. The suggested changes fix two memory leaks. One is caused by a missing free, another from improper handling when realloc fails. Additionally UB has been identified, because a pointer to a local variable is returned.

#### Check all that apply (change to `[x]`)
- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
