### PR TITLE
Add 719_ExplodedView to tutorials folder.

### DIFF
--- a/cmake/LibiglFolders.cmake
+++ b/cmake/LibiglFolders.cmake
@@ -111,6 +111,7 @@ igl_folder_targets("Tutorials"
     715_MeshImplicitFunction_bin
     716_HeatGeodesics_bin
     718_IterativeClosestPoint_bin
+    719_ExplodedView_bin
 )
 
 endfunction()


### PR DESCRIPTION
I noticed that tutorial 719 was outside of the tutorials folder in the Visual Studio solution. After running a comparison against the other tutorials, it seems this line was missing from LibiglFolders.cmake. Regenerating the solution with this line added fixes the problem.

- [x] This is a minor change.
