### PR TITLE
Viewer const accessors + use viewport size (fixes #1166, fixes #1167).

### DIFF
--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -124,7 +124,7 @@ namespace glfw
 {
 
   IGL_INLINE int Viewer::launch(bool resizable /*= true*/, bool fullscreen /*= false*/,
-    const std::string &name, int windowWidth /*= 1280*/, int windowHeight /*= 800*/)
+    const std::string &name, int windowWidth /*= 0*/, int windowHeight /*= 0*/)
   {
     // TODO return values are being ignored...
     launch_init(resizable,fullscreen,name,windowWidth,windowHeight);
@@ -153,9 +153,21 @@ namespace glfw
       GLFWmonitor *monitor = glfwGetPrimaryMonitor();
       const GLFWvidmode *mode = glfwGetVideoMode(monitor);
       window = glfwCreateWindow(mode->width,mode->height,name.c_str(),monitor,nullptr);
+      windowWidth = mode->width;
+      windowHeight = mode->height;
     }
     else
     {
+      // Set default windows width
+      if (windowWidth <= 0 & core_list.size() == 1 && core().viewport[2] > 0)
+        windowWidth = core().viewport[2];
+      else if (windowWidth <= 0)
+        windowWidth = 1280;
+      // Set default windows height
+      if (windowHeight <= 0 & core_list.size() == 1 && core().viewport[3] > 0)
+        windowHeight = core().viewport[3];
+      else if (windowHeight <= 0)
+        windowHeight = 800;
       window = glfwCreateWindow(windowWidth,windowHeight,name.c_str(),nullptr,nullptr);
     }
     if (!window)
@@ -988,6 +1000,20 @@ namespace glfw
     return data_list[index];
   }
 
+  IGL_INLINE const ViewerData& Viewer::data(int mesh_id /*= -1*/) const
+  {
+    assert(!data_list.empty() && "data_list should never be empty");
+    int index;
+    if (mesh_id == -1)
+      index = selected_data_index;
+    else
+      index = mesh_index(mesh_id);
+
+    assert((index >= 0 && index < data_list.size()) &&
+      "selected_data_index or mesh_id should be in bounds");
+    return data_list[index];
+  }
+
   IGL_INLINE int Viewer::append_mesh(bool visible /*= true*/)
   {
     assert(data_list.size() >= 1);
@@ -1032,6 +1058,18 @@ namespace glfw
   }
 
   IGL_INLINE ViewerCore& Viewer::core(unsigned core_id /*= 0*/)
+  {
+    assert(!core_list.empty() && "core_list should never be empty");
+    int core_index;
+    if (core_id == 0)
+      core_index = selected_core_index;
+    else
+      core_index = this->core_index(core_id);
+    assert((core_index >= 0 && core_index < core_list.size()) && "selected_core_index should be in bounds");
+    return core_list[core_index];
+  }
+
+  IGL_INLINE const ViewerCore& Viewer::core(unsigned core_id /*= 0*/) const
   {
     assert(!core_list.empty() && "core_list should never be empty");
     int core_index;

--- a/include/igl/opengl/glfw/Viewer.h
+++ b/include/igl/opengl/glfw/Viewer.h
@@ -45,8 +45,8 @@ namespace glfw
     // UI Enumerations
     enum class MouseButton {Left, Middle, Right};
     enum class MouseMode { None, Rotation, Zoom, Pan, Translation} mouse_mode;
-    IGL_INLINE int launch(bool resizable = true, bool fullscreen = false, const std::string &name = "libigl viewer", int width = 1280, int height = 800);
-    IGL_INLINE int launch_init(bool resizable = true, bool fullscreen = false, const std::string &name = "libigl viewer", int width = 1280, int height = 800);
+    IGL_INLINE int launch(bool resizable = true, bool fullscreen = false, const std::string &name = "libigl viewer", int width = 0, int height = 0);
+    IGL_INLINE int launch_init(bool resizable = true, bool fullscreen = false, const std::string &name = "libigl viewer", int width = 0, int height = 0);
     IGL_INLINE bool launch_rendering(bool loop = true);
     IGL_INLINE void launch_shut();
     IGL_INLINE void init();
@@ -89,6 +89,7 @@ namespace glfw
     // Inputs:
     //   mesh_id  unique identifier associated to the desired mesh (current mesh if -1)
     IGL_INLINE ViewerData& data(int mesh_id = -1);
+    IGL_INLINE const ViewerData& data(int mesh_id = -1) const;
 
     // Append a new "slot" for a mesh (i.e., create empty entries at the end of
     // the data_list and opengl_state_list.
@@ -133,6 +134,7 @@ namespace glfw
     // Inputs:
     //   core_id  unique identifier corresponding to the desired viewport (current viewport if 0)
     IGL_INLINE ViewerCore& core(unsigned core_id = 0);
+    IGL_INLINE const ViewerCore& core(unsigned core_id = 0) const;
 
     // Append a new "slot" for a viewport (i.e., copy properties of the current viewport, only
     // changing the viewport size/position)

--- a/python/modules/py_igl_opengl_glfw.cpp
+++ b/python/modules/py_igl_opengl_glfw.cpp
@@ -353,14 +353,6 @@ py::class_<igl::opengl::ViewerCore> viewercore_class(me, "ViewerCore");
 // UI Enumerations
     py::class_<igl::opengl::glfw::Viewer> viewer_class(me, "Viewer");
 
-//    #ifdef IGL_VIEWER_WITH_NANOGUI
-//    py::object fh = (py::object) py::module::import("nanogui").attr("FormHelper");
-//    py::class_<nanogui::FormHelper> form_helper_class(me, "FormHelper", fh);
-
-//    py::object screen = (py::object) py::module::import("nanogui").attr("Screen");
-//    py::class_<nanogui::Screen> screen_class(me, "Screen", screen);
-//    #endif
-
     py::enum_<igl::opengl::glfw::Viewer::MouseButton>(viewer_class, "MouseButton")
         .value("Left", igl::opengl::glfw::Viewer::MouseButton::Left)
         .value("Middle", igl::opengl::glfw::Viewer::MouseButton::Middle)
@@ -378,15 +370,11 @@ py::class_<igl::opengl::ViewerCore> viewercore_class(me, "ViewerCore");
     //   viewer.data() = data;
     // })
 
-    .def("data", &igl::opengl::glfw::Viewer::data,pybind11::return_value_policy::reference)
+    .def("data", (igl::opengl::ViewerData & (igl::opengl::glfw::Viewer::*)(int)) &igl::opengl::glfw::Viewer::data,pybind11::return_value_policy::reference)
+    // .def("data", (const igl::opengl::ViewerData & (igl::opengl::glfw::Viewer::*)(int) const) &igl::opengl::glfw::Viewer::data,pybind11::return_value_policy::reference)
 
     //.def_readwrite("core", &igl::opengl::glfw::Viewer::core)
     //.def_readwrite("opengl", &igl::opengl::glfw::Viewer::opengl)
-
-    #ifdef IGL_VIEWER_WITH_NANOGUI
-    .def_readwrite("ngui", &igl::opengl::glfw::Viewer::ngui)
-    .def_readwrite("screen", &igl::opengl::glfw::Viewer::screen)
-    #endif
 
     .def("launch", &igl::opengl::glfw::Viewer::launch, py::arg("resizable") = true,
       py::arg("fullscreen") = false, py::arg("name") = "libigl viewer",


### PR DESCRIPTION
See #1166 and #1167 for more details.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [x] Adds corresponding python binding.
- [x] This is a minor change.
