### PR TITLE
Set default value for ViewerCore::rotation_type

### DIFF
--- a/include/igl/opengl/ViewerCore.h
+++ b/include/igl/opengl/ViewerCore.h
@@ -117,7 +117,7 @@ public:
   Eigen::Vector3f light_position;
   float lighting_factor;
 
-  RotationType rotation_type;
+  RotationType rotation_type = RotationType::ROTATION_TYPE_TRACKBALL;
   Eigen::Quaternionf trackball_angle;
 
   // Camera parameters


### PR DESCRIPTION
Fix a complaint from Valgrind.

During the initialization of `ViewerCore::ViewerCore()`, `set_rotation_type` is called where value of  `rotation_type` is a value used without initialization.
[Describe your changes and what you've already done to test it.]

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
