### PR TITLE
load_mesh obj fix

### DIFF
--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -432,6 +432,7 @@ namespace glfw
       }
 
       data().set_mesh(V,F);
+      if(!UV_V.empty() && !UV_F.empty()) // not every obj file contains UV_V,UV_F information.
       data().set_uv(UV_V,UV_F);
 
     }


### PR DESCRIPTION
Fixes # .

 Not all obj files contain UV_V information and igl::readOBJ might return an empty Matrix for this argument.

#### Check all that apply (change to `[x]`)
- [X] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [X] This is a minor change.
