### PR TITLE
Remove serialize / deserialize overloads

### DIFF
--- a/include/igl/serialize.h
+++ b/include/igl/serialize.h
@@ -1241,19 +1241,6 @@ namespace igl
  
     }
  
-    // functions to overload for non-intrusive serialization
-    template <typename T>
-    inline void serialize(const T& obj,std::vector<char>& buffer)
-    {
-      std::cerr << typeid(obj).name() << " is not serializable: derive from igl::Serializable or spezialize the template function igl::serialization::serialize(const T& obj,std::vector<char>& buffer)" << std::endl;
-    }
- 
-    template <typename T>
-    inline void deserialize(T& obj,const std::vector<char>& buffer)
-    {
-      std::cerr << typeid(obj).name() << " is not deserializable: derive from igl::Serializable or spezialize the template function igl::serialization::deserialize(T& obj, const std::vector<char>& buffer)" << std::endl;
-    }
- 
     // helper functions
  
     template <typename T>


### PR DESCRIPTION
These overloads effectively replaced compile-time errors with run-time errors. 

If a user calls `serialize` on an object that does not implement this, the compilation should fail and the user should either implement the serialization or remove the serialization call.

#### Checklist
- [X] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [X] This is a minor change.

(This PR makes #1789 irrelevant)