### PR TITLE
Update remove_duplicate_vertices.h

### DIFF
--- a/include/igl/remove_duplicate_vertices.h
+++ b/include/igl/remove_duplicate_vertices.h
@@ -15,7 +15,7 @@ namespace igl
   // tolerance (epsilon)
   //
   // Inputs:
-  //   V  #V by dim list of vertex positions
+  //   V  #SV by dim list of vertex positions
   //   epsilon  uniqueness tolerance (significant digit), can probably think of
   //     this as a tolerance on L1 distance
   // Outputs:

--- a/include/igl/remove_duplicate_vertices.h
+++ b/include/igl/remove_duplicate_vertices.h
@@ -15,11 +15,11 @@ namespace igl
   // tolerance (epsilon)
   //
   // Inputs:
-  //   V  #SV by dim list of vertex positions
+  //   V  #V by dim list of vertex positions
   //   epsilon  uniqueness tolerance (significant digit), can probably think of
   //     this as a tolerance on L1 distance
   // Outputs:
-  //   SV  #V by dim new list of vertex positions
+  //   SV  #SV by dim new list of vertex positions
   //   SVI #SV by 1 list of indices so SV = V(SVI,:) 
   //   SVJ #V by 1 list of indices so V = SV(SVJ,:)
   //

--- a/include/igl/remove_duplicate_vertices.h
+++ b/include/igl/remove_duplicate_vertices.h
@@ -19,9 +19,9 @@ namespace igl
   //   epsilon  uniqueness tolerance (significant digit), can probably think of
   //     this as a tolerance on L1 distance
   // Outputs:
-  //   SV  #SV by dim new list of vertex positions
-  //   SVI #V by 1 list of indices so SV = V(SVI,:) 
-  //   SVJ #SV by 1 list of indices so V = SV(SVJ,:)
+  //   SV  #V by dim new list of vertex positions
+  //   SVI #SV by 1 list of indices so SV = V(SVI,:) 
+  //   SVJ #V by 1 list of indices so V = SV(SVJ,:)
   //
   // Example:
   //   % Mesh in (V,F)


### PR DESCRIPTION
Seems to be a typo in the documentation


#### Check all that apply (change to `[x]`)
- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
