### PR TITLE
mesh_to_polyhedron need estimated halfedge num

### DIFF
--- a/include/igl/copyleft/cgal/mesh_to_polyhedron.cpp
+++ b/include/igl/copyleft/cgal/mesh_to_polyhedron.cpp
@@ -21,7 +21,7 @@ IGL_INLINE bool igl::copyleft::cgal::mesh_to_polyhedron(
   typedef typename Polyhedron::HalfedgeDS HalfedgeDS;
   // Postcondition: hds is a valid polyhedral surface.
   CGAL::Polyhedron_incremental_builder_3<HalfedgeDS> B(poly.hds());
-  B.begin_surface(V.rows(),F.rows(),3*F.rows());
+  B.begin_surface(V.rows(),F.rows(),3*F.rows()+1);
   typedef typename HalfedgeDS::Vertex   Vertex;
   typedef typename Vertex::Point Point;
   assert(V.cols() == 3 && "V must be #V by 3");

--- a/include/igl/copyleft/cgal/mesh_to_polyhedron.cpp
+++ b/include/igl/copyleft/cgal/mesh_to_polyhedron.cpp
@@ -21,7 +21,7 @@ IGL_INLINE bool igl::copyleft::cgal::mesh_to_polyhedron(
   typedef typename Polyhedron::HalfedgeDS HalfedgeDS;
   // Postcondition: hds is a valid polyhedral surface.
   CGAL::Polyhedron_incremental_builder_3<HalfedgeDS> B(poly.hds());
-  B.begin_surface(V.rows(),F.rows());
+  B.begin_surface(V.rows(),F.rows(),3*F.rows());
   typedef typename HalfedgeDS::Vertex   Vertex;
   typedef typename Vertex::Point Point;
   assert(V.cols() == 3 && "V must be #V by 3");


### PR DESCRIPTION
In CGAL, `cgal/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h:583`,
the number of half edges is estimated to be ` h = (std::size_t)((double)(v + f - 2 + 12) * 2.1);`

For example, when V=296, F=732, `h=2179`. However, the real half edge number should be `3*F=2196`. This will result in CGAL crash. 

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
