### PR TITLE
# fix issue #1237

### DIFF
--- a/include/igl/heat_geodesics.cpp
+++ b/include/igl/heat_geodesics.cpp
@@ -84,7 +84,8 @@ IGL_INLINE bool igl::heat_geodesics_precompute(
         return false;
       }
     }
-    const Eigen::SparseMatrix<double> Aeq = M.diagonal().transpose().sparseView();
+    const DerivedV M_diag_tr = M.diagonal().transpose();
+    const Eigen::SparseMatrix<Scalar> Aeq = M_diag_tr.sparseView();
     L *= -0.5;
     if(!igl::min_quad_with_fixed_precompute(
       L,Eigen::VectorXi(),Aeq,true,data.Poisson))


### PR DESCRIPTION
#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.

Hello, I tested the fix by @xinyazhang on #1230 and #1237 in my environment (VS2017/Windows 10). Unfortunately, it still doesn't work for me. I checked it with the debugger and found that Aeq is still empty after running the original line of code (maybe this should be Eigen bug).  
To fix this, I made one additional line to create M.diagonal().transpose() and make it sparse representation in the second line. Additionally, I also set the type as Scalar, not "double" to follow the original template.  
I certificated that it now works in my environment.