### PR TITLE
Instead of calling `exit(1)`, teach triangle to throw exception

### DIFF
--- a/cmake/LibiglDownloadExternal.cmake
+++ b/cmake/LibiglDownloadExternal.cmake
@@ -157,7 +157,7 @@ endfunction()
 function(igl_download_triangle)
 	igl_download_project(triangle
 		GIT_REPOSITORY https://github.com/libigl/triangle.git
-		GIT_TAG        5a70326574b34d6a51d9eaf6a9f78813657ee108
+		GIT_TAG        4df461c0083e0d768fe42ab41a617070b5acc5ef
 	)
 endfunction()
 

--- a/include/igl/triangle/triangulate.cpp
+++ b/include/igl/triangle/triangulate.cpp
@@ -22,10 +22,7 @@
 #define REAL double
 #define VOID int
 
-extern "C"
-{
 #include <triangle.h>
-}
 
 #undef ANSI_DECLARATORS
 #ifdef IGL_PREVIOUSLY_DEFINED_ANSI_DECLARATORS
@@ -85,9 +82,9 @@ IGL_INLINE void igl::triangle::triangulate(
   using namespace std;
   using namespace Eigen;
 
-  assert( (VM.size() == 0 || V.rows() == VM.size()) && 
+  assert( (VM.size() == 0 || V.rows() == VM.size()) &&
     "Vertex markers must be empty or same size as V");
-  assert( (EM.size() == 0 || E.rows() == EM.size()) && 
+  assert( (EM.size() == 0 || E.rows() == EM.size()) &&
     "Segment markers must be empty or same size as E");
   assert(V.cols() == 2);
   assert(E.size() == 0 || E.cols() == 2);


### PR DESCRIPTION
Switch triangle version to [one where it's possible to customize the function `triexit`](https://github.com/libigl/triangle/commit/9cceb2f0c9d364ec229fd9182b4f45e3c5bed63a) which is called when triangle fails.

Meanwhile, in libigl provide this custom implementation to throw a `std::runtime_exception`.

(Note, this change is unrelated to switching to https://github.com/qnzhou/trianglelite . That may be a good idea in the future but doesn't immediately solve the problem of triangle calling exit)