### PR TITLE
Fix dirty flag for ViewerData::set_labels

### DIFF
--- a/include/igl/opengl/ViewerData.cpp
+++ b/include/igl/opengl/ViewerData.cpp
@@ -445,6 +445,8 @@ IGL_INLINE void igl::opengl::ViewerData::set_labels(const Eigen::MatrixXd& P, co
   assert(P.cols() == 3 && "dimension of label positions incorrect!");
   labels_positions = P;
   labels_strings = str;
+
+  dirty |= MeshGL::DIRTY_CUSTOM_LABELS;
 }
 
 IGL_INLINE void igl::opengl::ViewerData::clear_labels()


### PR DESCRIPTION
`igl::opengl::ViewerData::set_labels` seems missing an update to the dirty flag. All changes made by `igl::opengl::ViewerData::set_labels` may not be drawn by the viewer.

<!-- Describe your changes and what you've already done to test it. -->


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
