### PR TITLE
Fix is_irregular_vertex for triangle meshes

### DIFF
--- a/include/igl/is_irregular_vertex.cpp
+++ b/include/igl/is_irregular_vertex.cpp
@@ -13,7 +13,7 @@
 template <typename DerivedV, typename DerivedF>
 IGL_INLINE std::vector<bool> igl::is_irregular_vertex(const Eigen::PlainObjectBase<DerivedV> &V, const Eigen::PlainObjectBase<DerivedF> &F)
 {
-  Eigen::VectorXi count = Eigen::VectorXi::Zero(F.maxCoeff());
+  Eigen::VectorXi count = Eigen::VectorXi::Zero(F.maxCoeff()+1);
 
   for(unsigned i=0; i<F.rows();++i)
   {


### PR DESCRIPTION
Output vector was one too short for is_irregular_vertex. It is still broken for quad meshes since it relies on is_border_vertex, which does not work for quad meshes due to using triangle_triangle_adjacency.

[Describe your changes and what you've already done to test it.]

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
