### PR TITLE
Fix the order of principal curvature

### DIFF
--- a/include/igl/principal_curvature.cpp
+++ b/include/igl/principal_curvature.cpp
@@ -40,8 +40,8 @@ class CurvatureCalculator
 {
 public:
   /* Row number i represents the i-th vertex, whose columns are:
-   curv[i][0] : K2
-   curv[i][1] : K1
+   curv[i][0] : K1
+   curv[i][1] : K2
    curvDir[i][0] : PD1
    curvDir[i][1] : PD2
    */
@@ -425,20 +425,20 @@ IGL_INLINE void CurvatureCalculator::finalEigenStuff(int i, const std::vector<Ei
   if (c_val[0] > c_val[1])
   {
     curv[i]=std::vector<double>(2);
-    curv[i][0]=c_val(1);
-    curv[i][1]=c_val(0);
-    curvDir[i]=std::vector<Eigen::Vector3d>(2);
-    curvDir[i][0]=v2global;
-    curvDir[i][1]=v1global;
-  }
-  else
-  {
-    curv[i]=std::vector<double>(2);
     curv[i][0]=c_val(0);
     curv[i][1]=c_val(1);
     curvDir[i]=std::vector<Eigen::Vector3d>(2);
     curvDir[i][0]=v1global;
     curvDir[i][1]=v2global;
+  }
+  else
+  {
+    curv[i]=std::vector<double>(2);
+    curv[i][0]=c_val(1);
+    curv[i][1]=c_val(0);
+    curvDir[i]=std::vector<Eigen::Vector3d>(2);
+    curvDir[i][0]=v2global;
+    curvDir[i][1]=v1global;
   }
   // ---- end Eigen stuff
 }

--- a/tests/include/igl/principal_curvature.cpp
+++ b/tests/include/igl/principal_curvature.cpp
@@ -1,0 +1,29 @@
+#include <test_common.h>
+#include <igl/principal_curvature.h>
+#include <igl/cylinder.h>
+
+TEST_CASE("principal_curvature: cylinder", "[igl]")
+{
+  using namespace igl;
+  const int axis_devisions = 20;
+  const int height_devisions = 20;
+  Eigen::MatrixXd V;
+  Eigen::MatrixXi F;
+  cylinder(axis_devisions,height_devisions,V,F);
+  Eigen::MatrixXd PD1,PD2;
+  Eigen::VectorXd PV1,PV2;
+  //PV1: maximal curvature value for each vertex.
+  //PV2: minimal curvature value for each vertex.
+  igl::principal_curvature(V,F,PD1,PD2,PV1,PV2);
+  REQUIRE (PD1.rows() == V.rows());
+  REQUIRE (PD2.rows() == V.rows()); 
+  REQUIRE (PD1.cols() == 3);
+  REQUIRE (PD2.cols() == 3);
+  REQUIRE (PV1.size() == V.rows());
+  REQUIRE (PV2.size() == V.rows());
+  for(int i = 0; i<PV1.size(); ++i)
+  {
+    //max curvature is greater than or equal to min curvature
+    REQUIRE (PV1[i]>=PV2[i]);
+  }
+}

--- a/tutorial/203_CurvatureDirections/main.cpp
+++ b/tutorial/203_CurvatureDirections/main.cpp
@@ -51,12 +51,12 @@ int main(int argc, char *argv[])
   // Average edge length for sizing
   const double avg = igl::avg_edge_length(V,F);
 
-  // Draw a blue segment parallel to the minimal curvature direction
-  const RowVector3d red(0.8,0.2,0.2),blue(0.2,0.2,0.8);
-  viewer.data().add_edges(V + PD1*avg, V - PD1*avg, blue);
-
   // Draw a red segment parallel to the maximal curvature direction
-  viewer.data().add_edges(V + PD2*avg, V - PD2*avg, red);
+  const RowVector3d red(0.8,0.2,0.2),blue(0.2,0.2,0.8);
+  viewer.data().add_edges(V + PD1*avg, V - PD1*avg, red);
+
+  // Draw a blue segment parallel to the minimal curvature direction
+  viewer.data().add_edges(V + PD2*avg, V - PD2*avg, blue);
 
   // Hide wireframe
   viewer.data().show_lines = false;


### PR DESCRIPTION
principle_curvature returns PD1, PV1 as minimal curvature direction and value, PD2, PV2 as maximum curvature direction and value.
The order is not the same as described in the docs(https://libigl.github.io/libigl-python-bindings/igl_docs/#principal_curvature) and the comments in the header file:
https://github.com/libigl/libigl/blob/36e8435a2f724e83e14f79d128102d06b514a4f4/include/igl/principal_curvature.h#L34-L38

Here's the code (using python bindings) and screenshot to demonstrate this bug:
```python
v, f = igl.cylinder(20, 20)
# pd1, pv1: maximal
# pd2, pv2: minimal
pd1, pd2, pv1, pv2 = igl.principal_curvature(v, f)
print(np.all(pv1<=pv2)) # printing true means pv2 is actually maximal curvature value

p = meshplot.plot(v, f, shading={"wireframe": False}, return_plot=True)
avg = igl.avg_edge_length(v, f) / 2
# red segments should be parallel to the maximal curvature direction
p.add_lines(v + pd1 * avg, v - pd1 * avg, shading={"line_color": "red"})
# blue segments should be parallel to the minimal curvature direction
p.add_lines(v + pd2 * avg, v - pd2 * avg, shading={"line_color": "blue"})
```
<img width="374" alt="Screen Shot 2021-03-28 at 2 14 55 PM" src="https://user-images.githubusercontent.com/10322559/112762893-287a3800-8fd0-11eb-8e9a-40a63d7d50c1.png">

The red lines are actually parallel to the minimal curvature direction.

I wrote unit test to simply make sure that max curvature is no less than min curvature.

I also fix the corresponding tutorial.

#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [x] Adds new .cpp file.
- [x] Adds corresponding unit test.
- [x] This is a minor change.
