### PR TITLE
Avoid reading beyond boundaries of arrays in readSTL.cpp

### DIFF
--- a/include/igl/readSTL.cpp
+++ b/include/igl/readSTL.cpp
@@ -85,14 +85,14 @@ IGL_INLINE bool igl::readSTL(
 
   // Specifically 80 character header
   char header[80];
-  char solid[80];
+  char solid[80] = {0};
   bool is_ascii = true;
   if(fread(header,1,80,stl_file) != 80)
   {
     cerr<<"IOError: too short (1)."<<endl;
     goto close_false;
   }
-  sscanf(header,"%s",solid);
+  sscanf(header,"%79s",solid);
   if(string("solid") != solid)
   {
     // definitely **not** ascii 


### PR DESCRIPTION
valgrind reported undefined behaviour while using readSTL.cpp. This simple change ensures no uninitialized data is read while reading the header line in readSTL.cpp

#### Check all that apply (change to `[x]`)
- [x ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x ] This is a minor change.
