### PR TITLE
Allows hsv_to_rgb to work on negative hues

### DIFF
--- a/include/igl/hsv_to_rgb.cpp
+++ b/include/igl/hsv_to_rgb.cpp
@@ -25,7 +25,8 @@ IGL_INLINE void igl::hsv_to_rgb(
   // From medit
   double f,p,q,t,hh;
   int    i;
-  hh = ((int)h % 360) / 60.;
+  // shift the hue to the range [0, 360] before performing calculations
+  hh = ((360 + ((int)h % 360)) % 360) / 60.;
   i = (int)std::floor(hh);    /* largest int <= h     */
   f = hh - i;                    /* fractional part of h */
   p = v * (1.0 - s);

--- a/include/igl/hsv_to_rgb.h
+++ b/include/igl/hsv_to_rgb.h
@@ -14,7 +14,7 @@ namespace igl
   // Convert RGB to HSV
   //
   // Inputs:
-  //   h  hue value (degrees: [0,360])
+  //   h  hue value (degrees: [0,360]. Values outside this range will be mapped periodically to [0,360].)
   //   s  saturation value ([0,1])
   //   v  value value ([0,1])
   // Outputs:


### PR DESCRIPTION
The previous behavior of hsv_to_rgb is to map positive hue values to the range [0, 360], but does not do the same thing for negative values, instead returning a random result (uninitialized variables). This change causes hsv_to_rgb to always map the input hue to [0, 360].

Closes #1397.

#### Check all that apply (change to `[x]`)
- [X] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [X] This is a minor change.
