### PR TITLE
numeric_limits<double>::min() is the minimal positive number

### DIFF
--- a/include/igl/copyleft/cgal/extract_cells.cpp
+++ b/include/igl/copyleft/cgal/extract_cells.cpp
@@ -200,7 +200,7 @@ IGL_INLINE size_t igl::copyleft::cgal::extract_cells(
     DerivedV bbox_max(num_components, 3);
     // Assuming our mesh (in exact numbers) fits in the range of double.
     bbox_min.setConstant(std::numeric_limits<double>::max());
-    bbox_max.setConstant(std::numeric_limits<double>::min());
+    bbox_max.setConstant(std::numeric_limits<double>::lowest());
     // Loop over faces
     for (size_t i=0; i<num_faces; i++)
     {

--- a/include/igl/copyleft/cgal/extract_cells.cpp
+++ b/include/igl/copyleft/cgal/extract_cells.cpp
@@ -1,7 +1,7 @@
 // This file is part of libigl, a simple c++ geometry processing library.
 //
 // Copyright (C) 2015 Qingnan Zhou <qnzhou@gmail.com>
-//
+// 
 // This Source Code Form is subject to the terms of the Mozilla Public License
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
From the context it seems this line should be numeric_limits::lowest() since numeric_limits::min() refers to the minimal positive number (2.22507e-308) in the double range, instead of the lowest number (-1.79769e+308) in the double range. This bug would cause incorrect computation of the bounding box.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] Adds corresponding python binding.
- [x] This is a minor change.
