### PR TITLE
Specify if the color matrix should be applied to the verticies or faces. 

### DIFF
--- a/include/igl/opengl/ViewerData.cpp
+++ b/include/igl/opengl/ViewerData.cpp
@@ -140,7 +140,7 @@ IGL_INLINE void igl::opengl::ViewerData::copy_options(const ViewerCore &from, co
   to.set(show_lines        , from.is_set(show_lines)        );
 }
 
-IGL_INLINE void igl::opengl::ViewerData::set_colors(const Eigen::MatrixXd &C)
+IGL_INLINE void igl::opengl::ViewerData::set_colors(const Eigen::MatrixXd &C, ColorDataType cdt)
 {
   using namespace std;
   using namespace Eigen;
@@ -189,7 +189,7 @@ IGL_INLINE void igl::opengl::ViewerData::set_colors(const Eigen::MatrixXd &C)
     F_material_ambient = ambient(F_material_diffuse);
     F_material_specular = specular(F_material_diffuse);
   }
-  else if (C.rows() == V.rows())
+  else if (C.rows() == V.rows() && (cdt == COLOR_DATA_TYPE_AUTO || cdt == COLOR_DATA_TYPE_VERTICIES))
   {
     set_face_based(false);
     for (unsigned i=0;i<V_material_diffuse.rows();++i)
@@ -202,7 +202,7 @@ IGL_INLINE void igl::opengl::ViewerData::set_colors(const Eigen::MatrixXd &C)
     V_material_ambient = ambient(V_material_diffuse);
     V_material_specular = specular(V_material_diffuse);
   }
-  else if (C.rows() == F.rows())
+  else if (C.rows() == F.rows() && (cdt == COLOR_DATA_TYPE_AUTO || cdt == COLOR_DATA_TYPE_FACES))
   {
     set_face_based(true);
     for (unsigned i=0;i<F_material_diffuse.rows();++i)

--- a/include/igl/opengl/ViewerData.h
+++ b/include/igl/opengl/ViewerData.h
@@ -60,7 +60,13 @@ public:
   //
   // Inputs:
   //   C  #V|#F|1 by 3 list of colors
-  IGL_INLINE void set_colors(const Eigen::MatrixXd &C);
+  enum ColorDataType 
+  {
+    COLOR_DATA_TYPE_AUTO = 0,  //  infer if the input color matrix is applied to verticies or faces
+    COLOR_DATA_TYPE_VERTICIES = 1, // color matrix is applied to verticies
+    COLOR_DATA_TYPE_FACES = 2 // color matrix is applied to faces
+  };
+  IGL_INLINE void set_colors(const Eigen::MatrixXd &C, ColorDataType cdt = COLOR_DATA_TYPE_AUTO);
 
   // Set per-vertex UV coordinates
   //


### PR DESCRIPTION
[Describe your changes and what you've already done to test it.]
Right now ViewerData::set_colors automatically determines if the color matrix is applied to vertices or faces by checking the number of rows in the color matrix and matching them against the number of rows in V/F matrices. This is fine for typical triangular meshes where the number of vertices and faces is usually different. But in cases where the triangular mesh is the result of splitting tet mesh into 4 triangles, then the number of vertices and faces will be the same (4*#numtets).   In that case ViewerData::set_colors will just default to assuming the color matrix should be applied to vertices even if you want it to be applied to faces.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
