### PR TITLE
Update libigl.cmake

### DIFF
--- a/cmake/libigl.cmake
+++ b/cmake/libigl.cmake
@@ -103,8 +103,8 @@ endif()
 
 if(HUNTER_ENABLED)
   hunter_add_package(Eigen)
-  find_package(Eigen3 CONFIG REQUIRED)
 endif()
+find_package(Eigen3 CONFIG QUIET)
 
 # Eigen
 if(NOT TARGET Eigen3::Eigen)


### PR DESCRIPTION
https://github.com/libigl/libigl/issues/1556

give a chance for cmake to pick up user provided Eigen3 through defining -DEigen3_DIR=${usr_path} when configuring the libigl.

Fixes # .

[Describe your changes and what you've already done to test it.]


#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
