### PR TITLE
lscm: fix order of UV after area term sign fix

### DIFF
--- a/include/igl/lscm.cpp
+++ b/include/igl/lscm.cpp
@@ -63,7 +63,7 @@ IGL_INLINE bool igl::lscm(
   V_uv.resize(V.rows(),2);
   for (unsigned i=0;i<V_uv.cols();++i)
   {
-    V_uv.col(V_uv.cols()-i-1) = W_flat.block(V_uv.rows()*i,0,V_uv.rows(),1);
+    V_uv.col(i) = W_flat.block(V_uv.rows()*i,0,V_uv.rows(),1);
   }
   return true;
 }


### PR DESCRIPTION
The fix in #1853 causes the solution UVs to be flipped, so this is a simple fix to that.

See attached a parameterization of an example surface. Apologies in advance for no reproducible example code in C -- I've been working with the python bindings and whipped this up on short notice. 

#### Checklist
<!-- Check all that apply (change to `[x]`) -->
![screenshot_000000](https://user-images.githubusercontent.com/29670153/127387540-bb7652e9-19d4-4ed6-949b-6b610afde7b0.png)
![igl_lscm_param2](https://user-images.githubusercontent.com/29670153/127387122-74944912-3c9a-43db-8766-23d1bdaba00b.png)

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
