### PR TITLE
Deletes print statement in the exact_geodesics method

### DIFF
--- a/include/igl/exact_geodesic.cpp
+++ b/include/igl/exact_geodesic.cpp
@@ -1027,7 +1027,6 @@ inline void Mesh::build_adjacencies()
 
 inline bool Mesh::verify()		//verifies connectivity of the mesh and prints some debug info
 {
-	std::cout << std::endl;
 	// make sure that all vertices are mentioned at least once.
 	// though the loose vertex is not a bug, it most likely indicates that something is wrong with the mesh
 	std::vector<bool> map(m_vertices.size(), false);


### PR DESCRIPTION
The print statement is always called, which affects debugging output of
calling code.

Fixes # .

[Describe your changes and what you've already done to test it.]
Deletes a print statement in the exact geodesic method that only outputs whitespace.

#### Check all that apply (change to `[x]`)
- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
