### PR TITLE
Thread-safe predicate initialization using singleton pattern.

### DIFF
--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -164,7 +164,7 @@ endfunction()
 function(igl_download_predicates)
 	igl_download_project(predicates
 		GIT_REPOSITORY https://github.com/libigl/libigl-predicates.git
-		GIT_TAG        4c57c1d3f31646b010d1d58bfbe201e75c2b2ad8
+		GIT_TAG        2462fb81b8ae111eadbe5b07ae2f7e0418f8b48a
 	)
 endfunction()
 

--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -164,7 +164,7 @@ endfunction()
 function(igl_download_predicates)
 	igl_download_project(predicates
 		GIT_REPOSITORY https://github.com/libigl/libigl-predicates.git
-		GIT_TAG        2462fb81b8ae111eadbe5b07ae2f7e0418f8b48a
+		GIT_TAG        5a1d2194ec114bff51d5a33230586cafb83adc86
 	)
 endfunction()
 

--- a/include/igl/predicates/predicates.cpp
+++ b/include/igl/predicates/predicates.cpp
@@ -28,11 +28,17 @@ using REAL = IGL_PREDICATES_REAL;
 #endif
 
 IGL_INLINE void exactinit() {
-  static bool initialized = false;
-  if (! initialized) {
-    ::exactinit();
-    initialized = true;
-  }
+  // Thread-safe initialization using Meyers' singleton
+  class MySingleton {
+  public:
+    static MySingleton& instance() {
+      static MySingleton instance;
+      return instance;
+    }
+  private:
+    MySingleton() { ::exactinit(); }
+  };
+  MySingleton::instance();
 }
 
 template<typename Vector2D>

--- a/include/igl/predicates/predicates.h
+++ b/include/igl/predicates/predicates.h
@@ -2,8 +2,8 @@
 //
 // Copyright (C) 2019 Qingnan Zhou <qnzhou@gmail.com>
 //
-// This Source Code Form is subject to the terms of the Mozilla Public License 
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 #pragma once
 #ifndef IGL_PREDICATES_PREDICATES_H
@@ -20,8 +20,9 @@ namespace igl {
       COLLINEAR=0, COPLANAR=0, COCIRCULAR=0, COSPHERICAL=0, DEGENERATE=0
     };
 
-    // Initialize internal variable used by predciates.  Must be called before
-    // using exact predicates.
+    // Initialize internal variable used by predciates. Must be called before
+    // using exact predicates. It is safe to call this function from multiple
+    // threads.
     IGL_INLINE void exactinit();
 
     // Compute the orientation of the triangle formed by pa, pb, pc.


### PR DESCRIPTION
Might as well make this function thread-safe... Doesn't hurt.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [x] This is a minor change.
