### PR TITLE
Address memory heap corruption on Windows open dialog on long filenames

### DIFF
--- a/include/igl/file_dialog_open.cpp
+++ b/include/igl/file_dialog_open.cpp
@@ -60,7 +60,7 @@ IGL_INLINE std::string igl::file_dialog_open()
   ZeroMemory(&ofn, sizeof(ofn));
   ofn.lStructSize = sizeof(ofn);
   ofn.hwndOwner = NULL;
-  ofn.lpstrFile = new char[100];
+  ofn.lpstrFile = szFile;
   // Set lpstrFile[0] to '\0' so that GetOpenFileName does not
   // use the contents of szFile to initialize itself.
   ofn.lpstrFile[0] = '\0';

--- a/include/igl/file_dialog_save.cpp
+++ b/include/igl/file_dialog_save.cpp
@@ -60,7 +60,7 @@ IGL_INLINE std::string igl::file_dialog_save()
   ZeroMemory(&ofn, sizeof(ofn));
   ofn.lStructSize = sizeof(ofn);
   ofn.hwndOwner = NULL;//hwnd;
-  ofn.lpstrFile = new char[100];
+  ofn.lpstrFile = szFile;
   // Set lpstrFile[0] to '\0' so that GetOpenFileName does not
   // use the contents of szFile to initialize itself.
   ofn.lpstrFile[0] = '\0';


### PR DESCRIPTION
Should fix #1513. It seems the solution to the issue was correctly identified but no PR was made for it yet.

As far as I can tell there was a buffer (szBuffer) that was intended to be used instead of the dynamic allocation, but it was unused. I just made the structure use that buffer, which matches the size defined elsewhere.

