### PR TITLE
Fixed load_mesh for obj

### DIFF
--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -432,8 +432,10 @@ namespace glfw
       }
 
       data().set_mesh(V,F);
-      data().set_uv(UV_V,UV_F);
-
+      if(!UV_V.rows() != 0 && UV_F.rows() != 0)
+      {
+        data().set_uv(UV_V,UV_F);
+      }
     }
     else
     {


### PR DESCRIPTION
Fixes # .

igl::readOBJ might return a zero matrix for UV_V,UV_F


#### Check all that apply (change to `[x]`)
- [X] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [X] This is a minor change.
