### PR TITLE
added uniform sampler estimation multiplier parameter

### DIFF
--- a/include/igl/blue_noise.cpp
+++ b/include/igl/blue_noise.cpp
@@ -245,7 +245,25 @@ template <
 IGL_INLINE void igl::blue_noise(
     const Eigen::MatrixBase<DerivedV> & V,
     const Eigen::MatrixBase<DerivedF> & F,
+    const typename DerivedV::Scalar r,    
+    Eigen::PlainObjectBase<DerivedB> & B,
+    Eigen::PlainObjectBase<DerivedFI> & FI,
+    Eigen::PlainObjectBase<DerivedP> & P)
+{
+  blue_noise(V,F,r,30.0,B,FI,P);
+}
+
+template <
+  typename DerivedV,
+  typename DerivedF,
+  typename DerivedB,
+  typename DerivedFI,
+  typename DerivedP>
+IGL_INLINE void igl::blue_noise(
+    const Eigen::MatrixBase<DerivedV> & V,
+    const Eigen::MatrixBase<DerivedF> & F,
     const typename DerivedV::Scalar r,
+    const typename DerivedV::Scalar m,
     Eigen::PlainObjectBase<DerivedB> & B,
     Eigen::PlainObjectBase<DerivedFI> & FI,
     Eigen::PlainObjectBase<DerivedP> & P)
@@ -273,8 +291,8 @@ IGL_INLINE void igl::blue_noise(
   const double expected_number_of_points =
     area * (igl::PI * sqrt(3.0) / 6.0) / (igl::PI * min_r * min_r / 4.0);
 
-  // Make a uniform random sampling with 30*expected_number_of_points.
-  const int nx = 30.0*expected_number_of_points;
+  // Make a uniform random sampling with m*expected_number_of_points.
+  const int nx = m*expected_number_of_points;
   MatrixX3S X,XB;
   Eigen::VectorXi XFI;
   igl::random_points_on_mesh(nx,V,F,XB,XFI,X);

--- a/include/igl/blue_noise.h
+++ b/include/igl/blue_noise.h
@@ -40,6 +40,40 @@ namespace igl
       Eigen::PlainObjectBase<DerivedB> & B,
       Eigen::PlainObjectBase<DerivedFI> & FI,
       Eigen::PlainObjectBase<DerivedP> & P);
+
+
+// "Fast Poisson Disk Sampling in Arbitrary Dimensions" [Bridson 2007]
+  //
+  // For very dense samplings this is faster than (up to 2x) cyCodeBase's
+  // implementation of "Sample Elimination for Generating Poisson Disk Sample
+  // Sets" [Yuksel 2015]. YMMV
+  //
+  // Inputs:
+  //   V  #V by dim list of mesh vertex positions
+  //   F  #F by 3 list of mesh triangle indices into rows of V
+  //   r  Poisson disk radius (evaluated according to Euclidean distance on V)
+  //   m  uniform sampler estimation multiplier 
+  // Outputs:
+  //   B  #P by 3 list of barycentric coordinates, ith row are coordinates of
+  //     ith sampled point in face FI(i)
+  //   FI  #P list of indices into F 
+  //   P  #P by dim list of sample positions.
+  // See also: random_points_on_mesh
+
+ template <
+    typename DerivedV,
+    typename DerivedF,
+    typename DerivedB,
+    typename DerivedFI,
+    typename DerivedP>
+  IGL_INLINE void blue_noise(
+      const Eigen::MatrixBase<DerivedV> & V,
+      const Eigen::MatrixBase<DerivedF> & F,
+      const typename DerivedV::Scalar r,
+      const typename DerivedV::Scalar m,
+      Eigen::PlainObjectBase<DerivedB> & B,
+      Eigen::PlainObjectBase<DerivedFI> & FI,
+      Eigen::PlainObjectBase<DerivedP> & P);
 }
 
 #ifndef IGL_STATIC_LIBRARY

--- a/include/igl/copyleft/cgal/SelfIntersectMesh.h
+++ b/include/igl/copyleft/cgal/SelfIntersectMesh.h
@@ -635,32 +635,14 @@ inline bool igl::copyleft::cgal::SelfIntersectMesh<
   const std::vector<std::pair<Index,Index> > shared)
 {
   using namespace std;
-  
-  auto opposite_vertex = [](const Index a0, const Index a1) {
-    // get opposite index of A
-    int a2=-1;
-	for(int c=0;c<3;++c)
-      if(c!=a0 && c!=a1) {
-        a2 = c;
-        break;
-      }
-      assert(a2 != -1);
-      return a2;
-  };
 
   // must be co-planar
-  // must be co-planar
-  Index a2 = opposite_vertex(shared[0].first, shared[1].first);
-  if (! B.supporting_plane().has_on(A.vertex(a2)))
+  if(
+    A.supporting_plane() != B.supporting_plane() &&
+    A.supporting_plane() != B.supporting_plane().opposite())
+  {
     return false;
-  
-  Index b2 = opposite_vertex(shared[0].second, shared[1].second);
-
-  if (int(CGAL::coplanar_orientation(A.vertex(shared[0].first), A.vertex(shared[1].first), A.vertex(a2))) * 
-	  int(CGAL::coplanar_orientation(B.vertex(shared[0].second), B.vertex(shared[1].second), B.vertex(b2))) < 0)
-    // There is certainly no self intersection as the non-shared triangle vertices lie on opposite sides of the shared edge.
-    return false;
-
+  }
   // Since A and B are non-degenerate the intersection must be a polygon
   // (triangle). Either
   //   - the vertex of A (B) opposite the shared edge of lies on B (A), or
@@ -669,10 +651,22 @@ inline bool igl::copyleft::cgal::SelfIntersectMesh<
   // Determine if the vertex opposite edge (a0,a1) in triangle A lies in
   // (intersects) triangle B
   const auto & opposite_point_inside = [](
-    const Triangle_3 & A, const Index a2, const Triangle_3 & B) 
+    const Triangle_3 & A, const Index a0, const Index a1, const Triangle_3 & B)
     -> bool
   {
-    return CGAL::do_intersect(A.vertex(a2),B);
+    // get opposite index
+    Index a2 = -1;
+    for(int c = 0;c<3;c++)
+    {
+      if(c != a0 && c != a1)
+      {
+        a2 = c;
+        break;
+      }
+    }
+    assert(a2 != -1);
+    bool ret = CGAL::do_intersect(A.vertex(a2),B);
+    return ret;
   };
 
   // Determine if edge opposite vertex va in triangle A intersects edge
@@ -688,8 +682,8 @@ inline bool igl::copyleft::cgal::SelfIntersectMesh<
   };
 
   if(
-    !opposite_point_inside(A,a2,B) &&
-    !opposite_point_inside(B,b2,A) &&
+    !opposite_point_inside(A,shared[0].first,shared[1].first,B) &&
+    !opposite_point_inside(B,shared[0].second,shared[1].second,A) &&
     !opposite_edges_intersect(A,shared[0].first,B,shared[1].second) &&
     !opposite_edges_intersect(A,shared[1].first,B,shared[0].second))
   {

--- a/include/igl/copyleft/cgal/SelfIntersectMesh.h
+++ b/include/igl/copyleft/cgal/SelfIntersectMesh.h
@@ -635,14 +635,32 @@ inline bool igl::copyleft::cgal::SelfIntersectMesh<
   const std::vector<std::pair<Index,Index> > shared)
 {
   using namespace std;
+  
+  auto opposite_vertex = [](const Index a0, const Index a1) {
+    // get opposite index of A
+    int a2=-1;
+	for(int c=0;c<3;++c)
+      if(c!=a0 && c!=a1) {
+        a2 = c;
+        break;
+      }
+      assert(a2 != -1);
+      return a2;
+  };
 
   // must be co-planar
-  if(
-    A.supporting_plane() != B.supporting_plane() &&
-    A.supporting_plane() != B.supporting_plane().opposite())
-  {
+  // must be co-planar
+  Index a2 = opposite_vertex(shared[0].first, shared[1].first);
+  if (! B.supporting_plane().has_on(A.vertex(a2)))
     return false;
-  }
+  
+  Index b2 = opposite_vertex(shared[0].second, shared[1].second);
+
+  if (int(CGAL::coplanar_orientation(A.vertex(shared[0].first), A.vertex(shared[1].first), A.vertex(a2))) * 
+	  int(CGAL::coplanar_orientation(B.vertex(shared[0].second), B.vertex(shared[1].second), B.vertex(b2))) < 0)
+    // There is certainly no self intersection as the non-shared triangle vertices lie on opposite sides of the shared edge.
+    return false;
+
   // Since A and B are non-degenerate the intersection must be a polygon
   // (triangle). Either
   //   - the vertex of A (B) opposite the shared edge of lies on B (A), or
@@ -651,22 +669,10 @@ inline bool igl::copyleft::cgal::SelfIntersectMesh<
   // Determine if the vertex opposite edge (a0,a1) in triangle A lies in
   // (intersects) triangle B
   const auto & opposite_point_inside = [](
-    const Triangle_3 & A, const Index a0, const Index a1, const Triangle_3 & B)
+    const Triangle_3 & A, const Index a2, const Triangle_3 & B) 
     -> bool
   {
-    // get opposite index
-    Index a2 = -1;
-    for(int c = 0;c<3;c++)
-    {
-      if(c != a0 && c != a1)
-      {
-        a2 = c;
-        break;
-      }
-    }
-    assert(a2 != -1);
-    bool ret = CGAL::do_intersect(A.vertex(a2),B);
-    return ret;
+    return CGAL::do_intersect(A.vertex(a2),B);
   };
 
   // Determine if edge opposite vertex va in triangle A intersects edge
@@ -682,8 +688,8 @@ inline bool igl::copyleft::cgal::SelfIntersectMesh<
   };
 
   if(
-    !opposite_point_inside(A,shared[0].first,shared[1].first,B) &&
-    !opposite_point_inside(B,shared[0].second,shared[1].second,A) &&
+    !opposite_point_inside(A,a2,B) &&
+    !opposite_point_inside(B,b2,A) &&
     !opposite_edges_intersect(A,shared[0].first,B,shared[1].second) &&
     !opposite_edges_intersect(A,shared[1].first,B,shared[0].second))
   {


### PR DESCRIPTION
Fixes # .

<!-- Describe your changes and what you've already done to test it. -->
I've added a new parameter to change the uniform distribuition multiplier that was hardcoded to 30.0. I've maintained the existing function signature so it doesn't break the api and functionallity. I calls the new function with the multiplier parameter set to 30.
Unit tests passed.

#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
