### PR TITLE
✨ Enable OpenMP for MSVC users (#1147)

### DIFF
--- a/include/igl/signed_distance.cpp
+++ b/include/igl/signed_distance.cpp
@@ -291,7 +291,7 @@ IGL_INLINE void igl::signed_distance_pseudonormal(
   C.resize(np,3);
   typedef typename AABB<DerivedV,3>::RowVectorDIMS RowVector3S;
 # pragma omp parallel for if(np>1000)
-  for(size_t p = 0;p<np;p++)
+  for(std::ptrdiff_t p = 0;p<np;p++)
   {
     typename DerivedV::Scalar s,sqrd;
     RowVector3S n,c;


### PR DESCRIPTION
Changed `size_t` → `std::ptrdiff_t` for OpenMP2.0 compatibility; now compiles without issue on MSVC

- [X] This is a minor change.
