### PR TITLE
Add +1 offset in writeOBJ for hybrid mesh

### DIFF
--- a/include/igl/writeOBJ.cpp
+++ b/include/igl/writeOBJ.cpp
@@ -144,7 +144,7 @@ IGL_INLINE bool igl::writeOBJ(
 
     for(const auto& vi : face)
     {
-      s<<" "<<vi; 
+      s<<" "<<(vi+1); 
     }
     s<<"\n";
   }


### PR DESCRIPTION
This would keep the behavior the same as the non-hybrid situation.

Fixes # .

<!-- Describe your changes and what you've already done to test it. -->


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
