### PR TITLE
Fixed behaviour of writePLY to properly treat force_ascii flag

### DIFF
--- a/include/igl/writePLY.cpp
+++ b/include/igl/writePLY.cpp
@@ -313,7 +313,7 @@ bool writePLY(
   std::vector<std::string> _dummy_header;
 
   return writePLY(filename,V,F,_dummy, _dummy,_dummy, _dummy, _dummy_header,
-                         _dummy, _dummy_header, _dummy, _dummy_header, _dummy_header, force_ascii);
+                         _dummy, _dummy_header, _dummy, _dummy_header, _dummy_header, !force_ascii);
 }
 
 template <
@@ -333,7 +333,7 @@ bool writePLY(
   std::vector<std::string> _dummy_header;
 
   return writePLY(filename,V,F,E, _dummy,_dummy, _dummy, _dummy_header,
-                         _dummy, _dummy_header, _dummy, _dummy_header, _dummy_header, force_ascii);
+                         _dummy, _dummy_header, _dummy, _dummy_header, _dummy_header, !force_ascii);
 }
 
 


### PR DESCRIPTION
`writePLY(X,V,force_ascii)` was not treating `force_ascii` as expected. 
This commit fixes it. 

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
