### PR TITLE
file_dialog_open/save fixes

### DIFF
--- a/include/igl/file_dialog_open.cpp
+++ b/include/igl/file_dialog_open.cpp
@@ -33,7 +33,7 @@ IGL_INLINE std::string igl::file_dialog_open()
     "   end tell\n"
     "   set existing_file_path to (POSIX path of (existing_file))\n"
     "\" 2>/dev/null | tr -d '\n' ","r");
-  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL)
+  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL || ferror(output))
   {
     buffer[0] = '\0';
   }
@@ -76,7 +76,7 @@ IGL_INLINE std::string igl::file_dialog_open()
   
   // For linux use zenity
   FILE * output = popen("/usr/bin/zenity --file-selection","r");
-  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL)
+  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL || ferror(output))
   {
     buffer[0] = '\0';
   }

--- a/include/igl/file_dialog_open.cpp
+++ b/include/igl/file_dialog_open.cpp
@@ -1,9 +1,9 @@
 // This file is part of libigl, a simple c++ geometry processing library.
-// 
+//
 // Copyright (C) 2014 Daniele Panozzo <daniele.panozzo@gmail.com>
-// 
-// This Source Code Form is subject to the terms of the Mozilla Public License 
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 #include "file_dialog_open.h"
 #include <cstdio>
@@ -13,7 +13,7 @@
   #include <windows.h>
   #undef max
   #undef min
-  
+
   #include <Commdlg.h>
 #endif
 
@@ -22,7 +22,8 @@ IGL_INLINE std::string igl::file_dialog_open()
   const int FILE_DIALOG_MAX_BUFFER = 1024;
   char buffer[FILE_DIALOG_MAX_BUFFER];
   buffer[0] = '\0';
-  
+  buffer[FILE_DIALOG_MAX_BUFFER - 1] = 'x'; // Initialize last character with a char != '\0'
+
 #ifdef __APPLE__
   // For apple use applescript hack
   FILE * output = popen(
@@ -33,12 +34,22 @@ IGL_INLINE std::string igl::file_dialog_open()
     "   end tell\n"
     "   set existing_file_path to (POSIX path of (existing_file))\n"
     "\" 2>/dev/null | tr -d '\n' ","r");
-  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL || ferror(output))
+  if (output)
   {
-    buffer[0] = '\0';
+    auto ret = fgets(buffer, FILE_DIALOG_MAX_BUFFER, output);
+    if (ret == NULL || ferror(output))
+    {
+      // I/O error
+      buffer[0] = '\0';
+    }
+    if (buffer[FILE_DIALOG_MAX_BUFFER - 1] == '\0')
+    {
+      // File name too long, buffer has been filled, so we return empty string instead
+      buffer[0] = '\0';
+    }
   }
 #elif defined _WIN32
-  
+
   // Use native windows file dialog box
   // (code contributed by Tino Weinkauf)
 
@@ -50,7 +61,7 @@ IGL_INLINE std::string igl::file_dialog_open()
   ofn.lStructSize = sizeof(ofn);
   ofn.hwndOwner = NULL;
   ofn.lpstrFile = new char[100];
-  // Set lpstrFile[0] to '\0' so that GetOpenFileName does not 
+  // Set lpstrFile[0] to '\0' so that GetOpenFileName does not
   // use the contents of szFile to initialize itself.
   ofn.lpstrFile[0] = '\0';
   ofn.nMaxFile = sizeof(szFile);
@@ -61,7 +72,7 @@ IGL_INLINE std::string igl::file_dialog_open()
   ofn.lpstrInitialDir = NULL;
   ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
 
-  // Display the Open dialog box. 
+  // Display the Open dialog box.
   int pos = 0;
   if (GetOpenFileName(&ofn)==TRUE)
   {
@@ -70,17 +81,28 @@ IGL_INLINE std::string igl::file_dialog_open()
       buffer[pos] = (char)ofn.lpstrFile[pos];
       pos++;
     }
-  } 
+  }
   buffer[pos] = 0;
 #else
-  
+
   // For linux use zenity
   FILE * output = popen("/usr/bin/zenity --file-selection","r");
-  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL || ferror(output))
+  if (output)
   {
-    buffer[0] = '\0';
+    auto ret = fgets(buffer, FILE_DIALOG_MAX_BUFFER, output);
+    if (ret == NULL || ferror(output))
+    {
+      // I/O error
+      buffer[0] = '\0';
+    }
+    if (buffer[FILE_DIALOG_MAX_BUFFER - 1] == '\0')
+    {
+      // File name too long, buffer has been filled, so we return empty string instead
+      buffer[0] = '\0';
+    }
   }
 
+  // Replace last '\n' by '\0'
   if(strlen(buffer) > 0)
   {
     buffer[strlen(buffer)-1] = '\0';

--- a/include/igl/file_dialog_open.cpp
+++ b/include/igl/file_dialog_open.cpp
@@ -21,6 +21,7 @@ IGL_INLINE std::string igl::file_dialog_open()
 {
   const int FILE_DIALOG_MAX_BUFFER = 1024;
   char buffer[FILE_DIALOG_MAX_BUFFER];
+  buffer[0] = '\0';
   
 #ifdef __APPLE__
   // For apple use applescript hack
@@ -32,8 +33,9 @@ IGL_INLINE std::string igl::file_dialog_open()
     "   end tell\n"
     "   set existing_file_path to (POSIX path of (existing_file))\n"
     "\" 2>/dev/null | tr -d '\n' ","r");
-  while ( fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL )
+  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL)
   {
+    buffer[0] = '\0';
   }
 #elif defined _WIN32
   
@@ -74,14 +76,16 @@ IGL_INLINE std::string igl::file_dialog_open()
   
   // For linux use zenity
   FILE * output = popen("/usr/bin/zenity --file-selection","r");
-  while ( fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL )
+  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL)
   {
+    buffer[0] = '\0';
   }
-  
-  if (strlen(buffer) > 0)
+
+  if(strlen(buffer) > 0)
   {
-    buffer[strlen(buffer)-1] = 0;
+    buffer[strlen(buffer)-1] = '\0';
   }
+
 #endif
   return std::string(buffer);
 }

--- a/include/igl/file_dialog_save.cpp
+++ b/include/igl/file_dialog_save.cpp
@@ -32,7 +32,7 @@ IGL_INLINE std::string igl::file_dialog_save()
     "   end tell\n"
     "   set existing_file_path to (POSIX path of (existing_file))\n"
     "\" 2>/dev/null | tr -d '\n' ","r");
-  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL)
+  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL || ferror(output))
   {
     buffer[0] = '\0';
   }
@@ -75,7 +75,7 @@ IGL_INLINE std::string igl::file_dialog_save()
 #else
   // For every other machine type use zenity
   FILE * output = popen("/usr/bin/zenity --file-selection --save","r");
-  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL)
+  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL || ferror(output))
   {
     buffer[0] = '\0';
   }

--- a/include/igl/file_dialog_save.cpp
+++ b/include/igl/file_dialog_save.cpp
@@ -18,6 +18,7 @@ IGL_INLINE std::string igl::file_dialog_save()
 {
   const int FILE_DIALOG_MAX_BUFFER = 1024;
   char buffer[FILE_DIALOG_MAX_BUFFER];
+  buffer[0] = '\0';
 #ifdef __APPLE__
   // For apple use applescript hack
   // There is currently a bug in Applescript that strips extensions off
@@ -31,8 +32,9 @@ IGL_INLINE std::string igl::file_dialog_save()
     "   end tell\n"
     "   set existing_file_path to (POSIX path of (existing_file))\n"
     "\" 2>/dev/null | tr -d '\n' ","r");
-  while ( fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL )
+  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL)
   {
+    buffer[0] = '\0';
   }
 #elif defined _WIN32
 
@@ -73,14 +75,16 @@ IGL_INLINE std::string igl::file_dialog_save()
 #else
   // For every other machine type use zenity
   FILE * output = popen("/usr/bin/zenity --file-selection --save","r");
-  while ( fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL )
+  if( !output || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) == NULL || fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL)
   {
+    buffer[0] = '\0';
   }
   
-  if (strlen(buffer) > 0)
+  if(strlen(buffer) > 0)
   {
-    buffer[strlen(buffer)-1] = 0;
+    buffer[strlen(buffer)-1] = '\0';
   }
+  
 #endif
   return std::string(buffer);
 }


### PR DESCRIPTION
Attempt to fix several issues with the libigl file dialogs, so that they correctly return an empty string rather than garbage when:
 - the user cancels the dialog
 - the user selects a file somehow longer than the 1024-character limit
 - the file selection using zenity etc. fails for any other reason.

There is a strange erasure of the last character in the Linux version
(presumably to remove some trailing newline?) that I did not touch.

Fixes #1209.

#### Check all that apply (change to `[x]`)
- [X] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [X] This is a minor change.
