### PR TITLE
writePLY fix

### DIFF
--- a/include/igl/writePLY.cpp
+++ b/include/igl/writePLY.cpp
@@ -147,7 +147,7 @@ bool writePLY(
         _ed.resize(ED.size());
         Eigen::Map<Eigen::Matrix<EDScalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor > >( &_ed[0], ED.rows(), ED.cols() ) = ED;
 
-        file.add_properties_to_element("face", FDheader,
+        file.add_properties_to_element("edge", EDheader,
             tynyply_type<EDScalar>(), ED.rows(), reinterpret_cast<uint8_t*>( &_ed[0] ), tinyply::Type::INVALID, 0);
     }
 

--- a/tests/include/igl/writePLY.cpp
+++ b/tests/include/igl/writePLY.cpp
@@ -27,9 +27,16 @@ TEST_CASE("writePLY: bunny.ply", "[igl]")
     Eigen::MatrixXd VD2(V1.rows(),VD1.cols()+1);
     VD2<<VD1,dummy_data;
 
+    Fheader1.push_back("face_data");
+    Eigen::VectorXd face_data(F1.rows());
+    for(size_t i=0;i<F1.rows();++i)
+        face_data(i)=(double)i;
+    Eigen::MatrixXd FD2(F1.rows(),FD1.cols()+1);
+    // there is no face data in the input file
+    FD2<<face_data;
 
     // test that saving preserves all the data, including new data column
-    REQUIRE (igl::writePLY("test_bunny.ply", V1, F1, E1, N1, UV1, VD2, Vheader1, FD1,Fheader1, ED1, Eheader1, comments1, igl::FileEncoding::Binary));
+    REQUIRE (igl::writePLY("test_bunny.ply", V1, F1, E1, N1, UV1, VD2, Vheader1, FD2,Fheader1, ED1, Eheader1, comments1, igl::FileEncoding::Binary));
 
     Eigen::MatrixXd V,N,UV,VD,FD,ED;
     Eigen::MatrixXi F,E;
@@ -65,10 +72,15 @@ TEST_CASE("writePLY: bunny.ply", "[igl]")
     REQUIRE (Vheader[1] == "intensity" );
     REQUIRE (Vheader[2] == "dummy_data" );
 
-    // no Face data or edge data
-    REQUIRE (FD.rows() == 0);
-    REQUIRE (FD.cols() == 0);
-    REQUIRE (Fheader.size() == 0);
+    // Face should have only one column
+    REQUIRE (Fheader.size() == 1);
+    REQUIRE (Fheader[0] == "face_data" );
+    REQUIRE (FD.rows() == F.rows());
+    REQUIRE (FD.cols() == 1);
+
+    // the dummy column contents check
+    for(size_t i=0;i<F.rows();++i)
+        REQUIRE (FD(i,0) == (double)i);
 
     REQUIRE (ED.rows() == 0);
     REQUIRE (ED.cols() == 0);


### PR DESCRIPTION
Fixed a bug in writePLY, when face properties were doubled and edge properties were dropped

#### Check all that apply (change to `[x]`)
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [x] Adds corresponding unit test.
- [ ] This is a minor change.
