### PR TITLE
ImGuiTextEditCallback was renamed/deprecated in Imgui 1.63 (2018)

### DIFF
--- a/include/igl/opengl/glfw/imgui/ImGuiHelpers.h
+++ b/include/igl/opengl/glfw/imgui/ImGuiHelpers.h
@@ -58,7 +58,7 @@ inline bool ListBox(const char* label, int* idx, std::vector<std::string>& value
     static_cast<void*>(&values), values.size());
 }
 
-inline bool InputText(const char* label, std::string &str, ImGuiInputTextFlags flags = 0, ImGuiTextEditCallback callback = NULL, void* user_data = NULL)
+inline bool InputText(const char* label, std::string &str, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL)
 {
   char buf[1024];
   std::fill_n(buf, 1024, 0);


### PR DESCRIPTION
Fixes #1692. `ImGuiTextEditCallback` was renamed to `ImGuiInputTextCallback` [in 1.63 (august 2018)](https://github.com/ocornut/imgui/blob/94a432275b8ce29fa1dfb36439cfaf325e12a1ab/docs/CHANGELOG.txt#L1368), the old name was deprecated then, and [removed end of 2020](https://github.com/ocornut/imgui/blob/94a432275b8ce29fa1dfb36439cfaf325e12a1ab/docs/CHANGELOG.txt#L56).

#### Check all that apply:
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.