### PR TITLE
Python: igl.glfw.Viewer().core => igl.glfw.Viewer().core() with default arg unsigned core_id = 0

### DIFF
--- a/python/modules/py_igl_opengl_glfw.cpp
+++ b/python/modules/py_igl_opengl_glfw.cpp
@@ -373,6 +373,7 @@ py::class_<igl::opengl::ViewerCore> viewercore_class(me, "ViewerCore");
     .def("data", (igl::opengl::ViewerData & (igl::opengl::glfw::Viewer::*)(int)) &igl::opengl::glfw::Viewer::data,pybind11::return_value_policy::reference)
     // .def("data", (const igl::opengl::ViewerData & (igl::opengl::glfw::Viewer::*)(int) const) &igl::opengl::glfw::Viewer::data,pybind11::return_value_policy::reference)
 
+    .def("core", (igl::opengl::ViewerCore & (igl::opengl::glfw::Viewer::*)(unsigned)) &igl::opengl::glfw::Viewer::core, pybind11::return_value_policy::reference, py::arg("core_id")=0)
     //.def_readwrite("core", &igl::opengl::glfw::Viewer::core)
     //.def_readwrite("opengl", &igl::opengl::glfw::Viewer::opengl)
 

--- a/python/tutorial/103_Events.py
+++ b/python/tutorial/103_Events.py
@@ -35,11 +35,11 @@ def key_pressed(viewer, key, modifier):
         # # If a mesh is already displayed, draw_mesh returns an error if the given V and
         # # F have size different than the current ones
         viewer.data().set_mesh(V1, F1)
-        viewer.core.align_camera_center(V1,F1)
+        viewer.core().align_camera_center(V1,F1)
     elif key == ord('2'):
         viewer.data().clear()
         viewer.data().set_mesh(V2, F2)
-        viewer.core.align_camera_center(V2,F2)
+        viewer.core().align_camera_center(V2,F2)
     return False
 
 

--- a/python/tutorial/205_Laplacian.py
+++ b/python/tutorial/205_Laplacian.py
@@ -101,7 +101,7 @@ def key_pressed(viewer, key, modifier):
     # Send new positions, update normals, recenter
     viewer.data().set_vertices(U)
     viewer.data().compute_normals()
-    viewer.core.align_camera_center(U, F)
+    viewer.core().align_camera_center(U, F)
     return True
 
 

--- a/python/tutorial/401_BiharmonicDeformation.py
+++ b/python/tutorial/401_BiharmonicDeformation.py
@@ -35,7 +35,7 @@ b = igl.eigen.MatrixXi()
 def pre_draw(viewer):
     global bc_frac, bc_dir, deformation_field, V, U, V_bc, U_bc, F, b
     # Determine boundary conditions
-    if (viewer.core.is_animating):
+    if (viewer.core().is_animating):
         bc_frac += bc_dir
         bc_dir *= (-1.0 if bc_frac >= 1.0 or bc_frac <= 0.0 else 1.0)
 
@@ -58,7 +58,7 @@ def key_down(viewer, key, mods):
     global bc_frac, bc_dir, deformation_field, V, U, V_bc, U_bc, F, b
 
     if key == ord(' '):
-        viewer.core.is_animating = not viewer.core.is_animating
+        viewer.core().is_animating = not viewer.core().is_animating
         return True
     if key == ord('D') or key == ord('d'):
         deformation_field = not deformation_field
@@ -110,13 +110,13 @@ viewer = igl.glfw.Viewer()
 viewer.data().set_mesh(U, F)
 viewer.data().show_lines = False
 viewer.data().set_colors(C)
-# viewer.core.trackball_angle = igl.eigen.Quaterniond(sqrt(2.0),0,sqrt(2.0),0)
-# viewer.core.trackball_angle.normalize()
+# viewer.core().trackball_angle = igl.eigen.Quaterniond(sqrt(2.0),0,sqrt(2.0),0)
+# viewer.core().trackball_angle.normalize()
 
 viewer.callback_pre_draw = pre_draw
 viewer.callback_key_down = key_down
 
-viewer.core.animation_max_fps = 30.0
+viewer.core().animation_max_fps = 30.0
 print("Press [space] to toggle deformation.")
 print("Press 'd' to toggle between biharmonic surface or displacements.")
 viewer.launch()

--- a/python/tutorial/402_PolyharmonicDeformation.py
+++ b/python/tutorial/402_PolyharmonicDeformation.py
@@ -46,7 +46,7 @@ def pre_draw(viewer):
     viewer.data().set_vertices(U)
     viewer.data().compute_normals()
 
-    if viewer.core.is_animating:
+    if viewer.core().is_animating:
         z_max += z_dir
         z_dir *= (-1.0 if z_max >= 1.0 or z_max <= 0.0 else 1.0)
 
@@ -57,7 +57,7 @@ def key_down(viewer, key, mods):
     global z_max, z_dir, k, resolve, V, U, Z, F, b, bc
 
     if key == ord(' '):
-        viewer.core.is_animating = not viewer.core.is_animating
+        viewer.core().is_animating = not viewer.core().is_animating
     elif key == ord('.'):
         k = k + 1
         k = (4 if k > 4 else k)
@@ -102,12 +102,12 @@ viewer = igl.glfw.Viewer()
 viewer.data().set_mesh(U, F)
 viewer.data().show_lines = False
 viewer.data().set_colors(C)
-viewer.core.trackball_angle = igl.eigen.Quaterniond(0.81,-0.58,-0.03,-0.03)
-viewer.core.trackball_angle.normalize()
+viewer.core().trackball_angle = igl.eigen.Quaterniond(0.81,-0.58,-0.03,-0.03)
+viewer.core().trackball_angle.normalize()
 viewer.callback_pre_draw = pre_draw
 viewer.callback_key_down = key_down
-viewer.core.is_animating = True
-viewer.core.animation_max_fps = 30.0
+viewer.core().is_animating = True
+viewer.core().animation_max_fps = 30.0
 print("Press [space] to toggle animation.")
 print("Press '.' to increase k.")
 print("Press ',' to decrease k.")

--- a/python/tutorial/403_BoundedBiharmonicWeights.py
+++ b/python/tutorial/403_BoundedBiharmonicWeights.py
@@ -22,7 +22,7 @@ check_dependencies(dependencies)
 def pre_draw(viewer):
     global pose, anim_t, C, BE, P, U, M, anim_t_dir
 
-    if viewer.core.is_animating:
+    if viewer.core().is_animating:
         # Interpolate pose and identity
         anim_pose = igl.RotationList(len(pose))
 
@@ -69,7 +69,7 @@ def key_down(viewer, key, mods):
         selected = min(max(selected, 0), W.cols()-1)
         set_color(viewer)
     elif key == ord(' '):
-        viewer.core.is_animating = not viewer.core.is_animating
+        viewer.core().is_animating = not viewer.core().is_animating
 
     return True
 
@@ -146,9 +146,9 @@ if __name__ == "__main__":
     viewer.data().show_lines = False
     viewer.data().show_overlay_depth = False
     viewer.data().line_width = 1
-    viewer.core.trackball_angle.normalize()
+    viewer.core().trackball_angle.normalize()
     viewer.callback_pre_draw = pre_draw
     viewer.callback_key_down = key_down
-    viewer.core.is_animating = False
-    viewer.core.animation_max_fps = 30.0
+    viewer.core().is_animating = False
+    viewer.core().animation_max_fps = 30.0
     viewer.launch()

--- a/python/tutorial/404_DualQuaternionSkinning.py
+++ b/python/tutorial/404_DualQuaternionSkinning.py
@@ -62,7 +62,7 @@ def pre_draw(viewer):
         viewer.data().set_vertices(U)
         viewer.data().set_edges(CT, BET, sea_green)
         viewer.data().compute_normals()
-        if viewer.core.is_animating:
+        if viewer.core().is_animating:
             anim_t += anim_t_dir
         else:
             recompute = False
@@ -75,7 +75,7 @@ def key_down(viewer, key, mods):
     recompute = True
     if key == ord('D') or key == ord('d'):
         use_dqs = not use_dqs
-        viewer.core.is_animating = False
+        viewer.core().is_animating = False
         animation = False
         if use_dqs:
             print("Switched to Dual Quaternion Skinning")
@@ -83,10 +83,10 @@ def key_down(viewer, key, mods):
             print("Switched to Linear Blend Skinning")
     elif key == ord(' '):
         if animation:
-            viewer.core.is_animating = False
+            viewer.core().is_animating = False
             animation = False
         else:
-            viewer.core.is_animating = True
+            viewer.core().is_animating = True
             animation = True
     return False
 
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     anim_t_dir = 0.015
     use_dqs = False
     recompute = True
-    animation = False  # Flag needed as there is some synchronization problem with viewer.core.is_animating
+    animation = False  # Flag needed as there is some synchronization problem with viewer.core().is_animating
 
     poses = [[]]
 
@@ -140,10 +140,10 @@ if __name__ == "__main__":
     viewer.data().show_lines = False
     viewer.data().show_overlay_depth = False
     viewer.data().line_width = 1
-    viewer.core.trackball_angle.normalize()
+    viewer.core().trackball_angle.normalize()
     viewer.callback_pre_draw = pre_draw
     viewer.callback_key_down = key_down
-    viewer.core.is_animating = False
-    viewer.core.camera_zoom = 2.5
-    viewer.core.animation_max_fps = 30.0
+    viewer.core().is_animating = False
+    viewer.core().camera_zoom = 2.5
+    viewer.core().animation_max_fps = 30.0
     viewer.launch()

--- a/python/tutorial/405_AsRigidAsPossible.py
+++ b/python/tutorial/405_AsRigidAsPossible.py
@@ -60,7 +60,7 @@ def pre_draw(viewer):
     viewer.data().set_vertices(U)
     viewer.data().compute_normals()
 
-    if viewer.core.is_animating:
+    if viewer.core().is_animating:
         anim_t += anim_t_dir
 
     return False
@@ -68,7 +68,7 @@ def pre_draw(viewer):
 
 def key_down(viewer, key, mods):
     if key == ord(' '):
-        viewer.core.is_animating = not viewer.core.is_animating
+        viewer.core().is_animating = not viewer.core().is_animating
         return True
     return False
 
@@ -105,7 +105,7 @@ viewer.data().set_mesh(U, F)
 viewer.data().set_colors(C)
 viewer.callback_pre_draw = pre_draw
 viewer.callback_key_down = key_down
-viewer.core.is_animating = True
-viewer.core.animation_max_fps = 30.
+viewer.core().is_animating = True
+viewer.core().animation_max_fps = 30.
 print("Press [space] to toggle animation")
 viewer.launch()

--- a/python/tutorial/501_HarmonicParam.py
+++ b/python/tutorial/501_HarmonicParam.py
@@ -28,11 +28,11 @@ def key_down(viewer, key, modifier):
     if key == ord('1'):
         # Plot the 3D mesh
         viewer.data().set_mesh(V, F)
-        viewer.core.align_camera_center(V, F)
+        viewer.core().align_camera_center(V, F)
     elif key == ord('2'):
         # Plot the mesh in 2D using the UV coordinates as vertex coordinates
         viewer.data().set_mesh(V_uv, F)
-        viewer.core.align_camera_center(V_uv, F)
+        viewer.core().align_camera_center(V_uv, F)
     viewer.data().compute_normals()
     return False
 

--- a/python/tutorial/502_LSCMParam.py
+++ b/python/tutorial/502_LSCMParam.py
@@ -28,11 +28,11 @@ def key_down(viewer, key, modifier):
     if key == ord('1'):
         # Plot the 3D mesh
         viewer.data().set_mesh(V, F)
-        viewer.core.align_camera_center(V, F)
+        viewer.core().align_camera_center(V, F)
     elif key == ord('2'):
         # Plot the mesh in 2D using the UV coordinates as vertex coordinates
         viewer.data().set_mesh(V_uv, F)
-        viewer.core.align_camera_center(V_uv, F)
+        viewer.core().align_camera_center(V_uv, F)
     viewer.data().compute_normals()
     return False
 

--- a/python/tutorial/503_ARAPParam.py
+++ b/python/tutorial/503_ARAPParam.py
@@ -38,10 +38,10 @@ def key_down(viewer, key, modifier):
 
     if show_uv:
         viewer.data().set_mesh(V_uv, F)
-        viewer.core.align_camera_center(V_uv, F)
+        viewer.core().align_camera_center(V_uv, F)
     else:
         viewer.data().set_mesh(V, F)
-        viewer.core.align_camera_center(V, F)
+        viewer.core().align_camera_center(V, F)
 
     viewer.data().compute_normals()
     return False

--- a/python/tutorial/505_MIQ.py
+++ b/python/tutorial/505_MIQ.py
@@ -205,7 +205,7 @@ def key_down(viewer, key, modifier):
 
     viewer.data().set_texture(texture_R, texture_B, texture_G)
 
-    viewer.core.align_camera_center(viewer.data().V, viewer.data().F)
+    viewer.core().align_camera_center(viewer.data().V, viewer.data().F)
 
     return False
 

--- a/python/tutorial/606_AmbientOcclusion.py
+++ b/python/tutorial/606_AmbientOcclusion.py
@@ -43,13 +43,13 @@ def key_down(viewer, key, modifier):
             C.setRow(i, C.row(i) * AO[i, 0])
         viewer.data().set_colors(C)
     elif key == ord('.'):
-        viewer.core.lighting_factor += 0.1
+        viewer.core().lighting_factor += 0.1
     elif key == ord(','):
-        viewer.core.lighting_factor -= 0.1
+        viewer.core().lighting_factor -= 0.1
     else:
         return False
 
-    viewer.core.lighting_factor = min(max(viewer.core.lighting_factor, 0.0), 1.0)
+    viewer.core().lighting_factor = min(max(viewer.core().lighting_factor, 0.0), 1.0)
     return True
 
 
@@ -70,5 +70,5 @@ viewer.data().set_mesh(V, F)
 key_down(viewer, ord('2'), 0)
 viewer.callback_key_down = key_down
 viewer.data().show_lines = False
-viewer.core.lighting_factor = 0.0
+viewer.core().lighting_factor = 0.0
 viewer.launch()

--- a/python/tutorial/607_ScreenCapture.py
+++ b/python/tutorial/607_ScreenCapture.py
@@ -29,7 +29,7 @@ def key_down(viewer, key, modifier):
         A = igl.eigen.MatrixXuc(1280, 800)
 
         # Draw the scene in the buffers
-        viewer.core.draw_buffer(viewer.data(), False, R, G, B, A)
+        viewer.core().draw_buffer(viewer.data(), False, R, G, B, A)
 
         # Save it to a PNG
         igl.png.writePNG(R, G, B, A, temp_png)
@@ -56,7 +56,7 @@ def key_down(viewer, key, modifier):
         viewer.data().clear()
         viewer.data().set_mesh(V, F)
         viewer.data().set_uv(UV)
-        viewer.core.align_camera_center(V)
+        viewer.core().align_camera_center(V)
         viewer.data().show_texture = True
 
         # Use the image as a texture

--- a/python/tutorial/609_Boolean.py
+++ b/python/tutorial/609_Boolean.py
@@ -50,9 +50,9 @@ def key_down(viewer, key, modifier):
     elif key == ord(','):
         boolean_type = boolean_types[(boolean_types.index(boolean_type) + len(boolean_types) - 1) % len(boolean_types)]
     elif key == ord('['):
-        viewer.core.camera_dnear -= 0.1
+        viewer.core().camera_dnear -= 0.1
     elif key == ord(']'):
-        viewer.core.camera_dnear += 0.1
+        viewer.core().camera_dnear += 0.1
     else:
         return False
 
@@ -88,5 +88,5 @@ if __name__ == "__main__":
 
     viewer.data().show_lines = True
     viewer.callback_key_down = key_down
-    viewer.core.camera_dnear = 3.9
+    viewer.core().camera_dnear = 3.9
     viewer.launch()

--- a/python/tutorial/704_SignedDistance.py
+++ b/python/tutorial/704_SignedDistance.py
@@ -97,7 +97,7 @@ def update_visualization(viewer):
     viewer.data().clear()
     viewer.data().set_mesh(V_vis, F_vis)
     viewer.data().set_colors(C_vis)
-    viewer.core.lighting_factor = overlay
+    viewer.core().lighting_factor = overlay
 
 
 def key_down(viewer, key, modifier):

--- a/python/tutorial/707_SweptVolume.py
+++ b/python/tutorial/707_SweptVolume.py
@@ -33,7 +33,7 @@ def key_down(viewer, key, modifier):
         else:
             viewer.data().set_mesh(V, F)
 
-        viewer.core.is_animating = not show_swept_volume
+        viewer.core().is_animating = not show_swept_volume
         viewer.data().set_face_based(True)
 
     return True
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     viewer = igl.glfw.Viewer()
     viewer.data().set_mesh(V, F)
     viewer.data().set_face_based(True)
-    viewer.core.is_animating = not show_swept_volume
+    viewer.core().is_animating = not show_swept_volume
     viewer.callback_pre_draw = pre_draw
     viewer.callback_key_down = key_down
     viewer.launch()

--- a/python/tutorial/708_Picking.py
+++ b/python/tutorial/708_Picking.py
@@ -25,9 +25,9 @@ def mouse_down(viewer, a, b):
 
     # Cast a ray in the view direction starting from the mouse position
     fid = igl.eigen.MatrixXi(np.array([-1]))
-    coord = igl.eigen.MatrixXd([viewer.current_mouse_x, viewer.core.viewport[3] - viewer.current_mouse_y])
-    hit = igl.unproject_onto_mesh(coord, viewer.core.view,
-      viewer.core.proj, viewer.core.viewport, V, F, fid, bc)
+    coord = igl.eigen.MatrixXd([viewer.current_mouse_x, viewer.core().viewport[3] - viewer.current_mouse_y])
+    hit = igl.unproject_onto_mesh(coord, viewer.core().view,
+      viewer.core().proj, viewer.core().viewport, V, F, fid, bc)
     if hit:
         # paint hit red
         C.setRow(fid[0, 0], igl.eigen.MatrixXd([[1, 0, 0]]))

--- a/python/tutorial/709_VectorFieldVisualizer.py
+++ b/python/tutorial/709_VectorFieldVisualizer.py
@@ -53,7 +53,7 @@ def representative_to_nrosy(V, F, R, N, Y):
 
 
 def pre_draw(viewer):
-    if not viewer.core.is_animating:
+    if not viewer.core().is_animating:
         return False
 
     global anim_t
@@ -77,7 +77,7 @@ def pre_draw(viewer):
 
 def key_down(viewer, key, modifier):
     if key == ord(' '):
-        viewer.core.is_animating = not viewer.core.is_animating
+        viewer.core().is_animating = not viewer.core().is_animating
         return True
 
     return False
@@ -107,10 +107,10 @@ def main():
     viewer.callback_pre_draw = pre_draw
     viewer.callback_key_down = key_down
 
-    viewer.core.show_lines = False
+    viewer.core().show_lines = False
 
-    viewer.core.is_animating = False
-    viewer.core.animation_max_fps = 30.0
+    viewer.core().is_animating = False
+    viewer.core().animation_max_fps = 30.0
 
     # Paint mesh grayish
     C = igl.eigen.MatrixXd()


### PR DESCRIPTION
Expose igl.glfw.Viewer.core() the same way as in C++ and set defallt argument.
Replace 'viewer.core' with 'viewer.core()' in python tutorials. Use same API style like in C++. (However some other functions for multiple viewport support do not have python bindings.)

Together with #1220 this fixes #1225 
Tested various other python tutorials, they seam to work now.


#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [x] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
