### PR TITLE
fix: compilation error caused by missing "inline" keyword.

### DIFF
--- a/include/igl/embree/EmbreeIntersector.cpp
+++ b/include/igl/embree/EmbreeIntersector.cpp
@@ -119,7 +119,7 @@ IGL_INLINE void igl::embree::EmbreeIntersector::init(
   initialized = true;
 }
 
-igl::embree::EmbreeIntersector
+IGL_INLINE igl::embree::EmbreeIntersector
 ::~EmbreeIntersector()
 {
   if(initialized)
@@ -127,7 +127,7 @@ igl::embree::EmbreeIntersector
   igl::embree::EmbreeDevice::release_device();
 }
 
-void igl::embree::EmbreeIntersector::deinit()
+IGL_INLINE void igl::embree::EmbreeIntersector::deinit()
 {
   if(device && scene)
   {


### PR DESCRIPTION
Fixes https://github.com/libigl/libigl/issues/1708

[Describe your changes and what you've already done to test it.]
adding "inline" keyword to class member func.

compilation passed.

#### Check all that apply (change to `[x]`)
- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
