### PR TITLE
activate label rendering for tutorial 105 overlays.

### DIFF
--- a/tutorial/105_Overlays/main.cpp
+++ b/tutorial/105_Overlays/main.cpp
@@ -67,6 +67,8 @@ int main(int argc, char *argv[])
   std::stringstream l2;
   l2 << M(0) << ", " << M(1) << ", " << M(2);
   viewer.data().add_label(M,l2.str());
+  // activate label rendering
+  viewer.data().show_labels = true;
 
   // Rendering of text labels is handled by ImGui, so we need to enable the ImGui
   // plugin to show text labels.


### PR DESCRIPTION
`ViewerData::show_labels` exists since #1196 and is `false` by default, thus turn it on for tutorial 105.

previously:
<img width="1392" alt="Bildschirmfoto 2019-10-15 um 21 17 48" src="https://user-images.githubusercontent.com/9728182/66862548-67a9fa00-ef91-11e9-82af-503c98a4e355.png">
now:
<img width="1392" alt="Bildschirmfoto 2019-10-15 um 21 18 23" src="https://user-images.githubusercontent.com/9728182/66862567-6e387180-ef91-11e9-96d5-a459086489fb.png">


#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
