### PR TITLE
Bugfix in remesh_along_isoline.h

### DIFF
--- a/include/igl/remesh_along_isoline.h
+++ b/include/igl/remesh_along_isoline.h
@@ -28,7 +28,7 @@ namespace igl
   //  U  #U by dim list of mesh vertex positions #U>=#V
   //  G  #G by 3 list of mesh triangle indices into U, #G>=#F
   //  SU  #U list of scalar field values over new mesh
-  //  J  #G list of indices into G revealing birth triangles
+  //  J  #G list of indices into F revealing birth triangles
   //  BC  #U by #V sparse matrix of barycentric coordinates so that U = BC*V
   //  L  #G list of bools whether scalar field in triangle below or above val
   template <

--- a/include/igl/remesh_along_isoline.h
+++ b/include/igl/remesh_along_isoline.h
@@ -75,7 +75,7 @@ namespace igl
 }
 
 #ifndef IGL_STATIC_LIBRARY
-#  include "remesh_along_isoline.h"
+#  include "remesh_along_isoline.cpp"
 #endif
 
 #endif


### PR DESCRIPTION
[Describe your changes and what you've already done to test it.]
- Fix typo in the header documentation
- Solve linker error caused by typo in the bottom of the header file (including wrong file)

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
