### PR TITLE
Default arg for igl.glfw.Viewer().data() => mesh_id -1

### DIFF
--- a/python/modules/py_igl_opengl_glfw.cpp
+++ b/python/modules/py_igl_opengl_glfw.cpp
@@ -370,7 +370,7 @@ py::class_<igl::opengl::ViewerCore> viewercore_class(me, "ViewerCore");
     //   viewer.data() = data;
     // })
 
-    .def("data", (igl::opengl::ViewerData & (igl::opengl::glfw::Viewer::*)(int)) &igl::opengl::glfw::Viewer::data,pybind11::return_value_policy::reference)
+    .def("data", (igl::opengl::ViewerData & (igl::opengl::glfw::Viewer::*)(int)) &igl::opengl::glfw::Viewer::data, pybind11::return_value_policy::reference, py::arg("mesh_id")=-1)
     // .def("data", (const igl::opengl::ViewerData & (igl::opengl::glfw::Viewer::*)(int) const) &igl::opengl::glfw::Viewer::data,pybind11::return_value_policy::reference)
 
     //.def_readwrite("core", &igl::opengl::glfw::Viewer::core)


### PR DESCRIPTION
Due to the changes in glfw::Viewer one should pass a parameter when calling data() to select a mesh. In C++ mesh_id=-1 by default ( the last element). This commit adds this behaviour for the python bindings.

For corresponding C++ code see: https://github.com/libigl/libigl/blob/dev/include/igl/opengl/glfw/Viewer.h#L91

This fixes #1211 and makes the previous usages of ` igl.glfw.Viewer().data()` python code work again.  

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
