### PR TITLE
Fixes stack overwriting bug in gl::is_stl, when file have binary data

### DIFF
--- a/include/igl/is_stl.cpp
+++ b/include/igl/is_stl.cpp
@@ -41,6 +41,8 @@ IGL_INLINE bool igl::is_stl(FILE * stl_file, bool & is_ascii)
     f = false;
     goto finish;
   }
+  // make sure sscanf doesn't read past the end of the header, overwriting stack
+  header[sizeof(header)-1]='\0';
 
   sscanf(header,"%s",solid);
   if(std::string("solid") == solid)

--- a/include/igl/is_stl.cpp
+++ b/include/igl/is_stl.cpp
@@ -1,4 +1,4 @@
-#include "is_stl.h"
+#include "is_stl.h" 
 #include <string>
 IGL_INLINE bool igl::is_stl(FILE * stl_file, bool & is_ascii)
 {


### PR DESCRIPTION
detected by running with ASAN in all_meshes test. Made sure that string is zero terminated.


#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [ ] This is a minor change.
