### PR TITLE
Update per_vertex_point_to_plane_quadrics.cpp

### DIFF
--- a/include/igl/per_vertex_point_to_plane_quadrics.cpp
+++ b/include/igl/per_vertex_point_to_plane_quadrics.cpp
@@ -143,7 +143,7 @@ IGL_INLINE void igl::per_vertex_point_to_plane_quadrics(
       assert(N.rows() == ev.size()-2);
       Eigen::MatrixXd S(N.rows()+1,ev.size());
       S<<ev,N;
-      Quadric boundary_edge_quadric = subspace_quadric(p,S,length);
+      Quadric boundary_edge_quadric = subspace_quadric(p,S,length*length);
       for(int c = 0;c<3;c++)
       {
         if(c != infinite_corner)


### PR DESCRIPTION
change boundary weight from length to length squared so that it has the same unit as face_quadric

#### Check all that apply (change to `[x]`)
- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.