### PR TITLE
Fix Cuda compilation issue on Windows.

### DIFF
--- a/cmake/libigl.cmake
+++ b/cmake/libigl.cmake
@@ -84,7 +84,7 @@ target_compile_features(igl_common INTERFACE ${CXX11_FEATURES})
 # Other compilation flags
 if(MSVC)
   # Enable parallel compilation for Visual Studio
-  target_compile_options(igl_common INTERFACE /MP /bigobj)
+  target_compile_options(igl_common INTERFACE /MP $<$<COMPILE_LANGUAGE:CXX>:/bigobj>)
   target_compile_definitions(igl_common INTERFACE -DNOMINMAX)
 endif()
 


### PR DESCRIPTION
Only propagates /bigobj flag to C++ files, as the option is not
recognized by nvcc.

Fixes #1722
