### PR TITLE
Prevent the export of Embree into the directiory specified by 'CMAKE_…

### DIFF
--- a/cmake/libigl.cmake
+++ b/cmake/libigl.cmake
@@ -302,7 +302,7 @@ if(LIBIGL_WITH_EMBREE)
     # TODO: Should probably save/restore the CMAKE_CXX_FLAGS_*, since embree seems to be
     # overriding them on Windows. But well... it works for now.
     igl_download_embree()
-    add_subdirectory("${EMBREE_DIR}" "embree")
+    add_subdirectory("${EMBREE_DIR}" "embree" EXCLUDE_FROM_ALL)
   endif()
 
   compile_igl_module("embree")


### PR DESCRIPTION
…INSTALL_PREFIX' when calling 'make install'. Tested and verified on both macOS and Ubuntu.

Currently if one tries to install libigl Embree exports a whole bunch into that the `CMAKE_INSTALL_PREFIX` directory. Even though install the `igl::embree` module is officially not supported.
This takes care that only `igl::core` is installed.
Related comment: https://github.com/libigl/libigl.github.io/pull/19#issuecomment-542713353

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
