### PR TITLE
ImGui Update to v1.76

### DIFF
--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -103,12 +103,12 @@ endfunction()
 function(igl_download_imgui)
 	igl_download_project(imgui
 		GIT_REPOSITORY https://github.com/ocornut/imgui.git
-		GIT_TAG        v1.69
+		GIT_TAG        v1.76
 		${LIBIGL_BRANCH_OPTIONS}
 	)
 	igl_download_project(libigl-imgui
-		GIT_REPOSITORY https://github.com/libigl/libigl-imgui.git
-		GIT_TAG        07ecd3858acc71e70f0f9b2dea20a139bdddf8ae
+		GIT_REPOSITORY https://github.com/gmin7/libigl-imgui.git
+		GIT_TAG        92fbf1318ebd044beaf3a70e2e549081816851cc
 	)
 endfunction()
 

--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -107,8 +107,8 @@ function(igl_download_imgui)
 		${LIBIGL_BRANCH_OPTIONS}
 	)
 	igl_download_project(libigl-imgui
-		GIT_REPOSITORY https://github.com/gmin7/libigl-imgui.git
-		GIT_TAG        92fbf1318ebd044beaf3a70e2e549081816851cc
+		GIT_REPOSITORY https://github.com/libigl/libigl-imgui.git
+		GIT_TAG        99f0643089b19f6daf5b3efd9544a65c9a851966
 	)
 endfunction()
 

--- a/include/igl/opengl/glfw/imgui/ImGuiMenu.cpp
+++ b/include/igl/opengl/glfw/imgui/ImGuiMenu.cpp
@@ -167,8 +167,8 @@ IGL_INLINE void ImGuiMenu::draw_menu()
 IGL_INLINE void ImGuiMenu::draw_viewer_window()
 {
   float menu_width = 180.f * menu_scaling();
-  ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiSetCond_FirstUseEver);
-  ImGui::SetNextWindowSize(ImVec2(0.0f, 0.0f), ImGuiSetCond_FirstUseEver);
+  ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowSize(ImVec2(0.0f, 0.0f), ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowSizeConstraints(ImVec2(menu_width, -1.0f), ImVec2(menu_width, -1.0f));
   bool _viewer_menu_visible = true;
   ImGui::Begin(
@@ -310,8 +310,8 @@ IGL_INLINE void ImGuiMenu::draw_viewer_menu()
 IGL_INLINE void ImGuiMenu::draw_labels_window()
 {
   // Text labels
-  ImGui::SetNextWindowPos(ImVec2(0,0), ImGuiSetCond_Always);
-  ImGui::SetNextWindowSize(ImGui::GetIO().DisplaySize, ImGuiSetCond_Always);
+  ImGui::SetNextWindowPos(ImVec2(0,0), ImGuiCond_Always);
+  ImGui::SetNextWindowSize(ImGui::GetIO().DisplaySize, ImGuiCond_Always);
   bool visible = true;
   ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0,0,0,0));
   ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0);

--- a/tutorial/106_ViewerMenu/main.cpp
+++ b/tutorial/106_ViewerMenu/main.cpp
@@ -79,8 +79,8 @@ int main(int argc, char *argv[])
   menu.callback_draw_custom_window = [&]()
   {
     // Define next window position + size
-    ImGui::SetNextWindowPos(ImVec2(180.f * menu.menu_scaling(), 10), ImGuiSetCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2(200, 160), ImGuiSetCond_FirstUseEver);
+    ImGui::SetNextWindowPos(ImVec2(180.f * menu.menu_scaling(), 10), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(200, 160), ImGuiCond_FirstUseEver);
     ImGui::Begin(
         "New Window", nullptr,
         ImGuiWindowFlags_NoSavedSettings


### PR DESCRIPTION
- Clones latest release of Dear ImGui (`v1.76`)
- Resolved breaking change: Renames ImGui variables that were changed in `v1.51`
- Tested by building tutorial 106 and ensuring all the options in the ImGui Menu are still functional
- In `v1.76` Dear ImGui included `imgui.h` in some header files which are exposed directly to the application for invariance of ordering of include headers within usage of the library. (See https://github.com/ocornut/imgui/commit/00927105ba6b14f6d05a651b316428a8342fb4d3) This caused a breaking change for us as until now ImGui has not been exposed to libigl. Hence needed to make ImGui directory `PUBLIC` to libigl through `libigl-imgui` repo. However, this PR uses my fork of `libigl-imgui` which modifies the commit in current `libigl` master (`07ecd38`) to achieve the aforementioned, but we need to update this change in the official https://github.com/libigl/libigl-imgui repo before this is merged.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
