### PR TITLE
fix #1230: Heat geodesics example crashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,14 +41,17 @@ matrix:
     env:
     - MATRIX_EVAL="export CC=gcc-7 CXX=g++-7 CONFIG=Release PYTHON=python3 CMAKE_EXTRA='-DLIBIGL_EIGEN_VERSION=3.3.7'"
   - os: osx
+    osx_image: xcode10.2
     compiler: clang
     env:
     - MATRIX_EVAL="export CONFIG=Debug PYTHON=python3 LIBIGL_NUM_THREADS=1"
   - os: osx # same config like above but with -DLIBIGL_USE_STATIC_LIBRARY=OFF to test static and header-only builds
+    osx_image: xcode10.2
     compiler: clang
     env:
     - MATRIX_EVAL="export CONFIG=Debug PYTHON=python3 LIBIGL_NUM_THREADS=1 CMAKE_EXTRA='-DLIBIGL_USE_STATIC_LIBRARY=OFF'"
   - os: osx
+    osx_image: xcode10.2
     compiler: clang
     env:
     - MATRIX_EVAL="export CONFIG=Debug PYTHON=python3 LIBIGL_NUM_THREADS=1 CMAKE_EXTRA='-DLIBIGL_EIGEN_VERSION=3.3.7'""

--- a/cmake/libigl-cgal.yml
+++ b/cmake/libigl-cgal.yml
@@ -1,0 +1,8 @@
+# This is a conda environment that can be used to compile libigl with CGAL on Windows
+# Only boost is required to be installed on the system, CGAL is automatically downloaded
+# by CMake and is built with libigl.
+name: libigl-cgal
+channels:
+  - conda-forge
+dependencies:
+  - boost-cpp=1.65.0

--- a/include/igl/deprecated.h
+++ b/include/igl/deprecated.h
@@ -10,7 +10,7 @@
 // Macro for marking a function as deprecated.
 // 
 // http://stackoverflow.com/a/295229/148668
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #define IGL_DEPRECATED(func) func __attribute__ ((deprecated))
 #elif defined(_MSC_VER)
 #define IGL_DEPRECATED(func) __declspec(deprecated) func

--- a/include/igl/heat_geodesics.cpp
+++ b/include/igl/heat_geodesics.cpp
@@ -84,7 +84,7 @@ IGL_INLINE bool igl::heat_geodesics_precompute(
         return false;
       }
     }
-    const Eigen::SparseMatrix<double> Aeq = M.diagonal().transpose().sparseView();
+    const Eigen::SparseMatrix<double> Aeq = M.diagonal().sparseView().transpose();
     L *= -0.5;
     if(!igl::min_quad_with_fixed_precompute(
       L,Eigen::VectorXi(),Aeq,true,data.Poisson))


### PR DESCRIPTION
[Describe your changes and what you've already done to test it.]

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.

This change swap the calling of transpose() and sparseView() and fixed the igl::heat_geodesics_precompute on Windows.

tutorial/716_HeatGeodesics has been tested on Windows with `cmake -DLIBIGL_USE_STATIC_LIBRARY=OFF ..`

P.S. I'm not an expert of Eigen so I've no idea this comes from misusing of Eigen, a Windows bug in Eigen, or a compiler bug from Visual C++.