### PR TITLE
Fix a potential crash when initializing the map for meshes with holes

### DIFF
--- a/tutorial/710_SCAF/main.cpp
+++ b/tutorial/710_SCAF/main.cpp
@@ -98,9 +98,8 @@ int main(int argc, char *argv[])
     all_bnds.erase(primary_bnd);
     Eigen::MatrixXi F_filled;
     igl::topological_hole_fill(F, bnd, all_bnds, F_filled);
-    igl::harmonic(F_filled, bnd, bnd_uv, 1, uv_init);
-    Eigen::MatrixXd tmpr_uv_init = uv_init.topRows(V.rows()); // copy to a temporary
-    uv_init = std::move(tmpr_uv_init); // and move over to prevent another copy
+    igl::harmonic(F_filled, bnd, bnd_uv ,1, uv_init);
+    uv_init.conservativeResize(V.rows(), 2);
   }
 
   Eigen::VectorXi b; Eigen::MatrixXd bc;

--- a/tutorial/710_SCAF/main.cpp
+++ b/tutorial/710_SCAF/main.cpp
@@ -21,7 +21,7 @@ igl::Timer timer;
 igl::SCAFData scaf_data;
 
 bool show_uv = false;
-float uv_scale = 0.2;
+float uv_scale = 0.2f;
 
 bool key_down(igl::opengl::glfw::Viewer& viewer, unsigned char key, int modifier)
 {
@@ -98,8 +98,9 @@ int main(int argc, char *argv[])
     all_bnds.erase(primary_bnd);
     Eigen::MatrixXi F_filled;
     igl::topological_hole_fill(F, bnd, all_bnds, F_filled);
-    igl::harmonic(F_filled, bnd, bnd_uv ,1, uv_init);
-    uv_init = uv_init.topRows(V.rows());
+    igl::harmonic(F_filled, bnd, bnd_uv, 1, uv_init);
+    Eigen::MatrixXd tmpr_uv_init = uv_init.topRows(V.rows()); // copy to a temporary
+    uv_init = std::move(tmpr_uv_init); // and move over to prevent another copy
   }
 
   Eigen::VectorXi b; Eigen::MatrixXd bc;


### PR DESCRIPTION
* Fix a potential crash when initializing the map for meshes with holes
* Fix a minor conversion warning

Without this change we can get crashes on models with holes.