### PR TITLE
consistent type deduction

### DIFF
--- a/include/igl/doublearea.cpp
+++ b/include/igl/doublearea.cpp
@@ -219,7 +219,7 @@ IGL_INLINE void igl::doublearea_quad(
   }
 
   // Compute areas
-  Eigen::VectorXd doublearea_tri;
+  Eigen::Matrix<typename DeriveddblA::Scalar, Eigen::Dynamic, 1> doublearea_tri;
   igl::doublearea(V,Ft,doublearea_tri);
 
   dblA.resize(F.rows(),1);


### PR DESCRIPTION
Fixes # .

<!-- Describe your changes and what you've already done to test it. -->
The type of doublearea_tri is inconsistent with input parameter dblA

#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
