### PR TITLE
Fix igl::is_irregular_vertex()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,14 +41,17 @@ matrix:
     env:
     - MATRIX_EVAL="export CC=gcc-7 CXX=g++-7 CONFIG=Release PYTHON=python3 CMAKE_EXTRA='-DLIBIGL_EIGEN_VERSION=3.3.7'"
   - os: osx
+    osx_image: xcode10.2
     compiler: clang
     env:
     - MATRIX_EVAL="export CONFIG=Debug PYTHON=python3 LIBIGL_NUM_THREADS=1"
   - os: osx # same config like above but with -DLIBIGL_USE_STATIC_LIBRARY=OFF to test static and header-only builds
+    osx_image: xcode10.2
     compiler: clang
     env:
     - MATRIX_EVAL="export CONFIG=Debug PYTHON=python3 LIBIGL_NUM_THREADS=1 CMAKE_EXTRA='-DLIBIGL_USE_STATIC_LIBRARY=OFF'"
   - os: osx
+    osx_image: xcode10.2
     compiler: clang
     env:
     - MATRIX_EVAL="export CONFIG=Debug PYTHON=python3 LIBIGL_NUM_THREADS=1 CMAKE_EXTRA='-DLIBIGL_EIGEN_VERSION=3.3.7'""

--- a/include/igl/is_irregular_vertex.cpp
+++ b/include/igl/is_irregular_vertex.cpp
@@ -13,7 +13,7 @@
 template <typename DerivedV, typename DerivedF>
 IGL_INLINE std::vector<bool> igl::is_irregular_vertex(const Eigen::PlainObjectBase<DerivedV> &V, const Eigen::PlainObjectBase<DerivedF> &F)
 {
-  Eigen::VectorXi count = Eigen::VectorXi::Zero(F.maxCoeff());
+  Eigen::VectorXi count = Eigen::VectorXi::Zero(F.maxCoeff()+1);
 
   for(unsigned i=0; i<F.rows();++i)
   {

--- a/tests/include/igl/is_irregular_vertex.cpp
+++ b/tests/include/igl/is_irregular_vertex.cpp
@@ -6,16 +6,10 @@ TEST_CASE("is_irregular_vertex: simple", "[igl]")
 {
     Eigen::MatrixXd V;
     Eigen::MatrixXi F;
-    // Known non-manifold mesh
+    // Known "bad" mesh (many boundaries + irregular vertices, non-manifold)
     test_common::load_mesh("truck.obj", V, F);
     std::vector<bool> vec = igl::is_irregular_vertex(V,F);
-    int ret = false;
-    for (auto val : vec)
-    {
-        // true corresponds to 1
-        ret += val;
-    }
-    // some verticies are irregular thus the sum over all verticies should evaluate to a value > 0
-    REQUIRE( ret > 0 );
+    // some vertices are irregular thus the sum over all vertices should evaluate to true
+    REQUIRE(std::any_of(vec.begin(),vec.end(), [](bool v) { return v; }));
 
 }

--- a/tests/include/igl/is_irregular_vertex.cpp
+++ b/tests/include/igl/is_irregular_vertex.cpp
@@ -1,0 +1,21 @@
+#include <test_common.h>
+#include <igl/is_irregular_vertex.h>
+
+
+TEST_CASE("is_irregular_vertex: simple", "[igl]")
+{
+    Eigen::MatrixXd V;
+    Eigen::MatrixXi F;
+    // Known non-manifold mesh
+    test_common::load_mesh("truck.obj", V, F);
+    std::vector<bool> vec = igl::is_irregular_vertex(V,F);
+    int ret = false;
+    for (auto val : vec)
+    {
+        // true corresponds to 1
+        ret += val;
+    }
+    // some verticies are irregular thus the sum over all verticies should evaluate to a value > 0
+    REQUIRE( ret > 0 );
+
+}


### PR DESCRIPTION
Only in DEBUG mode Eigen does all boundary checks when accessing elements.
Thus when using `igl::is_irregular_vertex()` fails if `CMAKE_BUILD_TYPE=Debug`.
I've added a test for igl::is_irregular_vertex to showcase that it segfaults with CMAKE_BUILD_TYPE=Debug due to a missing F.maxCoeff()+1 in https://github.com/libigl/libigl/blob/master/include/igl/is_irregular_vertex.cpp#L16 see build https://travis-ci.org/BruegelN/libigl/builds/550519463 (Note only macOS builds with `CMAKE_BUILD_TYPE=Debug` and it's not related to the recent changes on Travis CI for macOS)
After fixing the off-by-one issue everything works as expected (https://travis-ci.org/BruegelN/libigl/builds/550521102)


#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [x] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
