### PR TITLE
Clarify, fix bug in epsilon parameter in remove_duplicate_vertices

### DIFF
--- a/include/igl/remove_duplicate_vertices.cpp
+++ b/include/igl/remove_duplicate_vertices.cpp
@@ -27,7 +27,7 @@ IGL_INLINE void igl::remove_duplicate_vertices(
   if(epsilon > 0)
   {
     DerivedV rV,rSV;
-    round((V/(10.0*epsilon)).eval(),rV);
+    round((V/(epsilon)).eval(),rV);
     unique_rows(rV,rSV,SVI,SVJ);
     slice(V,SVI,colon<typename DerivedSVI::Scalar>(0,V.cols()-1),SV);
   }else

--- a/include/igl/remove_duplicate_vertices.h
+++ b/include/igl/remove_duplicate_vertices.h
@@ -16,8 +16,8 @@ namespace igl
   //
   // Inputs:
   //   V  #V by dim list of vertex positions
-  //   epsilon  uniqueness tolerance (significant digit), can probably think of
-  //     this as a tolerance on L1 distance
+  //   epsilon  uniqueness tolerance used coordinate-wise: 1e0 --> integer
+  //     match, 1e-1 --> match up to first decimal, ... , 0 --> exact match.
   // Outputs:
   //   SV  #SV by dim new list of vertex positions
   //   SVI #SV by 1 list of indices so SV = V(SVI,:) 


### PR DESCRIPTION
Noticed in gptoolbox: https://github.com/alecjacobson/gptoolbox/issues/81

most of the time we use `epsilon=0` so this bug/confusion didn't matter.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
