### PR TITLE
Viewer crash after calling clear

### DIFF
--- a/include/igl/opengl/ViewerData.cpp
+++ b/include/igl/opengl/ViewerData.cpp
@@ -694,7 +694,7 @@ IGL_INLINE void igl::opengl::ViewerData::updateGL(
           meshgl.F_vbo.row(i) << i*3+0, i*3+1, i*3+2;
       }
 
-      if (meshgl.dirty & MeshGL::DIRTY_UV)
+      if ( (meshgl.dirty & MeshGL::DIRTY_UV) && data.V_uv.rows()>0)
       {
         meshgl.V_uv_vbo.resize(data.F.rows()*3,2);
         for (unsigned i=0; i<data.F.rows();++i)


### PR DESCRIPTION
missing check for empty uv similar to line 747


#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] This is a minor change.
