### PR TITLE
Fix on linux path_to_executable()

### DIFF
--- a/include/igl/path_to_executable.cpp
+++ b/include/igl/path_to_executable.cpp
@@ -13,6 +13,7 @@
 #  include <windows.h>
 #endif
 #include <stdint.h>
+#include <unistd.h>
 IGL_INLINE std::string igl::path_to_executable()
 {
   // http://pastebin.com/ffzzxPzi
@@ -28,10 +29,11 @@ IGL_INLINE std::string igl::path_to_executable()
   {
     path = buffer;
   }
-#elif defined(UNIX)
-  if (readlink("/proc/self/exe", buffer, sizeof(buffer)) == -1)
+#elif defined(UNIX) || defined(unix) || defined(__unix) || defined(__unix__)
+  int byte_count = readlink("/proc/self/exe", buffer, size);
+  if (byte_count  != -1)
   {
-    path = buffer;
+    path = std::string(buffer, byte_count);
   }
 #elif defined(__FreeBSD__)
   int mib[4];

--- a/include/igl/path_to_executable.cpp
+++ b/include/igl/path_to_executable.cpp
@@ -11,9 +11,11 @@
 #endif
 #if defined(_WIN32)
 #  include <windows.h>
+#else
+  #include <unistd.h>
 #endif
 #include <stdint.h>
-#include <unistd.h>
+
 IGL_INLINE std::string igl::path_to_executable()
 {
   // http://pastebin.com/ffzzxPzi

--- a/tests/include/igl/path_to_executable.cpp
+++ b/tests/include/igl/path_to_executable.cpp
@@ -8,8 +8,8 @@ TEST_CASE("path_to_executable: example", "[igl]")
 {
   std::string path_to_executable = igl::path_to_executable();
   REQUIRE(0 < path_to_executable.size());
-  // check if path_to_executable ends with correct file name
-  std::string ending = "libigl_tests";
-  REQUIRE(ending.size() < path_to_executable.size());
-  REQUIRE(std::equal(ending.rbegin(), ending.rend(), path_to_executable.rbegin()));
+  // check if path_to_executable ends with correct file name, on windows .exe suffix is added.
+  std::string executable = "libigl_tests";
+  int pos = path_to_executable.length()-(executable.length() + 4/*".exe"*/);
+  REQUIRE( std::string::npos != path_to_executable.find(executable, pos));
 }

--- a/tests/include/igl/path_to_executable.cpp
+++ b/tests/include/igl/path_to_executable.cpp
@@ -1,0 +1,15 @@
+#include <test_common.h>
+#include <igl/path_to_executable.h>
+
+#include <iostream>
+
+
+TEST_CASE("path_to_executable: example", "[igl]")
+{
+  std::string path_to_executable = igl::path_to_executable();
+  REQUIRE(0 < path_to_executable.size());
+  // check if path_to_executable ends with correct file name
+  std::string ending = "libigl_tests";
+  REQUIRE(ending.size() < path_to_executable.size());
+  REQUIRE(std::equal(ending.rbegin(), ending.rend(), path_to_executable.rbegin()));
+}


### PR DESCRIPTION
 Added symboles to check for in path_to_executable() because capital case UNIX is not defined under Linux (i.e. Ubuntu).

Lowercase unix is defined however. See: https://stackoverflow.com/questions/142508/how-do-i-check-os-with-a-preprocessor-directive
Also added missing include for readlink().
readlink() does not append a null byte, thus use information about the written byted when building the resulting string.



#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [x] Adds new .cpp file.
- [x] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
