### PR TITLE
Update clone depth.

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
         with:
-          fetch-depth: 1
+          fetch-depth: 10
 
       - name: Dependencies (Linux)
         if: runner.os == 'Linux'
@@ -106,7 +106,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
         with:
-          fetch-depth: 1
+          fetch-depth: 10
       - uses: seanmiddleditch/gha-setup-ninja@master
 
         # https://github.com/actions/cache/issues/101

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
         with:
-          fetch-depth: 1
+          fetch-depth: 10
 
       - name: Dependencies (Linux)
         if: runner.os == 'Linux'
@@ -163,7 +163,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
         with:
-          fetch-depth: 1
+          fetch-depth: 10
       - uses: seanmiddleditch/gha-setup-ninja@master
 
         # We run configure + build in the same step, since they both need to call VsDevCmd


### PR DESCRIPTION
Currently some actions fail because of the limited clone depth. This is only a problem when merging/pushing multiple commits on a branch when there are other jobs running. I think a depth of 10 should be enough for most situation, but we can always change that.