### PR TITLE
Introduce continuous fuzzing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,10 @@ if(LIBIGL_BUILD_TESTS)
 	add_subdirectory(tests)
 endif()
 
+# OSS-fuzz build
+# This is only used by OSS-fuzz
+option(OSS_FUZZ "Build for OSS-fuzz" OFF)
+
 if(LIBIGL_TOPLEVEL_PROJECT)
 	# Set folders for Visual Studio/Xcode
 	igl_set_folders()

--- a/tests/fuzzing/igl_fuzzer.cpp
+++ b/tests/fuzzing/igl_fuzzer.cpp
@@ -1,0 +1,34 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+// 
+// Copyright (C) 2021 Alec Jacobson <alecjacobson@gmail.com>
+// 
+// This Source Code Form is subject to the terms of the Mozilla Public License 
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+// obtain one at http://mozilla.org/MPL/2.0/.
+
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <igl/MshLoader.h>
+#include <iostream>
+#include <fstream>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+        char *new_str = (char *)malloc(size+1);
+        if (new_str == NULL){
+                return 0;
+        }
+        memcpy(new_str, data, size);
+        new_str[size] = '\0';
+		
+        std::ofstream mshfile;
+        mshfile.open ("file.msh");
+        mshfile << new_str;
+        mshfile.close();
+
+        igl::MshLoader msh_loader("example.msh");
+
+        free(new_str);
+        return 0;
+}


### PR DESCRIPTION
Hello, this is [Adam](https://twitter.com/AdamKorcz4) of [Ada Logics](https://adalogics.com/). I have been working on setting up continuous fuzzing of libligl through OSS-fuzz. 
I have now come up with the first fuzz test. An integration PR with OSS-fuzz has been set up [here](https://github.com/google/oss-fuzz/pull/5708), and for the fuzzer to run continuously, we need to steer it away from runtime errors in the target code. For that a macro has been introduced.

For those unfamiliar: Fuzzing is a way of testing software, whereby pseudo-random data is passed to a target application with the goal of finding bugs and vulnerabilities. 

### Changes made:

1. Add fuzz test
2. Add macro to prevent target code from terminating during fuzz run


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] This is a minor change.
