### PR TITLE
Typo in documentation in orient2D

### DIFF
--- a/include/igl/copyleft/cgal/orient2D.h
+++ b/include/igl/copyleft/cgal/orient2D.h
@@ -21,7 +21,7 @@ namespace igl
       //   pa,pb,pc   2D points.
       // Output:
       //   1 if pa,pb,pc are counterclockwise oriented.
-      //   0 if pa,pb,pc are counterclockwise oriented.
+      //   0 if pa,pb,pc are collinear.
       //  -1 if pa,pb,pc are clockwise oriented.
       template <typename Scalar>
       IGL_INLINE short orient2D(


### PR DESCRIPTION

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
