### PR TITLE
Use dense matrix to improve performance of MIQ with constraints.

### DIFF
--- a/include/igl/copyleft/comiso/miq.cpp
+++ b/include/igl/copyleft/comiso/miq.cpp
@@ -194,6 +194,7 @@ namespace comiso {
     // Matrices
     Eigen::SparseMatrix<double> Lhs;
     Eigen::SparseMatrix<double> Constraints;
+    Eigen::MatrixXd T;
     Eigen::VectorXd rhs;
     Eigen::VectorXd constraints_rhs;
     ///vector of unknowns
@@ -1033,16 +1034,19 @@ IGL_INLINE void igl::copyleft::comiso::PoissonSolver<DerivedV, DerivedF>::buildU
 
   assert(num_userdefined_constraint == userdefined_constraints.size());
 
+  T.resize(Constraints.rows(), Constraints.cols());
+  T = Eigen::MatrixXd(Constraints);
   for (unsigned int i = 0; i < num_userdefined_constraint; i++)
   {
     for (unsigned int j = 0; j < userdefined_constraints[i].size()-1; ++j)
     {
-      Constraints.coeffRef(constr_row, j) = userdefined_constraints[i][j];
+      T(constr_row, j) = userdefined_constraints[i][j];
     }
 
     constraints_rhs[constr_row] = userdefined_constraints[i][userdefined_constraints[i].size()-1];
     constr_row +=1;
   }
+  Constraints = T.sparseView();
 }
 
 ///call of the mixed integer solver


### PR DESCRIPTION
Fixes performance problem of MIQ algorithm with constraints.

Change constraint matrix from sparse matrix to dense matrix to gain performance advantage. The constraint matrix can be large when constraints increase. In a test of fandisk model with 14454 facets and 682 edge constraints, the sparse constraint matrix's size is about 10 million, which leads to 1.5 hours to loop over the matrix (test on MBP 2016 with  2.6GHz quad-core Intel Core i7). As a contrast, the dense one need only about 16 seconds. 


#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
