### PR TITLE
Bug fix in min_quad_with_fixed.cpp

### DIFF
--- a/include/igl/min_quad_with_fixed.cpp
+++ b/include/igl/min_quad_with_fixed.cpp
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2016 Alec Jacobson <alecjacobson@gmail.com>
 //
-// This Source Code Form is subject to the terms of the Mozilla Public License
+// This Source Code Form is subject to the terms of the Mozilla Public License 
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 #include "min_quad_with_fixed.h"

--- a/include/igl/min_quad_with_fixed.cpp
+++ b/include/igl/min_quad_with_fixed.cpp
@@ -241,7 +241,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
       // Ideally we'd use LDLT but Eigen doesn't support positive semi-definite
       // matrices:
       // http://forum.kde.org/viewtopic.php?f=74&t=106962&p=291990#p291990
-      if(data.Auu_sym && false)
+      if(data.Auu_sym)
       {
         data.ldlt.compute(NA);
         switch(data.ldlt.info())


### PR DESCRIPTION
This `&& false` somehow appeared... I don't know/recall the origin of it. Current thinking is that it was debris from debugging that got accidentally committed.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
