### PR TITLE
install missing hpp files

### DIFF
--- a/cmake/libigl.cmake
+++ b/cmake/libigl.cmake
@@ -478,6 +478,7 @@ function(install_dir_files dir_name)
 
   file(GLOB public_headers
     ${CMAKE_CURRENT_SOURCE_DIR}/include/igl${subpath}/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/igl${subpath}/*.hpp
   )
 
   set(files_to_install ${public_headers})


### PR DESCRIPTION
Without this PR, if you simply link to igl and include svd3x3.h, you will get the below error

```
/usr/include/igl/svd3x3.cpp:18:10: fatal error: Singular_Value_Decomposition_Preamble.hpp: No such file or directory
 #include "Singular_Value_Decomposition_Preamble.hpp"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

and it is because the .hpp files are not installed along with the .h files. This PR fixes it and now I can include svd3x3.h without a problem.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [ ] This is a minor change.
