### PR TITLE
Make use of IGL_DEPRECATED

### DIFF
--- a/include/igl/all_edges.h
+++ b/include/igl/all_edges.h
@@ -8,6 +8,7 @@
 #ifndef IGL_ALL_EDGES_H
 #define IGL_ALL_EDGES_H
 #include "igl_inline.h"
+#include "deprecated.h"
 #include <Eigen/Dense>
 namespace igl
 {
@@ -26,9 +27,9 @@ namespace igl
   // show up once for each direction and non-manifold edges may appear more than
   // once for each direction).
   template <typename DerivedF, typename DerivedE>
-  IGL_INLINE void all_edges(
+  IGL_INLINE void IGL_DEPRECATED(all_edges(
     const Eigen::MatrixBase<DerivedF> & F,
-    Eigen::PlainObjectBase<DerivedE> & E);
+    Eigen::PlainObjectBase<DerivedE> & E));
 }
 
 #ifndef IGL_STATIC_LIBRARY

--- a/include/igl/all_edges.h
+++ b/include/igl/all_edges.h
@@ -27,9 +27,9 @@ namespace igl
   // show up once for each direction and non-manifold edges may appear more than
   // once for each direction).
   template <typename DerivedF, typename DerivedE>
-  IGL_INLINE void IGL_DEPRECATED(all_edges(
+  IGL_DEPRECATED IGL_INLINE void all_edges(
     const Eigen::MatrixBase<DerivedF> & F,
-    Eigen::PlainObjectBase<DerivedE> & E));
+    Eigen::PlainObjectBase<DerivedE> & E);
 }
 
 #ifndef IGL_STATIC_LIBRARY

--- a/include/igl/boundary_loop.cpp
+++ b/include/igl/boundary_loop.cpp
@@ -29,7 +29,7 @@ IGL_INLINE void igl::boundary_loop(
   triangle_triangle_adjacency(F,TT,TTi);
   vertex_triangle_adjacency(Vdummy,F,VF,VFi);
 
-  vector<bool> unvisited = is_border_vertex(Vdummy,F);
+  vector<bool> unvisited = is_border_vertex(F);
   set<int> unseen;
   for (size_t i = 0; i < unvisited.size(); ++i)
   {

--- a/include/igl/cross_field_mismatch.cpp
+++ b/include/igl/cross_field_mismatch.cpp
@@ -79,7 +79,7 @@ public:
   PD2(_PD2)
   {
     igl::per_face_normals(V,F,N);
-    V_border = igl::is_border_vertex(V,F);
+    V_border = igl::is_border_vertex(F);
     igl::vertex_triangle_adjacency(V,F,VF,VFi);
     igl::triangle_triangle_adjacency(F,TT,TTi);
   }

--- a/include/igl/deprecated.h
+++ b/include/igl/deprecated.h
@@ -8,21 +8,37 @@
 #ifndef IGL_DEPRECATED_H
 #define IGL_DEPRECATED_H
 // Macro for marking a function as deprecated.
-// 
-// http://stackoverflow.com/a/295229/148668
-#if defined(__GNUC__) || defined(__clang__)
-#define IGL_DEPRECATED(func) func __attribute__ ((deprecated))
-#elif defined(_MSC_VER)
-#define IGL_DEPRECATED(func) __declspec(deprecated) func
+// Use C++14 feature [[deprecated]] if available.
+// See also https://stackoverflow.com/questions/295120/c-mark-as-deprecated/21265197#21265197
+
+#ifdef __has_cpp_attribute
+#  define IGL_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
 #else
-#pragma message("WARNING: You need to implement IGL_DEPRECATED for this compiler")
-#define IGL_DEPRECATED(func) func
+#  define IGL_HAS_CPP_ATTRIBUTE(x) 0
 #endif
+
+#ifndef IGL_DEPRECATED
+#  if (IGL_HAS_CPP_ATTRIBUTE(deprecated) && __cplusplus >= 201402L) || \
+      IGL_MSC_VER >= 1900
+#    define IGL_DEPRECATED [[deprecated]]
+#  else
+#    if defined(__GNUC__) || defined(__clang__)
+#      define IGL_DEPRECATED __attribute__((deprecated))
+#    elif IGL_MSC_VER
+#      define IGL_DEPRECATED __declspec(deprecated)
+#    else
+#      define IGL_DEPRECATED /* deprecated */
+#    endif
+#  endif
+#endif
+
 // Usage:
 //
-//     template <typename T> IGL_INLINE void my_func(Arg1 a);
+//     template <typename T>
+//     IGL_INLINE void my_func(Arg1 a);
 //
-// becomes 
+// becomes
 //
-//     template <typename T> IGL_INLINE IGL_DEPRECATED(void my_func(Arg1 a));
+//     template <typename T>
+//     IGL_DEPRECATED IGL_INLINE void my_func(Arg1 a);
 #endif

--- a/include/igl/deprecated.h
+++ b/include/igl/deprecated.h
@@ -17,6 +17,12 @@
 #  define IGL_HAS_CPP_ATTRIBUTE(x) 0
 #endif
 
+#ifdef _MSC_VER
+#  define IGL_MSC_VER _MSC_VER
+#else
+#  define IGL_MSC_VER 0
+#endif
+
 #ifndef IGL_DEPRECATED
 #  if (IGL_HAS_CPP_ATTRIBUTE(deprecated) && __cplusplus >= 201402L) || \
       IGL_MSC_VER >= 1900
@@ -27,6 +33,7 @@
 #    elif IGL_MSC_VER
 #      define IGL_DEPRECATED __declspec(deprecated)
 #    else
+#      pragma message("WARNING: You need to implement IGL_DEPRECATED for this compiler")
 #      define IGL_DEPRECATED /* deprecated */
 #    endif
 #  endif

--- a/include/igl/find_cross_field_singularities.cpp
+++ b/include/igl/find_cross_field_singularities.cpp
@@ -22,7 +22,7 @@ IGL_INLINE void igl::find_cross_field_singularities(const Eigen::MatrixBase<Deri
                                                     Eigen::PlainObjectBase<DerivedO> &isSingularity,
                                                     Eigen::PlainObjectBase<DerivedO> &singularityIndex)
 {
-  std::vector<bool> V_border = igl::is_border_vertex(V,F);
+  std::vector<bool> V_border = igl::is_border_vertex(F);
 
   std::vector<std::vector<int> > VF;
   std::vector<std::vector<int> > VFi;

--- a/include/igl/internal_angles.h
+++ b/include/igl/internal_angles.h
@@ -50,9 +50,9 @@ namespace igl
   //   Usage of internal_angles_using_squared_edge_lengths is preferred to internal_angles_using_squared_edge_lengths
   //   This function is deprecated and probably will be removed in future versions
   template <typename DerivedL, typename DerivedK>
-  IGL_INLINE void IGL_DEPRECATED(internal_angles_using_edge_lengths(
+  IGL_DEPRECATED IGL_INLINE void internal_angles_using_edge_lengths(
     const Eigen::MatrixBase<DerivedL>& L,
-    Eigen::PlainObjectBase<DerivedK> & K));
+    Eigen::PlainObjectBase<DerivedK> & K);
 }
 
 #ifndef IGL_STATIC_LIBRARY

--- a/include/igl/internal_angles.h
+++ b/include/igl/internal_angles.h
@@ -8,6 +8,7 @@
 #ifndef IGL_INTERNAL_ANGLES_H
 #define IGL_INTERNAL_ANGLES_H
 #include "igl_inline.h"
+#include "deprecated.h"
 #include <Eigen/Core>
 namespace igl
 {
@@ -49,9 +50,10 @@ namespace igl
   //   Usage of internal_angles_using_squared_edge_lengths is preferred to internal_angles_using_squared_edge_lengths
   //   This function is deprecated and probably will be removed in future versions
   template <typename DerivedL, typename DerivedK>
-  IGL_INLINE void internal_angles_using_edge_lengths(
+  IGL_INLINE void IGL_DEPRECATED(internal_angles_using_edge_lengths(
     const Eigen::MatrixBase<DerivedL>& L,
-    Eigen::PlainObjectBase<DerivedK> & K);}
+    Eigen::PlainObjectBase<DerivedK> & K));
+}
 
 #ifndef IGL_STATIC_LIBRARY
 #  include "internal_angles.cpp"

--- a/include/igl/is_border_vertex.h
+++ b/include/igl/is_border_vertex.h
@@ -8,7 +8,7 @@
 #ifndef IGL_IS_BORDER_VERTEX_H
 #define IGL_IS_BORDER_VERTEX_H
 #include "igl_inline.h"
-
+#include "deprecated.h"
 #include <Eigen/Core>
 #include <vector>
 
@@ -29,9 +29,9 @@ namespace igl
    const Eigen::MatrixBase<DerivedF> &F);
   // Deprecated:
   template <typename DerivedV, typename DerivedF>
-  IGL_INLINE std::vector<bool> is_border_vertex(
+  IGL_INLINE std::vector<bool> IGL_DEPRECATED(is_border_vertex(
    const Eigen::MatrixBase<DerivedV> &V,
-   const Eigen::MatrixBase<DerivedF> &F);
+   const Eigen::MatrixBase<DerivedF> &F));
 }
 
 #ifndef IGL_STATIC_LIBRARY

--- a/include/igl/is_border_vertex.h
+++ b/include/igl/is_border_vertex.h
@@ -29,9 +29,9 @@ namespace igl
    const Eigen::MatrixBase<DerivedF> &F);
   // Deprecated:
   template <typename DerivedV, typename DerivedF>
-  IGL_INLINE std::vector<bool> IGL_DEPRECATED(is_border_vertex(
+  IGL_DEPRECATED IGL_INLINE std::vector<bool> is_border_vertex(
    const Eigen::MatrixBase<DerivedV> &V,
-   const Eigen::MatrixBase<DerivedF> &F));
+   const Eigen::MatrixBase<DerivedF> &F);
 }
 
 #ifndef IGL_STATIC_LIBRARY

--- a/include/igl/is_irregular_vertex.cpp
+++ b/include/igl/is_irregular_vertex.cpp
@@ -27,7 +27,7 @@ IGL_INLINE std::vector<bool> igl::is_irregular_vertex(const Eigen::MatrixBase<De
     }
   }
 
-  std::vector<bool> border = is_border_vertex(V,F);
+  std::vector<bool> border = is_border_vertex(F);
 
   std::vector<bool> res(count.size());
 

--- a/include/igl/line_field_mismatch.cpp
+++ b/include/igl/line_field_mismatch.cpp
@@ -92,7 +92,7 @@ public:
         PD2(_PD2)
     {
         igl::per_face_normals(V,F,N);
-        V_border = igl::is_border_vertex(V,F);
+        V_border = igl::is_border_vertex(F);
         igl::vertex_triangle_adjacency(V,F,VF,VFi);
         igl::triangle_triangle_adjacency(F,TT,TTi);
     }

--- a/include/igl/nchoosek.h
+++ b/include/igl/nchoosek.h
@@ -9,7 +9,6 @@
 #ifndef IGL_NCHOOSEK
 #define IGL_NCHOOSEK
 #include "igl_inline.h"
-#include "deprecated.h"
 #include <vector>
 
 #include <Eigen/Core>

--- a/include/igl/readOBJ.h
+++ b/include/igl/readOBJ.h
@@ -8,7 +8,6 @@
 #ifndef IGL_READOBJ_H
 #define IGL_READOBJ_H
 #include "igl_inline.h"
-#include "deprecated.h"
 // History:
 //  return type changed from void to bool  Alec 18 Sept 2011
 //  added pure vector of vectors version that has much more support Alec 31 Oct

--- a/include/igl/remove_duplicates.h
+++ b/include/igl/remove_duplicates.h
@@ -8,6 +8,7 @@
 #ifndef IGL_REMOVE_DUPLICATES_H
 #define IGL_REMOVE_DUPLICATES_H
 #include "igl_inline.h"
+#include "deprecated.h"
 
 #include <Eigen/Core>
 namespace igl 
@@ -32,7 +33,7 @@ namespace igl
 //                                   const double epsilon = 2.2204e-15);
   
   template <typename DerivedV, typename DerivedF>
-  IGL_INLINE void remove_duplicates(
+  IGL_DEPRECATED IGL_INLINE void remove_duplicates(
     const Eigen::MatrixBase<DerivedV> &V,
     const Eigen::MatrixBase<DerivedF> &F,
     Eigen::PlainObjectBase<DerivedV> &NV,


### PR DESCRIPTION
* Use the macro in `igl::all_edges`, `igl::internal_angles` and `igl::is_border_vertex`.
CTRL+F for "deprecated" to find functions where the comment says they're deprecated.

* Removed #include deprecated.h for `igl::nchoosek` and `igl::readOBJ` because it looks like the functions which have been marked as deprecated are already gone. See [igl::nchoosek](https://github.com/libigl/libigl/commit/471f0c9c37478120dd910bef84bbe87fd96fcaa7#diff-f56795cb8c2b945d68d392cb5d89688e) and [igl::readOBJ](https://github.com/libigl/libigl/commit/dcd8c80fbc71cc85050f4875025b646aeda572c9#diff-e0dd9ddd2a25dde223acf9d1252f437f)

The compiler warning will look sth. like below if you use a deprecated func.
```bash
std::vector<bool> igl::is_border_vertex(const Eigen::MatrixBase<Derived>&, const Eigen::MatrixBase<U>&) [with DerivedV = Eigen::Matrix<double, -1, -1>; DerivedF = Eigen::Matrix<int, -1, -1>]’ is deprecated [-Wdeprecated-declarations]
   15 |   igl::is_border_vertex(V,F);
      |                            ^
In file included from include/igl/is_border_vertex.h:11,
                 from main.cpp:2:
include/igl/is_border_vertex.h:32:32: note: declared here
   32 |   IGL_INLINE std::vector<bool> IGL_DEPRECATED(is_border_vertex(
      |                                ^~~~~~~~~~~~~~
main.cpp:15:28: warning: ‘std::vector<bool> igl::is_border_vertex(const Eigen::MatrixBase<Derived>&, const Eigen::MatrixBase<U>&) [with DerivedV = Eigen::Matrix<double, -1, -1>; DerivedF = Eigen::Matrix<int, -1, -1>]’ is deprecated [-Wdeprecated-declarations]
   15 |   igl::is_border_vertex(V,F);
      |                            ^
In file included from include/igl/is_border_vertex.h:11,
                 from main.cpp:2:
include/igl/is_border_vertex.h:32:32: note: declared here
   32 |   IGL_INLINE std::vector<bool> IGL_DEPRECATED(is_border_vertex(
```



#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [X] This is a minor change.
