### PR TITLE
Fix bug in readSTL

### DIFF
--- a/include/igl/readSTL.cpp
+++ b/include/igl/readSTL.cpp
@@ -48,6 +48,7 @@ IGL_INLINE bool is_stl_binary(std::istream &input) {
   constexpr size_t HEADER_SIZE = 80;
   char header[HEADER_SIZE];
   input.read(header, HEADER_SIZE);
+  input.seekg(start_pos);
   if (!starts_with(header, "solid")) {
     return true;
   }

--- a/include/igl/readSTL.cpp
+++ b/include/igl/readSTL.cpp
@@ -48,11 +48,12 @@ IGL_INLINE bool is_stl_binary(std::istream &input) {
   constexpr size_t HEADER_SIZE = 80;
   char header[HEADER_SIZE];
   input.read(header, HEADER_SIZE);
-  input.seekg(start_pos);
   if (!starts_with(header, "solid")) {
+    input.seekg(start_pos);
     return true;
   }
   if (!input.good()) {
+    input.seekg(start_pos);
     return false;
   }
 


### PR DESCRIPTION
reset the position of the current character in the input

Fixes # .

[Describe your changes and what you've already done to test it.]

Commit 1e905cba3d5e7d82487a6826d0d3fa7cd47de114 introduces bug in readSTL.
- when `is_stl_binary(...)` is called, the position of the current character for `std::istream input` is accidentally updated because of `input.read(...)`. So, I just add `input.seekg(...)` to reset the position.

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
