### PR TITLE
fix bug in read_file_binary(FILE *fp, std::vector<uint8_t> &fileBufferBytes)

### DIFF
--- a/include/igl/file_utils.cpp
+++ b/include/igl/file_utils.cpp
@@ -19,8 +19,10 @@ IGL_INLINE void read_file_binary(FILE *fp,
     fseek(fp, 0, SEEK_SET);
     fileBufferBytes.resize(sizeBytes);
 
-    if (fread((char *)fileBufferBytes.data(), 1, sizeBytes, fp) == sizeBytes)
-      return;
+    if (fread((char*)fileBufferBytes.data(), 1, sizeBytes, fp) == sizeBytes) {
+        fclose(fp);
+        return;
+    }
   }
 
   throw std::runtime_error("error reading from file");

--- a/include/igl/file_utils.cpp
+++ b/include/igl/file_utils.cpp
@@ -20,8 +20,8 @@ IGL_INLINE void read_file_binary(FILE *fp,
     fileBufferBytes.resize(sizeBytes);
 
     if (fread((char*)fileBufferBytes.data(), 1, sizeBytes, fp) == sizeBytes) {
-        fclose(fp);
-        return;
+      fclose(fp);
+      return;
     }
   }
 


### PR DESCRIPTION
Fixes # .

add ```fclose(File* fp).```

from in ```file_utils.cpp```
```
  if (!ferror(fp)) {
    fseek(fp, 0, SEEK_END);
    size_t sizeBytes = ftell(fp);
    fseek(fp, 0, SEEK_SET);
    fileBufferBytes.resize(sizeBytes);

    if (fread((char*)fileBufferBytes.data(), 1, sizeBytes, fp) == sizeBytes) 
      return;
  }

```
to
```
  if (!ferror(fp)) {
    fseek(fp, 0, SEEK_END);
    size_t sizeBytes = ftell(fp);
    fseek(fp, 0, SEEK_SET);
    fileBufferBytes.resize(sizeBytes);

    if (fread((char*)fileBufferBytes.data(), 1, sizeBytes, fp) == sizeBytes) {
      fclose(fp);
      return;
    }
  }
```


#### Checklist
- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
