### PR TITLE
Matcaps (material captures aka environment maps) in Viewer

### DIFF
--- a/include/igl/opengl/MeshGL.cpp
+++ b/include/igl/opengl/MeshGL.cpp
@@ -220,26 +220,35 @@ R"(#version 150
   uniform float specular_exponent;
   uniform float lighting_factor;
   uniform float texture_factor;
+  uniform float matcap_factor;
   out vec4 outColor;
   void main()
   {
-    vec3 Ia = La * vec3(Kai);    // ambient intensity
+    if(matcap_factor == 1.0f)
+    {
+      vec2 uv = normalize(normal_eye).xy * 0.5 + 0.5;
+      outColor = texture(tex, uv);
+    }else
+    {
+      vec3 Ia = La * vec3(Kai);    // ambient intensity
 
-    vec3 vector_to_light_eye = light_position_eye - position_eye;
-    vec3 direction_to_light_eye = normalize (vector_to_light_eye);
-    float dot_prod = dot (direction_to_light_eye, normalize(normal_eye));
-    float clamped_dot_prod = max (dot_prod, 0.0);
-    vec3 Id = Ld * vec3(Kdi) * clamped_dot_prod;    // Diffuse intensity
+      vec3 vector_to_light_eye = light_position_eye - position_eye;
+      vec3 direction_to_light_eye = normalize (vector_to_light_eye);
+      float dot_prod = dot (direction_to_light_eye, normalize(normal_eye));
+      float clamped_dot_prod = max (dot_prod, 0.0);
+      vec3 Id = Ld * vec3(Kdi) * clamped_dot_prod;    // Diffuse intensity
 
-    vec3 reflection_eye = reflect (-direction_to_light_eye, normalize(normal_eye));
-    vec3 surface_to_viewer_eye = normalize (-position_eye);
-    float dot_prod_specular = dot (reflection_eye, surface_to_viewer_eye);
-    dot_prod_specular = float(abs(dot_prod)==dot_prod) * max (dot_prod_specular, 0.0);
-    float specular_factor = pow (dot_prod_specular, specular_exponent);
-    vec3 Is = Ls * vec3(Ksi) * specular_factor;    // specular intensity
-    vec4 color = vec4(lighting_factor * (Is + Id) + Ia + (1.0-lighting_factor) * vec3(Kdi),(Kai.a+Ksi.a+Kdi.a)/3);
-    outColor = mix(vec4(1,1,1,1), texture(tex, texcoordi), texture_factor) * color;
-    if (fixed_color != vec4(0.0)) outColor = fixed_color;
+      vec3 reflection_eye = reflect (-direction_to_light_eye, normalize(normal_eye));
+      vec3 surface_to_viewer_eye = normalize (-position_eye);
+      float dot_prod_specular = dot (reflection_eye, surface_to_viewer_eye);
+      dot_prod_specular = float(abs(dot_prod)==dot_prod) * max (dot_prod_specular, 0.0);
+      float specular_factor = pow (dot_prod_specular, specular_exponent);
+      vec3 Is = Ls * vec3(Ksi) * specular_factor;    // specular intensity
+      vec4 color = vec4(lighting_factor * (Is + Id) + Ia + (1.0-lighting_factor) * vec3(Kdi),(Kai.a+Ksi.a+Kdi.a)/3);
+      outColor = mix(vec4(1,1,1,1), texture(tex, texcoordi), texture_factor) * color;
+
+      if (fixed_color != vec4(0.0)) outColor = fixed_color;
+    }
   }
 )";
 

--- a/include/igl/opengl/ViewerCore.cpp
+++ b/include/igl/opengl/ViewerCore.cpp
@@ -172,6 +172,7 @@ IGL_INLINE void igl::opengl::ViewerCore::draw(
   GLint lighting_factori      = glGetUniformLocation(data.meshgl.shader_mesh,"lighting_factor");
   GLint fixed_colori          = glGetUniformLocation(data.meshgl.shader_mesh,"fixed_color");
   GLint texture_factori       = glGetUniformLocation(data.meshgl.shader_mesh,"texture_factor");
+  GLint matcap_factori        = glGetUniformLocation(data.meshgl.shader_mesh,"matcap_factor");
 
   glUniform1f(specular_exponenti, data.shininess);
   glUniform3fv(light_position_eyei, 1, light_position.data());
@@ -185,7 +186,9 @@ IGL_INLINE void igl::opengl::ViewerCore::draw(
     {
       // Texture
       glUniform1f(texture_factori, is_set(data.show_texture) ? 1.0f : 0.0f);
+      glUniform1f(matcap_factori, is_set(data.use_matcap) ? 1.0f : 0.0f);
       data.meshgl.draw_mesh(true);
+      glUniform1f(matcap_factori, 0.0f);
       glUniform1f(texture_factori, 0.0f);
     }
 

--- a/include/igl/opengl/ViewerData.cpp
+++ b/include/igl/opengl/ViewerData.cpp
@@ -80,6 +80,9 @@ IGL_INLINE void igl::opengl::ViewerData::set_mesh(
       Eigen::Vector3d(GOLD_AMBIENT[0], GOLD_AMBIENT[1], GOLD_AMBIENT[2]),
       Eigen::Vector3d(GOLD_DIFFUSE[0], GOLD_DIFFUSE[1], GOLD_DIFFUSE[2]),
       Eigen::Vector3d(GOLD_SPECULAR[0], GOLD_SPECULAR[1], GOLD_SPECULAR[2]));
+
+    // Generates a checkerboard texture
+    grid_texture();
   }
   else
   {
@@ -531,6 +534,27 @@ IGL_INLINE void igl::opengl::ViewerData::normal_matcap()
     }
   }
   texture_A.setConstant(texture_R.rows(),texture_R.cols(),255);
+  dirty |= MeshGL::DIRTY_TEXTURE;
+}
+
+IGL_INLINE void igl::opengl::ViewerData::grid_texture()
+{
+  unsigned size = 128;
+  unsigned size2 = size/2;
+  texture_R.resize(size, size);
+  for (unsigned i=0; i<size; ++i)
+  {
+    for (unsigned j=0; j<size; ++j)
+    {
+      texture_R(i,j) = 0;
+      if ((i<size2 && j<size2) || (i>=size2 && j>=size2))
+        texture_R(i,j) = 255;
+    }
+  }
+
+  texture_G = texture_R;
+  texture_B = texture_R;
+  texture_A = Eigen::Matrix<unsigned char,Eigen::Dynamic,Eigen::Dynamic>::Constant(texture_R.rows(),texture_R.cols(),255);
   dirty |= MeshGL::DIRTY_TEXTURE;
 }
 

--- a/include/igl/opengl/ViewerData.cpp
+++ b/include/igl/opengl/ViewerData.cpp
@@ -80,11 +80,6 @@ IGL_INLINE void igl::opengl::ViewerData::set_mesh(
       Eigen::Vector3d(GOLD_AMBIENT[0], GOLD_AMBIENT[1], GOLD_AMBIENT[2]),
       Eigen::Vector3d(GOLD_DIFFUSE[0], GOLD_DIFFUSE[1], GOLD_DIFFUSE[2]),
       Eigen::Vector3d(GOLD_SPECULAR[0], GOLD_SPECULAR[1], GOLD_SPECULAR[2]));
-
-    // Alec: is anyone really using this default? It uses trivial UVs and
-    // produces an anisotropic checkerboard...
-    //grid_texture();
-    normal_matcap();
   }
   else
   {
@@ -536,44 +531,6 @@ IGL_INLINE void igl::opengl::ViewerData::normal_matcap()
     }
   }
   texture_A.setConstant(texture_R.rows(),texture_R.cols(),255);
-  dirty |= MeshGL::DIRTY_TEXTURE;
-}
-
-IGL_INLINE void igl::opengl::ViewerData::grid_texture()
-{
-  // Don't do anything for an empty mesh
-  if(V.rows() == 0)
-  {
-    V_uv.resize(V.rows(),2);
-    return;
-  }
-  if (V_uv.rows() == 0)
-  {
-    V_uv = V.block(0, 0, V.rows(), 2);
-    V_uv.col(0) = V_uv.col(0).array() - V_uv.col(0).minCoeff();
-    V_uv.col(0) = V_uv.col(0).array() / V_uv.col(0).maxCoeff();
-    V_uv.col(1) = V_uv.col(1).array() - V_uv.col(1).minCoeff();
-    V_uv.col(1) = V_uv.col(1).array() / V_uv.col(1).maxCoeff();
-    V_uv = V_uv.array() * 10;
-    dirty |= MeshGL::DIRTY_TEXTURE;
-  }
-
-  unsigned size = 128;
-  unsigned size2 = size/2;
-  texture_R.resize(size, size);
-  for (unsigned i=0; i<size; ++i)
-  {
-    for (unsigned j=0; j<size; ++j)
-    {
-      texture_R(i,j) = 0;
-      if ((i<size2 && j<size2) || (i>=size2 && j>=size2))
-        texture_R(i,j) = 255;
-    }
-  }
-
-  texture_G = texture_R;
-  texture_B = texture_R;
-  texture_A = Eigen::Matrix<unsigned char,Eigen::Dynamic,Eigen::Dynamic>::Constant(texture_R.rows(),texture_R.cols(),255);
   dirty |= MeshGL::DIRTY_TEXTURE;
 }
 

--- a/include/igl/opengl/ViewerData.h
+++ b/include/igl/opengl/ViewerData.h
@@ -183,6 +183,8 @@ public:
     const Eigen::Vector4d& diffuse,
     const Eigen::Vector4d& specular);
 
+  // Generate a normal image matcap
+  IGL_INLINE void normal_matcap();
   // Generates a default grid texture
   IGL_INLINE void grid_texture();
 
@@ -250,6 +252,7 @@ public:
   unsigned int show_overlay;
   unsigned int show_overlay_depth;
   unsigned int show_texture;
+  unsigned int use_matcap;
   unsigned int show_faces;
   unsigned int show_lines;
   bool show_vertid; // shared across viewports for now

--- a/include/igl/opengl/ViewerData.h
+++ b/include/igl/opengl/ViewerData.h
@@ -185,8 +185,6 @@ public:
 
   // Generate a normal image matcap
   IGL_INLINE void normal_matcap();
-  // Generates a default grid texture
-  IGL_INLINE void grid_texture();
 
   // Copy visualization options from one viewport to another
   IGL_INLINE void copy_options(const ViewerCore &from, const ViewerCore &to);

--- a/include/igl/opengl/ViewerData.h
+++ b/include/igl/opengl/ViewerData.h
@@ -186,6 +186,9 @@ public:
   // Generate a normal image matcap
   IGL_INLINE void normal_matcap();
 
+  // Generates a default grid texture (without uvs)
+  IGL_INLINE void grid_texture();
+
   // Copy visualization options from one viewport to another
   IGL_INLINE void copy_options(const ViewerCore &from, const ViewerCore &to);
 

--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -447,11 +447,6 @@ namespace glfw
                    Eigen::Vector3d(255.0/255.0,228.0/255.0,58.0/255.0),
                    Eigen::Vector3d(255.0/255.0,235.0/255.0,80.0/255.0));
 
-    // Alec: why?
-    if (data().V_uv.rows() == 0)
-    {
-      data().grid_texture();
-    }
     for(int i=0;i<core_list.size(); i++)
         core_list[i].align_camera_center(data().V,data().F);
 


### PR DESCRIPTION
Texture slot can be used as a material capture (also known as environment map). Swapping in a [matcap](https://github.com/nidorx/matcaps) from an image is very simple.

Here's a minimal example

```
#include <igl/opengl/glfw/Viewer.h>
#include <igl/read_triangle_mesh.h>
#include <igl/png/readPNG.h>

int main(int argc, char *argv[])
{
  igl::opengl::glfw::Viewer v;
  Eigen::MatrixXd V;
  Eigen::MatrixXi F;
  igl::read_triangle_mesh(argv[1],V,F);
  Eigen::Matrix<unsigned char,Eigen::Dynamic,Eigen::Dynamic> R,G,B,A;
  igl::png::readPNG(argv[2],R,G,B,A);
  v.data().set_mesh(V,F);
  v.data().set_texture(R,G,B,A);
  v.data().use_matcap = true;
  v.data().show_lines = false;
  v.launch();
}
```

For example, then
`./main beetle.off Chrome.png` will produce

<img width="635" alt="Screen Shot 2020-04-12 at 8 30 59 PM" src="https://user-images.githubusercontent.com/2241689/79083527-d11a8380-7cfc-11ea-819e-3b715c3d8f2e.png">

[Chrome.png.zip](https://github.com/libigl/libigl/files/4467466/Chrome.png.zip)

**_Note:_** I've disabled the automatic call to  `grid_texture()` in `ViewerData`. I wonder if this was really being used _as is_ like this. I made the judgement call that putting a default matcap in the texture is more useful (and that leaving the `V_uv` empty is more correct). 

related posts: 
 - https://twitter.com/_AlecJacobson/status/1207728511861088256 
 - http://www.alecjacobson.com/weblog/?p=4827
 - https://github.com/alecjacobson/matcap-viewer