### PR TITLE
Update issue_template.md

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,8 +1,10 @@
 [Describe your issue]
 
+[**If you are using the `MASTER` branch, please check out the `DEV` branch before reporting any issue**]
+
 #### Check all that apply (change to `[x]`)
 - [ ] Windows
 - [ ] Mac OS X
 - [ ] Linux
 
-See <https://libigl.github.io/CONTRIBUTING/#bugreport> for more tips.
+See https://libigl.github.io/CONTRIBUTING/#bugreport for more tips.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -6,6 +6,6 @@
 - [ ] Windows
 - [ ] Mac OS X
 - [ ] Linux
-- [ ] Issue also occurs on the `dev` branch
+- [ ] I have tried the `dev` branch and the problem persists
 
 See https://libigl.github.io/CONTRIBUTING/#bugreport for more tips.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,10 +1,9 @@
 [Describe your issue]
 
-[**If you are using the `MASTER` branch, please check out the `DEV` branch before reporting any issue**]
-
 #### Check all that apply (change to `[x]`)
 - [ ] Windows
 - [ ] Mac OS X
 - [ ] Linux
+- [ ] Issue also occurs on the `dev` branch
 
 See https://libigl.github.io/CONTRIBUTING/#bugreport for more tips.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,4 +1,6 @@
-[Describe your issue]
+#### Describe your issue
+
+...
 
 #### Check all that apply (change to `[x]`)
 - [ ] Windows


### PR DESCRIPTION
We've been having a couple of issues reported against the master branch, which are already fixed in dev. We already have a [checklist](https://libigl.github.io/CONTRIBUTING/) on the website but nobody seems to read it. Seems to me we should at least add a line in the issue template about whether or not the user is on the `dev` branch. I'm not sure if we should make it another checklist though (people seems to read checklists).

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [x] This is a minor change.
