### PR TITLE
Use boost via conda on Windows.

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -111,9 +111,15 @@ jobs:
           fetch-depth: 10
       - uses: seanmiddleditch/gha-setup-ninja@master
 
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: libigl-cgal
+          environment-file: cmake/libigl-cgal.yml
+          auto-activate-base: false
+
       - name: Set env
         run: |
-          echo "BOOST_ROOT=$env:BOOST_ROOT_1_72_0" >> ${env:GITHUB_ENV}
           echo "appdata=$env:LOCALAPPDATA" >> ${env:GITHUB_ENV}
 
       - name: Cache build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -162,9 +162,12 @@ jobs:
           fetch-depth: 10
       - uses: seanmiddleditch/gha-setup-ninja@master
 
-      - name: Set env
-        run: |
-          echo "BOOST_ROOT=$env:BOOST_ROOT_1_72_0" >> ${env:GITHUB_ENV}
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: libigl-cgal
+          environment-file: cmake/libigl-cgal.yml
+          auto-activate-base: false
 
         # We run configure + build in the same step, since they both need to call VsDevCmd
         # Also, cmd uses ^ to break commands into multiple lines (in powershell this is `)


### PR DESCRIPTION
Github [recently removed](https://github.com/actions/virtual-environments/issues/2667) boost from its virtual images, so now we need to use conda on Windows to install it on the system.