### PR TITLE
Use new gitlab remote to clone Eigen.

### DIFF
--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -67,7 +67,7 @@ endfunction()
 set(LIBIGL_EIGEN_VERSION 3.3.7 CACHE STRING "Default version of Eigen used by libigl.")
 function(igl_download_eigen)
 	igl_download_project(eigen
-		GIT_REPOSITORY https://github.com/eigenteam/eigen-git-mirror.git
+		GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
 		GIT_TAG        ${LIBIGL_EIGEN_VERSION}
 		${LIBIGL_BRANCH_OPTIONS}
 	)
@@ -196,4 +196,3 @@ function(igl_download_tutorial_data)
 		GIT_TAG        37d4e836054c9c2d2125a817c489ed8e07cd56fc
 	)
 endfunction()
-


### PR DESCRIPTION
As [Eigen is now on GitLab.com](http://eigen.tuxfamily.org/index.php?title=News:Eigen_is_now_on_GitLab.com) change path to Eigen's git repository in cmake.
The old github repo is only kept for convenience but does not receive further updates.
Using the repo on gitlab.com it's possible to change to the latest Eigen version 3.3.8 ([ChangeLog](http://eigen.tuxfamily.org/index.php?title=ChangeLog#Eigen_3.3.8) )
Whether updating to Eigen 3.3.8 is a good idea/worth it or not is another story.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] This is a minor change.
