### PR TITLE
remove LIBIGL_USE_STATIC_LIBRARY in favor of standard BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,6 @@ option(LIBIGL_BUILD_TUTORIALS  "Build libigl tutorial"         ${LIBIGL_TOPLEVEL
 option(LIBIGL_BUILD_PYTHON     "Build libigl python bindings"  ${LIBIGL_TOPLEVEL_PROJECT})
 option(LIBIGL_EXPORT_TARGETS   "Export libigl CMake targets"   ${LIBIGL_TOPLEVEL_PROJECT})
 
-# USE_STATIC_LIBRARY speeds up the generation of multiple binaries,
-# at the cost of a longer initial compilation time
-# (by default, static build is off since libigl is a header-only library)
-option(LIBIGL_USE_STATIC_LIBRARY "Use libigl as static library" ON)
-
 # All dependencies that are downloaded as cmake projects and tested on the auto-builds are ON
 # (by default, all build options are off)
 option(LIBIGL_WITH_COMISO            "Use CoMiso"                   ON)

--- a/cmake/libigl.cmake
+++ b/cmake/libigl.cmake
@@ -19,7 +19,6 @@ if(APPLE)
 endif()
 
 ### Available options ###
-option(LIBIGL_USE_STATIC_LIBRARY     "Use libigl as static library" OFF)
 option(LIBIGL_WITH_CGAL              "Use CGAL"                     OFF)
 option(LIBIGL_WITH_COMISO            "Use CoMiso"                   OFF)
 option(LIBIGL_WITH_CORK              "Use Cork"                     OFF)
@@ -46,10 +45,10 @@ set(LIBIGL_SOURCE_DIR "${LIBIGL_ROOT}/include")
 set(LIBIGL_EXTERNAL "${LIBIGL_ROOT}/external")
 
 # Dependencies are linked as INTERFACE targets unless libigl is compiled as a static library
-if(LIBIGL_USE_STATIC_LIBRARY)
-  set(IGL_SCOPE PUBLIC)
-else()
+if(BUILD_SHARED_LIBS)
   set(IGL_SCOPE INTERFACE)
+else()
+  set(IGL_SCOPE PUBLIC)
 endif()
 
 # Download and update 3rdparty libraries
@@ -67,7 +66,7 @@ target_include_directories(igl_common SYSTEM INTERFACE
 )
 # Export igl_common as igl::common
 set_property(TARGET igl_common PROPERTY EXPORT_NAME igl::common)
-if(LIBIGL_USE_STATIC_LIBRARY)
+if(NOT BUILD_SHARED_LIBS)
   target_compile_definitions(igl_common INTERFACE -DIGL_STATIC_LIBRARY)
 endif()
 
@@ -138,7 +137,7 @@ function(compile_igl_module module_dir)
   else()
     set(module_libname "igl_${module_name}")
   endif()
-  if(LIBIGL_USE_STATIC_LIBRARY)
+  if(NOT BUILD_SHARED_LIBS)
     file(GLOB SOURCES_IGL_${module_name}
       "${LIBIGL_SOURCE_DIR}/igl/${module_dir}/*.cpp")
     if(NOT LIBIGL_WITHOUT_COPYLEFT)
@@ -172,7 +171,7 @@ endfunction()
 ### IGL Core
 ################################################################################
 
-if(LIBIGL_USE_STATIC_LIBRARY)
+if(NOT BUILD_SHARED_LIBS)
   file(GLOB SOURCES_IGL
     "${LIBIGL_SOURCE_DIR}/igl/*.cpp"
     "${LIBIGL_SOURCE_DIR}/igl/copyleft/*.cpp")
@@ -464,7 +463,7 @@ function(install_dir_files dir_name)
 
   set(files_to_install ${public_headers})
 
-  if(NOT LIBIGL_USE_STATIC_LIBRARY)
+  if(BUILD_SHARED_LIBS)
     file(GLOB public_sources
       ${CMAKE_CURRENT_SOURCE_DIR}/include/igl${subpath}/*.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/include/igl${subpath}/*.c

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -4,11 +4,11 @@ project(pyigl)
 ### Adding libIGL: choose the path to your local copy libIGL
 if(NOT TARGET igl::core)
   ### Prefer header-only mode for compiling Python bindings
-  if(NOT LIBIGL_WITH_PYTHON OR NOT LIBIGL_USE_STATIC_LIBRARY)
+  if(NOT LIBIGL_WITH_PYTHON OR BUILD_SHARED_LIBS)
     message(FATAL_ERROR
       "Trying to compile Python bindings without -DLIBIGL_WITH_PYTHON=ON. "
       "Either enable manually all the necessary options, or compile from "
-      "the root folder with -DLIBIGL_USE_STATIC_LIBRARY=OFF")
+      "the root folder with -DBUILD_SHARED_LIBS=ON")
   endif()
   list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/../cmake")
   include(libigl)

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -4,9 +4,6 @@ project(libigl_tutorials)
 ### Conditionally compile certain modules depending on libraries found on the system
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../cmake)
 
-### Compile libigl in header-only mode for Python bindings
-option(LIBIGL_USE_STATIC_LIBRARY "Use LibIGL as static library" ON)
-
 ### Adding libIGL: choose the path to your local copy libIGL
 if(NOT TARGET igl_common)
   include(libigl)


### PR DESCRIPTION
There is actually a standard cmake variable [`BUILD_SHARED_LIBS`](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) that does exactly what the cmake variable `LIBIGL_USE_STATIC_LIBRARY` intends to do. It's better to eliminate `LIBIGL_USE_STATIC_LIBRARY` because what happened was when I first encounter libigl, I instinctively compile it with 

```
cmake -DBUILD_SHARED_LIBS=ON ..
make -j
sudo make install
``` 
and then I realized a simple downstream test project that links to libigl wouldn't compile 

```
/usr/include/igl/any.h:32:12: fatal error: any.cpp: No such file or directory
 #  include "any.cpp"
            ^~~~~~~~~
compilation terminated.
```

after further investigation, I realized it's because `BUILD_SHARED_LIBS` is set to on so it builds a shared library, but the variable `LIBIGL_USE_STATIC_LIBRARY` is by default on hence the confusion. After applying this PR, I can now compile and run my downstream project successfully.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [ ] This is a minor change.
