### PR TITLE
Fix a issue in octree.

### DIFF
--- a/include/igl/octree.cpp
+++ b/include/igl/octree.cpp
@@ -106,7 +106,7 @@ namespace igl {
         for(ChildrenType i = 0; i < 8; i++){
           children.emplace_back(neg_ones);
           point_indices.emplace_back(std::vector<IndexType>());
-          centers.emplace_back(translate_center(curr_center,h,i));
+          centers.emplace_back(translate_center(curr_center,h/2,i));
           widths.emplace_back(h);
         }
 

--- a/include/igl/remesh_along_isoline.h
+++ b/include/igl/remesh_along_isoline.h
@@ -28,7 +28,7 @@ namespace igl
   //  U  #U by dim list of mesh vertex positions #U>=#V
   //  G  #G by 3 list of mesh triangle indices into U, #G>=#F
   //  SU  #U list of scalar field values over new mesh
-  //  J  #G list of indices into G revealing birth triangles
+  //  J  #G list of indices into F revealing birth triangles
   //  BC  #U by #V sparse matrix of barycentric coordinates so that U = BC*V
   //  L  #G list of bools whether scalar field in triangle below or above val
   template <


### PR DESCRIPTION
 For translating centre, the distance should be the half of width of the sub cell instead of the width h.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
