### PR TITLE
Added uniform sampler estimation multiplier parameter

### DIFF
--- a/include/igl/blue_noise.cpp
+++ b/include/igl/blue_noise.cpp
@@ -245,7 +245,25 @@ template <
 IGL_INLINE void igl::blue_noise(
     const Eigen::MatrixBase<DerivedV> & V,
     const Eigen::MatrixBase<DerivedF> & F,
+    const typename DerivedV::Scalar r,    
+    Eigen::PlainObjectBase<DerivedB> & B,
+    Eigen::PlainObjectBase<DerivedFI> & FI,
+    Eigen::PlainObjectBase<DerivedP> & P)
+{
+  blue_noise(V,F,r,30.0,B,FI,P);
+}
+
+template <
+  typename DerivedV,
+  typename DerivedF,
+  typename DerivedB,
+  typename DerivedFI,
+  typename DerivedP>
+IGL_INLINE void igl::blue_noise(
+    const Eigen::MatrixBase<DerivedV> & V,
+    const Eigen::MatrixBase<DerivedF> & F,
     const typename DerivedV::Scalar r,
+    const typename DerivedV::Scalar m,
     Eigen::PlainObjectBase<DerivedB> & B,
     Eigen::PlainObjectBase<DerivedFI> & FI,
     Eigen::PlainObjectBase<DerivedP> & P)
@@ -273,8 +291,8 @@ IGL_INLINE void igl::blue_noise(
   const double expected_number_of_points =
     area * (igl::PI * sqrt(3.0) / 6.0) / (igl::PI * min_r * min_r / 4.0);
 
-  // Make a uniform random sampling with 30*expected_number_of_points.
-  const int nx = 30.0*expected_number_of_points;
+  // Make a uniform random sampling with m*expected_number_of_points.
+  const int nx = m*expected_number_of_points;
   MatrixX3S X,XB;
   Eigen::VectorXi XFI;
   igl::random_points_on_mesh(nx,V,F,XB,XFI,X);

--- a/include/igl/blue_noise.h
+++ b/include/igl/blue_noise.h
@@ -40,6 +40,40 @@ namespace igl
       Eigen::PlainObjectBase<DerivedB> & B,
       Eigen::PlainObjectBase<DerivedFI> & FI,
       Eigen::PlainObjectBase<DerivedP> & P);
+
+
+// "Fast Poisson Disk Sampling in Arbitrary Dimensions" [Bridson 2007]
+  //
+  // For very dense samplings this is faster than (up to 2x) cyCodeBase's
+  // implementation of "Sample Elimination for Generating Poisson Disk Sample
+  // Sets" [Yuksel 2015]. YMMV
+  //
+  // Inputs:
+  //   V  #V by dim list of mesh vertex positions
+  //   F  #F by 3 list of mesh triangle indices into rows of V
+  //   r  Poisson disk radius (evaluated according to Euclidean distance on V)
+  //   m  uniform sampler estimation multiplier 
+  // Outputs:
+  //   B  #P by 3 list of barycentric coordinates, ith row are coordinates of
+  //     ith sampled point in face FI(i)
+  //   FI  #P list of indices into F 
+  //   P  #P by dim list of sample positions.
+  // See also: random_points_on_mesh
+
+ template <
+    typename DerivedV,
+    typename DerivedF,
+    typename DerivedB,
+    typename DerivedFI,
+    typename DerivedP>
+  IGL_INLINE void blue_noise(
+      const Eigen::MatrixBase<DerivedV> & V,
+      const Eigen::MatrixBase<DerivedF> & F,
+      const typename DerivedV::Scalar r,
+      const typename DerivedV::Scalar m,
+      Eigen::PlainObjectBase<DerivedB> & B,
+      Eigen::PlainObjectBase<DerivedFI> & FI,
+      Eigen::PlainObjectBase<DerivedP> & P);
 }
 
 #ifndef IGL_STATIC_LIBRARY


### PR DESCRIPTION

I've added a new parameter to change the uniform distribuition multiplier that was hardcoded to 30.0. I've maintained the existing function signature so it doesn't break the api and functionallity. I calls the new function with the multiplier parameter set to 30.
Unit tests passed.


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
