### PR TITLE
Toggle double sided lighting

### DIFF
--- a/include/igl/opengl/MeshGL.cpp
+++ b/include/igl/opengl/MeshGL.cpp
@@ -220,6 +220,7 @@ R"(#version 150
   uniform float specular_exponent;
   uniform float lighting_factor;
   uniform float texture_factor;
+  uniform float double_sided;
   out vec4 outColor;
   void main()
   {
@@ -228,13 +229,13 @@ R"(#version 150
     vec3 vector_to_light_eye = light_position_eye - position_eye;
     vec3 direction_to_light_eye = normalize (vector_to_light_eye);
     float dot_prod = dot (direction_to_light_eye, normalize(normal_eye));
-    float clamped_dot_prod = max (dot_prod, 0.0);
+    float clamped_dot_prod = abs(max (dot_prod, -double_sided));
     vec3 Id = Ld * vec3(Kdi) * clamped_dot_prod;    // Diffuse intensity
 
     vec3 reflection_eye = reflect (-direction_to_light_eye, normalize(normal_eye));
     vec3 surface_to_viewer_eye = normalize (-position_eye);
     float dot_prod_specular = dot (reflection_eye, surface_to_viewer_eye);
-    dot_prod_specular = float(abs(dot_prod)==dot_prod) * max (dot_prod_specular, 0.0);
+    dot_prod_specular = float(abs(dot_prod)==dot_prod) * abs(max (dot_prod_specular, -double_sided));
     float specular_factor = pow (dot_prod_specular, specular_exponent);
     vec3 Is = Ls * vec3(Ksi) * specular_factor;    // specular intensity
     vec4 color = vec4(lighting_factor * (Is + Id) + Ia + (1.0-lighting_factor) * vec3(Kdi),(Kai.a+Ksi.a+Kdi.a)/3);

--- a/include/igl/opengl/ViewerCore.cpp
+++ b/include/igl/opengl/ViewerCore.cpp
@@ -186,7 +186,7 @@ IGL_INLINE void igl::opengl::ViewerCore::draw(
     {
       // Texture
       glUniform1f(texture_factori, is_set(data.show_texture) ? 1.0f : 0.0f);
-      glUniform1f(double_sidedi, is_set(data.double_sided) ? 1.0f : 0.0f);
+      glUniform1f(double_sidedi, data.double_sided ? 1.0f : 0.0f);
       data.meshgl.draw_mesh(true);
       glUniform1f(texture_factori, 0.0f);
     }

--- a/include/igl/opengl/ViewerCore.cpp
+++ b/include/igl/opengl/ViewerCore.cpp
@@ -172,6 +172,7 @@ IGL_INLINE void igl::opengl::ViewerCore::draw(
   GLint lighting_factori      = glGetUniformLocation(data.meshgl.shader_mesh,"lighting_factor");
   GLint fixed_colori          = glGetUniformLocation(data.meshgl.shader_mesh,"fixed_color");
   GLint texture_factori       = glGetUniformLocation(data.meshgl.shader_mesh,"texture_factor");
+  GLint double_sidedi         = glGetUniformLocation(data.meshgl.shader_mesh,"double_sided");
 
   glUniform1f(specular_exponenti, data.shininess);
   glUniform3fv(light_position_eyei, 1, light_position.data());
@@ -185,6 +186,7 @@ IGL_INLINE void igl::opengl::ViewerCore::draw(
     {
       // Texture
       glUniform1f(texture_factori, is_set(data.show_texture) ? 1.0f : 0.0f);
+      glUniform1f(double_sidedi, is_set(data.double_sided) ? 1.0f : 0.0f);
       data.meshgl.draw_mesh(true);
       glUniform1f(texture_factori, 0.0f);
     }

--- a/include/igl/opengl/ViewerData.cpp
+++ b/include/igl/opengl/ViewerData.cpp
@@ -30,6 +30,7 @@ IGL_INLINE igl::opengl::ViewerData::ViewerData()
   show_faceid       (false),
   show_labels       (false),
   show_texture      (false),
+  double_sided      (false),
   point_size(30),
   line_width(0.5f),
   line_color(0,0,0,1),
@@ -131,6 +132,7 @@ IGL_INLINE void igl::opengl::ViewerData::copy_options(const ViewerCore &from, co
   to.set(show_overlay      , from.is_set(show_overlay)      );
   to.set(show_overlay_depth, from.is_set(show_overlay_depth));
   to.set(show_texture      , from.is_set(show_texture)      );
+  to.set(double_sided      , from.is_set(double_sided)      );
   to.set(show_faces        , from.is_set(show_faces)        );
   to.set(show_lines        , from.is_set(show_lines)        );
 }
@@ -450,6 +452,7 @@ IGL_INLINE void igl::opengl::ViewerData::clear()
 
   face_based = false;
   show_texture = false;
+  double_sided = false;
 }
 
 IGL_INLINE void igl::opengl::ViewerData::compute_normals()

--- a/include/igl/opengl/ViewerData.cpp
+++ b/include/igl/opengl/ViewerData.cpp
@@ -23,6 +23,8 @@ IGL_INLINE igl::opengl::ViewerData::ViewerData()
 : dirty(MeshGL::DIRTY_ALL),
   show_faces        (~unsigned(0)),
   show_lines        (~unsigned(0)),
+  face_based        (false),
+  double_sided      (false),
   invert_normals    (false),
   show_overlay      (~unsigned(0)),
   show_overlay_depth(~unsigned(0)),
@@ -30,7 +32,6 @@ IGL_INLINE igl::opengl::ViewerData::ViewerData()
   show_faceid       (false),
   show_labels       (false),
   show_texture      (false),
-  double_sided      (false),
   point_size(30),
   line_width(0.5f),
   line_color(0,0,0,1),
@@ -132,7 +133,6 @@ IGL_INLINE void igl::opengl::ViewerData::copy_options(const ViewerCore &from, co
   to.set(show_overlay      , from.is_set(show_overlay)      );
   to.set(show_overlay_depth, from.is_set(show_overlay_depth));
   to.set(show_texture      , from.is_set(show_texture)      );
-  to.set(double_sided      , from.is_set(double_sided)      );
   to.set(show_faces        , from.is_set(show_faces)        );
   to.set(show_lines        , from.is_set(show_lines)        );
 }
@@ -451,8 +451,9 @@ IGL_INLINE void igl::opengl::ViewerData::clear()
   labels_strings.clear();
 
   face_based = false;
-  show_texture = false;
   double_sided = false;
+  invert_normals = false;
+  show_texture = false;
 }
 
 IGL_INLINE void igl::opengl::ViewerData::compute_normals()

--- a/include/igl/opengl/ViewerData.h
+++ b/include/igl/opengl/ViewerData.h
@@ -250,6 +250,7 @@ public:
   unsigned int show_overlay;
   unsigned int show_overlay_depth;
   unsigned int show_texture;
+  unsigned int double_sided;
   unsigned int show_faces;
   unsigned int show_lines;
   bool show_vertid; // shared across viewports for now
@@ -321,6 +322,7 @@ namespace igl
       SERIALIZE_MEMBER(show_faceid);
       SERIALIZE_MEMBER(show_labels);
       SERIALIZE_MEMBER(show_texture);
+      SERIALIZE_MEMBER(double_sided);
       SERIALIZE_MEMBER(point_size);
       SERIALIZE_MEMBER(line_width);
       SERIALIZE_MEMBER(line_color);

--- a/include/igl/opengl/ViewerData.h
+++ b/include/igl/opengl/ViewerData.h
@@ -240,6 +240,9 @@ public:
   // Enable per-face or per-vertex properties
   bool face_based;
 
+  // Enable double-sided lighting on faces
+  bool double_sided;
+
   // Invert mesh normals
   bool invert_normals;
 
@@ -250,7 +253,6 @@ public:
   unsigned int show_overlay;
   unsigned int show_overlay_depth;
   unsigned int show_texture;
-  unsigned int double_sided;
   unsigned int show_faces;
   unsigned int show_lines;
   bool show_vertid; // shared across viewports for now

--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -1,4 +1,4 @@
-// This file is part of libigl, a simple c++ geometry processing library. 
+// This file is part of libigl, a simple c++ geometry processing library.
 //
 // Copyright (C) 2014 Daniele Panozzo <daniele.panozzo@gmail.com>
 //
@@ -531,7 +531,7 @@ namespace glfw
       case 'D':
       case 'd':
       {
-        core().toggle(data().double_sided);
+        data().double_sided = !data().double_sided;
         return true;
       }
       case 'F':

--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -354,6 +354,7 @@ namespace glfw
     const std::string usage(R"(igl::opengl::glfw::Viewer usage:
   [drag]  Rotate scene
   A,a     Toggle animation (tight draw loop)
+  D,d     Toggle double sided lighting
   F,f     Toggle face based
   I,i     Toggle invert normals
   L,l     Toggle wireframe
@@ -525,6 +526,12 @@ namespace glfw
       case 'a':
       {
         core().is_animating = !core().is_animating;
+        return true;
+      }
+      case 'D':
+      case 'd':
+      {
+        core().toggle(data().double_sided);
         return true;
       }
       case 'F':


### PR DESCRIPTION
Add an option to display with double sided lighting. Helpful for poorly oriented models (like the truck in our test data) or for meshes that are the mid-surface of thin shape (rather than boundary of solid region).

![truck-double-sided](https://user-images.githubusercontent.com/2241689/79078279-4d996c00-7cd5-11ea-9e08-b753fda29a23.gif)


#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
