### PR TITLE
Silence MSVC warning with std::getenv.

### DIFF
--- a/include/igl/default_num_threads.cpp
+++ b/include/igl/default_num_threads.cpp
@@ -23,6 +23,18 @@ IGL_INLINE unsigned int igl::default_num_threads(unsigned int user_num_threads) 
     unsigned int get_num_threads() const { return m_num_threads; }
 
   private:
+    static const char* getenv_nowarning(const char* env_var)
+    {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+      return std::getenv(env_var);
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+    }
+
     MySingleton(unsigned int force_num_threads) {
       // User-defined default
       if (force_num_threads) {
@@ -30,7 +42,7 @@ IGL_INLINE unsigned int igl::default_num_threads(unsigned int user_num_threads) 
         return;
       }
       // Set from env var
-      if (char *env_str = getenv("IGL_NUM_THREADS")) {
+      if (const char *env_str = getenv_nowarning("IGL_NUM_THREADS")) {
         const int env_num_thread = atoi(env_str);
         if (env_num_thread > 0) {
           m_num_threads = static_cast<unsigned int>(env_num_thread);


### PR DESCRIPTION
Fixes #1743