### PR TITLE
fix align_camera_center in Viewer::init() for multiple cores

### DIFF
--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -1,4 +1,4 @@
-// This file is part of libigl, a simple c++ geometry processing library.
+// This file is part of libigl, a simple c++ geometry processing library. 
 //
 // Copyright (C) 2014 Daniele Panozzo <daniele.panozzo@gmail.com>
 //

--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -210,13 +210,18 @@ namespace glfw
     glfwGetWindowSize(window, &width_window, &height_window);
     highdpi = windowWidth/width_window;
     glfw_window_size(window,width_window,height_window);
-    //opengl.init();
-    for(int i=0;i<core_list.size(); i++)
-    {
-      core_list[i].align_camera_center(data().V,data().F);
-    }
     // Initialize IGL viewer
     init();
+    for(auto &core : this->core_list)
+    {
+      for(auto &data : this->data_list)
+      {
+        if(data.is_visible & core.id)
+        {
+          this->core(core.id).align_camera_center(data.V, data.F);
+        }
+      }
+    }
     return EXIT_SUCCESS;
   }
 


### PR DESCRIPTION
Iterate over viewer.core_list and viewer.data_list and align_camera_center per core with visible data

Previously with `core().align_camera_center(data().V,data().F);` the alignment wasn't done properly with multiple meshes and ViewerCores if the meshes had different centers and/or scale.

MWE:
```C++
#include "tutorial_shared_path.h"
#include <igl/opengl/glfw/Viewer.h>
#include <string>
#include <iostream>


int main(int argc, char * argv[])
{
  igl::opengl::glfw::Viewer viewer;

  viewer.load_mesh_from_file(std::string(TUTORIAL_SHARED_PATH) + "/snail.obj");
  viewer.load_mesh_from_file(std::string(TUTORIAL_SHARED_PATH) + "/cube.obj");

  unsigned int left_view, right_view;
  int cube_id = viewer.data_list[0].id;
  int sphere_id = viewer.data_list[1].id;
  viewer.callback_init = [&](igl::opengl::glfw::Viewer &)
  {
    viewer.core().viewport = Eigen::Vector4f(0, 0, 640, 800);
    left_view = viewer.core_list[0].id;
    right_view = viewer.append_core(Eigen::Vector4f(640, 0, 640, 800));
    viewer.data(cube_id).set_visible(false, left_view);
    viewer.data(sphere_id).set_visible(false, right_view);
    return false;
  };

  viewer.callback_post_resize = [&](igl::opengl::glfw::Viewer &v, int w, int h) {
    v.core( left_view).viewport = Eigen::Vector4f(0, 0, w / 2, h);
    v.core(right_view).viewport = Eigen::Vector4f(w / 2, 0, w - (w / 2), h);
    return true;
  };

  viewer.launch();
  return EXIT_SUCCESS;
}
```
The code above with current dev branch
![current situation in dev](https://user-images.githubusercontent.com/9728182/68599180-6db3cd80-04a0-11ea-802e-317c6952f7f0.png)

Now
![with this fix](https://user-images.githubusercontent.com/9728182/68599205-786e6280-04a0-11ea-859d-01150f75c895.png)


#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
