### PR TITLE
Update ImGui to v1.85 + use default include folders.

### DIFF
--- a/cmake/recipes/external/imgui.cmake
+++ b/cmake/recipes/external/imgui.cmake
@@ -8,7 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
     imgui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
-    GIT_TAG 61b19489f1ba35934d9114c034b24eb5bff149e7 # 1.81 + patch for #1669
+    GIT_TAG v1.85
 )
 FetchContent_MakeAvailable(imgui)
 
@@ -32,26 +32,11 @@ set(IMGUI_SRC
     "${imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp"
 )
 
-# Copy imgui source files into a subfolder `imgui/`
-set(output_folder "${CMAKE_CURRENT_BINARY_DIR}/imgui/include/imgui")
-message(VERBOSE "Copying imgui files to '${output_folder}'")
-foreach(filepath IN ITEMS ${IMGUI_SRC})
-    file(RELATIVE_PATH filename "${imgui_SOURCE_DIR}" ${filepath})
-    configure_file(${filepath} "${output_folder}/${filename}" COPYONLY)
-endforeach()
-
-file(GLOB_RECURSE IMGUI_SRC "${output_folder}/*.h" "${output_folder}/*.cpp")
-
 add_library(imgui ${IMGUI_SRC})
 add_library(imgui::imgui ALIAS imgui)
 
 # Include headers
-target_include_directories(imgui
-    PUBLIC
-        "${CMAKE_CURRENT_BINARY_DIR}/imgui/include"
-        "${CMAKE_CURRENT_BINARY_DIR}/imgui/include/imgui"
-        "${CMAKE_CURRENT_BINARY_DIR}/imgui/include/imgui/backends"
-)
+target_include_directories(imgui PUBLIC "${imgui_SOURCE_DIR}")
 
 # Compile definitions
 target_compile_definitions(imgui PUBLIC

--- a/cmake/recipes/external/imguizmo.cmake
+++ b/cmake/recipes/external/imguizmo.cmake
@@ -17,22 +17,12 @@ set(IMGUIZMO_SRC
     "${imguizmo_SOURCE_DIR}/ImGuizmo.cpp"
 )
 
-# Copy imguizmo source files into a subfolder `imguizmo/`
-set(output_folder "${CMAKE_CURRENT_BINARY_DIR}/imguizmo/include/imguizmo")
-message(VERBOSE "Copying imguizmo files to '${output_folder}'")
-foreach(filepath IN ITEMS ${IMGUIZMO_SRC})
-    file(RELATIVE_PATH filename "${imguizmo_SOURCE_DIR}" ${filepath})
-    configure_file(${filepath} "${output_folder}/${filename}" COPYONLY)
-endforeach()
-
-file(GLOB_RECURSE IMGUIZMO_SRC "${output_folder}/*.h" "${output_folder}/*.cpp")
-
 add_library(imguizmo ${IMGUIZMO_SRC})
 add_library(imguizmo::imguizmo ALIAS imguizmo)
 
 target_compile_features(imguizmo PUBLIC cxx_std_11)
 
-target_include_directories(imguizmo PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/imguizmo/include")
+target_include_directories(imguizmo PUBLIC "${imguizmo_SOURCE_DIR}")
 
 include(imgui)
 target_link_libraries(imguizmo PUBLIC imgui::imgui)

--- a/include/igl/opengl/glfw/imgui/ImGuiHelpers.h
+++ b/include/igl/opengl/glfw/imgui/ImGuiHelpers.h
@@ -10,7 +10,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 #include "ImGuiTraits.h"
-#include <imgui/imgui.h>
+#include <imgui.h>
 #include <vector>
 #include <string>
 #include <algorithm>

--- a/include/igl/opengl/glfw/imgui/ImGuiMenu.cpp
+++ b/include/igl/opengl/glfw/imgui/ImGuiMenu.cpp
@@ -9,9 +9,9 @@
 #include "ImGuiMenu.h"
 #include "ImGuiHelpers.h"
 #include <igl/project.h>
-#include <imgui/imgui.h>
-#include <imgui_impl_glfw.h>
-#include <imgui_impl_opengl3.h>
+#include <backends/imgui_impl_glfw.h>
+#include <backends/imgui_impl_opengl3.h>
+#include <imgui.h>
 #include <imgui_fonts_droid_sans.h>
 #include <GLFW/glfw3.h>
 #include <iostream>

--- a/include/igl/opengl/glfw/imgui/ImGuiTraits.h
+++ b/include/igl/opengl/glfw/imgui/ImGuiTraits.h
@@ -8,7 +8,7 @@
 #ifndef IGL_OPENGL_GLFW_IMGUI_IMGUITRAITS_H
 #define IGL_OPENGL_GLFW_IMGUI_IMGUITRAITS_H
 
-#include <imgui/imgui.h>
+#include <imgui.h>
 
 // Extend ImGui by populating its namespace directly
 namespace ImGui

--- a/include/igl/opengl/glfw/imgui/ImGuizmoPlugin.cpp
+++ b/include/igl/opengl/glfw/imgui/ImGuizmoPlugin.cpp
@@ -1,7 +1,7 @@
 #include "ImGuizmoPlugin.h"
-#include <imgui/imgui.h>
-#include <imgui_impl_glfw.h>
-#include <imgui_impl_opengl3.h>
+#include <imgui.h>
+#include <backends/imgui_impl_glfw.h>
+#include <backends/imgui_impl_opengl3.h>
 #include <imgui_fonts_droid_sans.h>
 #include <GLFW/glfw3.h>
 
@@ -11,7 +11,7 @@ IGL_INLINE void ImGuizmoPlugin::init(igl::opengl::glfw::Viewer *_viewer)
 {
   ImGuiMenu::init(_viewer);
 }
-IGL_INLINE bool ImGuizmoPlugin::pre_draw() 
+IGL_INLINE bool ImGuizmoPlugin::pre_draw()
 {
   if(!visible){ return false; }
   ImGuiMenu::pre_draw();
@@ -20,7 +20,7 @@ IGL_INLINE bool ImGuizmoPlugin::pre_draw()
   ImGui::PopStyleVar();
   return false;
 }
-IGL_INLINE bool ImGuizmoPlugin::post_draw() 
+IGL_INLINE bool ImGuizmoPlugin::post_draw()
 {
   if(!visible){ return false; }
   // Don't draw the Viewer's default menu: draw just the ImGuizmo
@@ -29,7 +29,7 @@ IGL_INLINE bool ImGuizmoPlugin::post_draw()
   if(viewer->core().orthographic){ view(2,3) -= 1000;/* Hack depth */ }
   // ImGuizmo doesn't like a lot of scaling in view, shift it to T
   const float z = viewer->core().camera_base_zoom;
-  const Eigen::Matrix4f S = 
+  const Eigen::Matrix4f S =
     (Eigen::Matrix4f()<< z,0,0,0, 0,z,0,0, 0,0,z,0, 0,0,0,1).finished();
   view = (view * S.inverse()).eval();
   const Eigen::Matrix4f T0 = T;

--- a/include/igl/opengl/glfw/imgui/ImGuizmoPlugin.h
+++ b/include/igl/opengl/glfw/imgui/ImGuizmoPlugin.h
@@ -2,9 +2,9 @@
 #define IGL_OPENGL_GFLW_IMGUI_IMGUIZMOPLUGIN_H
 #include "../../../igl_inline.h"
 #include "ImGuiMenu.h"
-#include <imgui/imgui.h>
-#include <imgui/imgui_internal.h>
-#include <imguizmo/ImGuizmo.h>
+#include <imgui.h>
+#include <imgui_internal.h>
+#include <ImGuizmo.h>
 #include <Eigen/Dense>
 
 namespace igl{ namespace opengl{ namespace glfw{ namespace imgui{

--- a/include/igl/opengl/glfw/imgui/SelectionPlugin.cpp
+++ b/include/igl/opengl/glfw/imgui/SelectionPlugin.cpp
@@ -1,8 +1,8 @@
 #include "SelectionPlugin.h"
 
-#include <imgui/imgui.h>
-#include <imgui_impl_glfw.h>
-#include <imgui_impl_opengl3.h>
+#include <imgui.h>
+#include <backends/imgui_impl_glfw.h>
+#include <backends/imgui_impl_opengl3.h>
 #include <imgui_fonts_droid_sans.h>
 #include <GLFW/glfw3.h>
 #include "../../../PI.h"
@@ -169,18 +169,18 @@ IGL_INLINE bool SelectionPlugin::key_pressed(unsigned int key, int modifiers)
   if(old != mode)
   {
     clear();
-    if(callback_post_mode_change){ callback_post_mode_change(old); } 
+    if(callback_post_mode_change){ callback_post_mode_change(old); }
     return true;
   }
   return false;
 }
 
 IGL_INLINE void SelectionPlugin::clear()
-{ 
-  M.setZero(); 
-  L.clear(); 
-  is_drawing = false; 
-  is_down = false; 
+{
+  M.setZero();
+  L.clear();
+  is_drawing = false;
+  is_down = false;
 };
 
 IGL_INLINE void SelectionPlugin::circle(const Eigen::Matrix<float,2,2> & M,  std::vector<Eigen::RowVector2f> & L)

--- a/include/igl/opengl/glfw/imgui/SelectionPlugin.h
+++ b/include/igl/opengl/glfw/imgui/SelectionPlugin.h
@@ -2,9 +2,9 @@
 #define IGL_OPENGL_GFLW_IMGUI_IMGUIDRAWLISTPLUGIN_H
 #include <igl/igl_inline.h>
 #include <igl/opengl/glfw/imgui/ImGuiMenu.h>
-#include <imgui/imgui.h>
-#include <imgui/imgui_internal.h>
-#include <imguizmo/ImGuizmo.h>
+#include <imgui.h>
+#include <imgui_internal.h>
+#include <ImGuizmo.h>
 #include <Eigen/Dense>
 #include <vector>
 
@@ -36,7 +36,7 @@ public:
   std::vector<Eigen::RowVector2f> L;
   // callback called when slection is completed (usually on mouse_up)
   std::function<void(void)> callback;
-  // callback called after mode is changed 
+  // callback called after mode is changed
   std::function<void(Mode)> callback_post_mode_change;
   // whether rotating, translating or scaling
   ImGuizmo::OPERATION operation;

--- a/include/igl/serialize.h
+++ b/include/igl/serialize.h
@@ -1,13 +1,13 @@
 // This file is part of libigl, a simple c++ geometry processing library.
 //
-// Copyright (C) 2014 Christian Schüller <schuellchr@gmail.com> 
+// Copyright (C) 2014 Christian Schüller <schuellchr@gmail.com>
 //
 // This Source Code Form is subject to the terms of the Mozilla Public License
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 #ifndef IGL_SERIALIZE_H
 #define IGL_SERIALIZE_H
- 
+
 // -----------------------------------------------------------------------------
 // Functions to save and load a serialization of fundamental c++ data types to
 // and from a binary file. STL containers, Eigen matrix types and nested data
@@ -19,11 +19,11 @@
 // TODOs:
 // * arbitrary pointer graph structures
 // -----------------------------------------------------------------------------
- 
+
 // Known issues: This is not written in libigl-style so it isn't (easily)
 // "dualized" into the static library.
 //
- 
+
 #include <type_traits>
 #include <iostream>
 #include <fstream>
@@ -35,14 +35,14 @@
 #include <memory>
 #include <cstdint>
 #include <list>
- 
+
 #include <Eigen/Dense>
 #include <Eigen/Sparse>
- 
+
 #include "igl_inline.h"
- 
+
 // non-intrusive serialization helper macros
- 
+
 #define SERIALIZE_TYPE(Type,Params) \
 namespace igl { namespace serialization { \
   void _serialization(bool s,Type& obj,std::vector<char>& buffer) {Params} \
@@ -53,7 +53,7 @@ namespace igl { namespace serialization { \
     _serialization(false,obj,const_cast<std::vector<char>&>(buffer)); \
     } \
 }}
- 
+
 #define SERIALIZE_TYPE_SOURCE(Type,Params) \
 namespace igl { namespace serialization { \
   void _serialization(bool s,Type& obj,std::vector<char>& buffer) {Params} \
@@ -64,15 +64,15 @@ namespace igl { namespace serialization { \
     _serialization(false,obj,const_cast<std::vector<char>&>(buffer)); \
     } \
 }}
- 
+
 #define SERIALIZE_MEMBER(Object) igl::serializer(s,obj.Object,std::string(#Object),buffer);
 #define SERIALIZE_MEMBER_NAME(Object,Name) igl::serializer(s,obj.Object,std::string(Name),buffer);
- 
- 
+
+
 namespace igl
 {
   struct IndexedPointerBase;
- 
+
   // Serializes the given object either to a file or to a provided buffer
   // Templates:
   //   T  type of the object to serialize
@@ -92,7 +92,7 @@ namespace igl
   inline bool serialize(const T& obj,const std::string& objectName,std::vector<char>& buffer);
   template <typename T>
   inline bool serialize(const T& obj,const std::string& objectName,std::vector<char>& buffer);
- 
+
   // Deserializes the given data from a file or buffer back to the provided object
   //
   // Templates:
@@ -110,7 +110,7 @@ namespace igl
   inline bool deserialize(T& obj,const std::string& objectName,const std::string& filename);
   template <typename T>
   inline bool deserialize(T& obj,const std::string& objectName,const std::vector<char>& buffer);
- 
+
   // Wrapper to expose both, the de- and serialization as one function
   //
   template <typename T>
@@ -119,7 +119,7 @@ namespace igl
   inline bool serializer(bool serialize,T& obj,const std::string& objectName,const std::string& filename,bool overwrite = false);
   template <typename T>
   inline bool serializer(bool serialize,T& obj,const std::string& objectName,std::vector<char>& buffer);
- 
+
   // User defined types have to either overload the function igl::serialization::serialize()
   // and igl::serialization::deserialize() for their type (non-intrusive serialization):
   //
@@ -153,68 +153,69 @@ namespace igl
   //     this->Add(var,"var");
   //   }
   // };
- 
+
   // Base interface for user defined types
   struct SerializableBase
   {
+    virtual ~SerializableBase() = default;
     virtual void Serialize(std::vector<char>& buffer) const = 0;
     virtual void Deserialize(const std::vector<char>& buffer) = 0;
   };
- 
+
   // Convenient interface for user defined types
   class Serializable: public SerializableBase
   {
   private:
- 
+
     template <typename T>
     struct SerializationObject : public SerializableBase
     {
       bool Binary;
       std::string Name;
       std::unique_ptr<T> Object;
- 
+
       void Serialize(std::vector<char>& buffer) const override {
         igl::serialize(*Object,Name,buffer);
       }
- 
+
       void Deserialize(const std::vector<char>& buffer) override {
         igl::deserialize(*Object,Name,buffer);
       }
     };
- 
+
     mutable bool initialized;
     mutable std::vector<SerializableBase*> objects;
- 
+
   public:
- 
+
     // You **MUST** Override this function to add your member variables which
     // should be serialized
     //
     // http://stackoverflow.com/a/6634382/148668
     virtual void InitSerialization() = 0;
- 
+
     // Following functions can be overridden to handle the specific events.
     // Return false to prevent the de-/serialization of an object.
     inline virtual bool PreSerialization() const;
     inline virtual void PostSerialization() const;
     inline virtual bool PreDeserialization();
     inline virtual void PostDeserialization();
- 
+
     // Default implementation of SerializableBase interface
     inline void Serialize(std::vector<char>& buffer) const override final;
     inline void Deserialize(const std::vector<char>& buffer) override final;
- 
+
     // Default constructor, destructor, assignment and copy constructor
     inline Serializable();
     inline Serializable(const Serializable& obj);
-    inline ~Serializable();
+    virtual inline ~Serializable();
     inline Serializable& operator=(const Serializable& obj);
- 
+
     // Use this function to add your variables which should be serialized
     template <typename T>
     inline void Add(T& obj,std::string name,bool binary = false);
   };
- 
+
   // structure for pointer handling
   struct IndexedPointerBase
   {
@@ -226,7 +227,7 @@ namespace igl
   {
     const T* Object;
   };
- 
+
   // internal functions
   namespace serialization
   {
@@ -243,7 +244,7 @@ namespace igl
     struct is_stl_container<std::map<T1,T2> > { static const bool value = true; };
     template <typename T>
     struct is_stl_container<std::list<T> > { static const bool value = true; };
- 
+
     template <typename T>
     struct is_eigen_type { static const bool value = false; };
     template <typename T,int R,int C,int P,int MR,int MC>
@@ -252,7 +253,7 @@ namespace igl
     struct is_eigen_type<Eigen::Array<T,R,C,P,MR,MC> > { static const bool value = true; };
     template <typename T,int P,typename I>
     struct is_eigen_type<Eigen::SparseMatrix<T,P,I> > { static const bool value = true; };
- 
+
     template <typename T>
     struct is_smart_ptr { static const bool value = false; };
     template <typename T>
@@ -261,13 +262,13 @@ namespace igl
     struct is_smart_ptr<std::unique_ptr<T> > { static const bool value = true; };
     template <typename T>
     struct is_smart_ptr<std::weak_ptr<T> > { static const bool value = true; };
- 
+
     template <typename T>
     struct is_serializable {
       static const bool value = std::is_fundamental<T>::value || std::is_same<std::string,T>::value || std::is_enum<T>::value || std::is_base_of<SerializableBase,T>::value
         || is_stl_container<T>::value || is_eigen_type<T>::value || std::is_pointer<T>::value || serialization::is_smart_ptr<T>::value;
     };
- 
+
     // non serializable types
     template <typename T>
     inline typename std::enable_if<!is_serializable<T>::value,size_t>::type getByteSize(const T& obj);
@@ -275,7 +276,7 @@ namespace igl
     inline typename std::enable_if<!is_serializable<T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template <typename T>
     inline typename std::enable_if<!is_serializable<T>::value>::type deserialize(T& obj,std::vector<char>::const_iterator& iter);
- 
+
     // fundamental types
     template <typename T>
     inline typename std::enable_if<std::is_fundamental<T>::value,size_t>::type getByteSize(const T& obj);
@@ -283,12 +284,12 @@ namespace igl
     inline typename std::enable_if<std::is_fundamental<T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template <typename T>
     inline typename std::enable_if<std::is_fundamental<T>::value>::type deserialize(T& obj,std::vector<char>::const_iterator& iter);
- 
+
     // std::string
     inline size_t getByteSize(const std::string& obj);
     inline void serialize(const std::string& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     inline void deserialize(std::string& obj,std::vector<char>::const_iterator& iter);
- 
+
     // enum types
     template <typename T>
     inline typename std::enable_if<std::is_enum<T>::value,size_t>::type getByteSize(const T& obj);
@@ -296,7 +297,7 @@ namespace igl
     inline typename std::enable_if<std::is_enum<T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template <typename T>
     inline typename std::enable_if<std::is_enum<T>::value>::type deserialize(T& obj,std::vector<char>::const_iterator& iter);
- 
+
     // SerializableBase
     template <typename T>
     inline typename std::enable_if<std::is_base_of<SerializableBase,T>::value,size_t>::type getByteSize(const T& obj);
@@ -304,7 +305,7 @@ namespace igl
     inline typename std::enable_if<std::is_base_of<SerializableBase,T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template <typename T>
     inline typename std::enable_if<std::is_base_of<SerializableBase,T>::value>::type deserialize(T& obj,std::vector<char>::const_iterator& iter);
- 
+
     // stl containers
     // std::pair
     template <typename T1,typename T2>
@@ -313,7 +314,7 @@ namespace igl
     inline void serialize(const std::pair<T1,T2>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template <typename T1,typename T2>
     inline void deserialize(std::pair<T1,T2>& obj,std::vector<char>::const_iterator& iter);
- 
+
     // std::vector
     template <typename T1,typename T2>
     inline size_t getByteSize(const std::vector<T1,T2>& obj);
@@ -323,7 +324,7 @@ namespace igl
     inline void deserialize(std::vector<T1,T2>& obj,std::vector<char>::const_iterator& iter);
     template <typename T2>
     inline void deserialize(std::vector<bool,T2>& obj,std::vector<char>::const_iterator& iter);
- 
+
     // std::set
     template <typename T>
     inline size_t getByteSize(const std::set<T>& obj);
@@ -331,7 +332,7 @@ namespace igl
     inline void serialize(const std::set<T>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template <typename T>
     inline void deserialize(std::set<T>& obj,std::vector<char>::const_iterator& iter);
- 
+
     // std::map
     template <typename T1,typename T2>
     inline size_t getByteSize(const std::map<T1,T2>& obj);
@@ -339,7 +340,7 @@ namespace igl
     inline void serialize(const std::map<T1,T2>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template <typename T1,typename T2>
     inline void deserialize(std::map<T1,T2>& obj,std::vector<char>::const_iterator& iter);
- 
+
     // std::list
     template <typename T>
     inline size_t getByteSize(const std::list<T>& obj);
@@ -347,7 +348,7 @@ namespace igl
     inline void serialize(const std::list<T>& obj, std::vector<char>& buffer, std::vector<char>::iterator& iter);
     template <typename T>
     inline void deserialize(std::list<T>& obj, std::vector<char>::const_iterator& iter);
- 
+
     // Eigen types
     template<typename T,int R,int C,int P,int MR,int MC>
     inline size_t getByteSize(const Eigen::Matrix<T,R,C,P,MR,MC>& obj);
@@ -355,28 +356,28 @@ namespace igl
     inline void serialize(const Eigen::Matrix<T,R,C,P,MR,MC>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template<typename T,int R,int C,int P,int MR,int MC>
     inline void deserialize(Eigen::Matrix<T,R,C,P,MR,MC>& obj,std::vector<char>::const_iterator& iter);
- 
+
     template<typename T,int R,int C,int P,int MR,int MC>
     inline size_t getByteSize(const Eigen::Array<T,R,C,P,MR,MC>& obj);
     template<typename T,int R,int C,int P,int MR,int MC>
     inline void serialize(const Eigen::Array<T,R,C,P,MR,MC>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template<typename T,int R,int C,int P,int MR,int MC>
     inline void deserialize(Eigen::Array<T,R,C,P,MR,MC>& obj,std::vector<char>::const_iterator& iter);
- 
+
     template<typename T,int P,typename I>
     inline size_t getByteSize(const Eigen::SparseMatrix<T,P,I>& obj);
     template<typename T,int P,typename I>
     inline void serialize(const Eigen::SparseMatrix<T,P,I>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template<typename T,int P,typename I>
     inline void deserialize(Eigen::SparseMatrix<T,P,I>& obj,std::vector<char>::const_iterator& iter);
- 
+
     template<typename T,int P>
     inline size_t getByteSize(const Eigen::Quaternion<T,P>& obj);
     template<typename T,int P>
     inline void serialize(const Eigen::Quaternion<T,P>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template<typename T,int P>
     inline void deserialize(Eigen::Quaternion<T,P>& obj,std::vector<char>::const_iterator& iter);
- 
+
     // raw pointers
     template <typename T>
     inline typename std::enable_if<std::is_pointer<T>::value,size_t>::type getByteSize(const T& obj);
@@ -384,7 +385,7 @@ namespace igl
     inline typename std::enable_if<std::is_pointer<T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template <typename T>
     inline typename std::enable_if<std::is_pointer<T>::value>::type deserialize(T& obj,std::vector<char>::const_iterator& iter);
- 
+
     // std::shared_ptr and std::unique_ptr
     template <typename T>
     inline typename std::enable_if<serialization::is_smart_ptr<T>::value,size_t>::type getByteSize(const T& obj);
@@ -392,7 +393,7 @@ namespace igl
     inline typename std::enable_if<serialization::is_smart_ptr<T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template <template<typename> class T0, typename T1>
     inline typename std::enable_if<serialization::is_smart_ptr<T0<T1> >::value>::type deserialize(T0<T1>& obj,std::vector<char>::const_iterator& iter);
- 
+
     // std::weak_ptr
     template <typename T>
     inline size_t getByteSize(const std::weak_ptr<T>& obj);
@@ -400,23 +401,23 @@ namespace igl
     inline void serialize(const std::weak_ptr<T>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter);
     template <typename T>
     inline void deserialize(std::weak_ptr<T>& obj,std::vector<char>::const_iterator& iter);
- 
+
     // functions to overload for non-intrusive serialization
     template <typename T>
     inline void serialize(const T& obj,std::vector<char>& buffer);
     template <typename T>
     inline void deserialize(T& obj,const std::vector<char>& buffer);
- 
+
     // helper functions
     template <typename T>
     inline void updateMemoryMap(T& obj,size_t size);
   }
 }
- 
+
 // Always include inlines for these functions
- 
+
 // IMPLEMENTATION
- 
+
 namespace igl
 {
   template <typename T>
@@ -424,41 +425,41 @@ namespace igl
   {
     return serialize(obj,"obj",filename,true);
   }
- 
+
   template <typename T>
   inline bool serialize(const T& obj,const std::string& objectName,const std::string& filename,bool overwrite)
   {
     bool success = false;
- 
+
     std::vector<char> buffer;
- 
+
     std::ios_base::openmode mode = std::ios::out | std::ios::binary;
- 
+
     if(overwrite)
       mode |= std::ios::trunc;
     else
       mode |= std::ios::app;
- 
+
     std::ofstream file(filename.c_str(),mode);
- 
+
     if(file.is_open())
     {
       serialize(obj,objectName,buffer);
- 
+
       file.write(&buffer[0],buffer.size());
- 
+
       file.close();
- 
+
       success = true;
     }
     else
     {
       std::cerr << "serialization: file " << filename << " not found!" << std::endl;
     }
- 
+
     return success;
   }
- 
+
   template <typename T>
   inline bool serialize(const T& obj,const std::string& objectName,std::vector<char>& buffer)
   {
@@ -467,50 +468,50 @@ namespace igl
     std::vector<char> tmp(size);
     auto it = tmp.begin();
     serialization::serialize(obj,tmp,it);
- 
+
     std::string objectType(typeid(obj).name());
     size_t newObjectSize = tmp.size();
     size_t newHeaderSize = serialization::getByteSize(objectName) + serialization::getByteSize(objectType) + sizeof(size_t);
     size_t curSize = buffer.size();
     size_t newSize = curSize + newHeaderSize + newObjectSize;
- 
+
     buffer.resize(newSize);
- 
+
     std::vector<char>::iterator iter = buffer.begin()+curSize;
- 
+
     // serialize object header (name/type/size)
     serialization::serialize(objectName,buffer,iter);
     serialization::serialize(objectType,buffer,iter);
     serialization::serialize(newObjectSize,buffer,iter);
- 
+
     // copy serialized data to buffer
     iter = std::copy(tmp.begin(),tmp.end(),iter);
- 
+
     return true;
   }
- 
+
   template <typename T>
   inline bool deserialize(T& obj,const std::string& filename)
   {
     return deserialize(obj,"obj",filename);
   }
- 
+
   template <typename T>
   inline bool deserialize(T& obj,const std::string& objectName,const std::string& filename)
   {
     bool success = false;
- 
+
     std::ifstream file(filename.c_str(),std::ios::binary);
- 
+
     if(file.is_open())
     {
       file.seekg(0,std::ios::end);
       std::streamoff size = file.tellg();
       file.seekg(0,std::ios::beg);
- 
+
       std::vector<char> buffer(size);
       file.read(&buffer[0],size);
- 
+
       success = deserialize(obj, objectName, buffer);
       file.close();
     }
@@ -518,15 +519,15 @@ namespace igl
     {
       std::cerr << "serialization: file " << filename << " not found!" << std::endl;
     }
- 
+
     return success;
   }
- 
+
   template <typename T>
   inline bool deserialize(T& obj,const std::string& objectName,const std::vector<char>& buffer)
   {
     bool success = false;
- 
+
     // find suitable object header
     auto objectIter = buffer.cend();
     auto iter = buffer.cbegin();
@@ -538,16 +539,16 @@ namespace igl
       serialization::deserialize(name,iter);
       serialization::deserialize(type,iter);
       serialization::deserialize(size,iter);
- 
+
       if(name == objectName && type == typeid(obj).name())
       {
         objectIter = iter;
         //break; // find first suitable object header
       }
- 
+
       iter+=size;
     }
- 
+
     if(objectIter != buffer.end())
     {
       serialization::deserialize(obj,objectIter);
@@ -557,47 +558,47 @@ namespace igl
     {
       obj = T();
     }
- 
+
     return success;
   }
- 
+
   // Wrapper function which combines both, de- and serialization
   template <typename T>
   inline bool serializer(bool s,T& obj,const std::string& filename)
   {
     return s ? serialize(obj,filename) : deserialize(obj,filename);
   }
- 
+
   template <typename T>
   inline bool serializer(bool s,T& obj,const std::string& objectName,const std::string& filename,bool overwrite)
   {
     return s ? serialize(obj,objectName,filename,overwrite) : deserialize(obj,objectName,filename);
   }
- 
+
   template <typename T>
   inline bool serializer(bool s,T& obj,const std::string& objectName,std::vector<char>& buffer)
   {
     return s ? serialize(obj,objectName,buffer) : deserialize(obj,objectName,buffer);
   }
- 
+
   inline bool Serializable::PreSerialization() const
   {
     return true;
   }
- 
+
   inline void Serializable::PostSerialization() const
   {
   }
- 
+
   inline bool Serializable::PreDeserialization()
   {
     return true;
   }
- 
+
   inline void Serializable::PostDeserialization()
   {
   }
- 
+
   inline void Serializable::Serialize(std::vector<char>& buffer) const
   {
     if(this->PreSerialization())
@@ -608,16 +609,16 @@ namespace igl
         (const_cast<Serializable*>(this))->InitSerialization();
         initialized = true;
       }
- 
+
       for(const auto& v : objects)
       {
         v->Serialize(buffer);
       }
- 
+
       this->PostSerialization();
     }
   }
- 
+
   inline void Serializable::Deserialize(const std::vector<char>& buffer)
   {
     if(this->PreDeserialization())
@@ -628,33 +629,33 @@ namespace igl
         (const_cast<Serializable*>(this))->InitSerialization();
         initialized = true;
       }
- 
+
       for(auto& v : objects)
       {
         v->Deserialize(buffer);
       }
- 
+
       this->PostDeserialization();
     }
   }
- 
+
   inline Serializable::Serializable()
   {
     initialized = false;
   }
- 
+
   inline Serializable::Serializable(const Serializable& obj)
   {
     initialized = false;
     objects.clear();
   }
- 
+
   inline Serializable::~Serializable()
   {
     initialized = false;
     objects.clear();
   }
- 
+
   inline Serializable& Serializable::operator=(const Serializable& obj)
   {
     if(this != &obj)
@@ -667,7 +668,7 @@ namespace igl
     }
     return *this;
   }
- 
+
   template <typename T>
   inline void Serializable::Add(T& obj,const std::string name,bool binary)
   {
@@ -675,10 +676,10 @@ namespace igl
     object->Binary = binary;
     object->Name = name;
     object->Object = std::unique_ptr<T>(&obj);
- 
+
     objects.push_back(object);
   }
- 
+
   namespace serialization
   {
     template <typename T>
@@ -686,46 +687,46 @@ namespace igl
     {
       return sizeof(std::vector<char>::size_type);
     }
- 
+
     template <typename T>
     inline typename std::enable_if<!is_serializable<T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
       // data
       std::vector<char> tmp;
       serialize<>(obj,tmp);
- 
+
       // size
       size_t size = buffer.size();
       serialization::serialize(tmp.size(),buffer,iter);
       size_t cur = iter - buffer.begin();
- 
+
       buffer.resize(size+tmp.size());
       iter = buffer.begin()+cur;
       iter = std::copy(tmp.begin(),tmp.end(),iter);
     }
- 
+
     template <typename T>
     inline typename std::enable_if<!is_serializable<T>::value>::type deserialize(T& obj,std::vector<char>::const_iterator& iter)
     {
       std::vector<char>::size_type size;
       serialization::deserialize<>(size,iter);
- 
+
       std::vector<char> tmp;
       tmp.resize(size);
       std::copy(iter,iter+size,tmp.begin());
- 
+
       deserialize<>(obj,tmp);
       iter += size;
     }
- 
+
     // fundamental types
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_fundamental<T>::value,size_t>::type getByteSize(const T& obj)
     {
       return sizeof(T);
     }
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_fundamental<T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
@@ -733,7 +734,7 @@ namespace igl
       const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&obj);
       iter = std::copy(ptr,ptr+sizeof(T),iter);
     }
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_fundamental<T>::value>::type deserialize(T& obj,std::vector<char>::const_iterator& iter)
     {
@@ -741,14 +742,14 @@ namespace igl
       std::copy(iter,iter+sizeof(T),ptr);
       iter += sizeof(T);
     }
- 
+
     // std::string
- 
+
     inline size_t getByteSize(const std::string& obj)
     {
       return getByteSize(obj.length())+obj.length()*sizeof(uint8_t);
     }
- 
+
     inline void serialize(const std::string& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
       serialization::serialize(obj.length(),buffer,iter);
@@ -757,36 +758,36 @@ namespace igl
         serialization::serialize(cur,buffer,iter);
       }
     }
- 
+
     inline void deserialize(std::string& obj,std::vector<char>::const_iterator& iter)
     {
       size_t size;
       serialization::deserialize(size,iter);
- 
+
       std::string str(size,'\0');
       for(size_t i=0; i<size; ++i)
       {
         serialization::deserialize(str.at(i),iter);
       }
- 
+
       obj = str;
     }
- 
+
     // enum types
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_enum<T>::value,size_t>::type getByteSize(const T& obj)
     {
       return sizeof(T);
     }
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_enum<T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
       const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&obj);
       iter = std::copy(ptr,ptr+sizeof(T),iter);
     }
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_enum<T>::value>::type deserialize(T& obj,std::vector<char>::const_iterator& iter)
     {
@@ -794,78 +795,78 @@ namespace igl
       std::copy(iter,iter+sizeof(T),ptr);
       iter += sizeof(T);
     }
- 
+
     // SerializableBase
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_base_of<SerializableBase,T>::value,size_t>::type getByteSize(const T& obj)
     {
       return sizeof(std::vector<char>::size_type);
     }
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_base_of<SerializableBase,T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
       // data
       std::vector<char> tmp;
       obj.Serialize(tmp);
- 
+
       // size
       size_t size = buffer.size();
       serialization::serialize(tmp.size(),buffer,iter);
       size_t cur = iter - buffer.begin();
- 
+
       buffer.resize(size+tmp.size());
       iter = buffer.begin()+cur;
       iter = std::copy(tmp.begin(),tmp.end(),iter);
     }
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_base_of<SerializableBase,T>::value>::type deserialize(T& obj,std::vector<char>::const_iterator& iter)
     {
       std::vector<char>::size_type size;
       serialization::deserialize(size,iter);
- 
+
       std::vector<char> tmp;
       tmp.resize(size);
       std::copy(iter,iter+size,tmp.begin());
- 
+
       obj.Deserialize(tmp);
       iter += size;
     }
- 
+
     // STL containers
- 
+
     // std::pair
- 
+
     template <typename T1,typename T2>
     inline size_t getByteSize(const std::pair<T1,T2>& obj)
     {
       return getByteSize(obj.first)+getByteSize(obj.second);
     }
- 
+
     template <typename T1,typename T2>
     inline void serialize(const std::pair<T1,T2>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
       serialization::serialize(obj.first,buffer,iter);
       serialization::serialize(obj.second,buffer,iter);
     }
- 
+
     template <typename T1,typename T2>
     inline void deserialize(std::pair<T1,T2>& obj,std::vector<char>::const_iterator& iter)
     {
       serialization::deserialize(obj.first,iter);
       serialization::deserialize(obj.second,iter);
     }
- 
+
     // std::vector
- 
+
     template <typename T1,typename T2>
     inline size_t getByteSize(const std::vector<T1,T2>& obj)
     {
       return std::accumulate(obj.begin(),obj.end(),sizeof(size_t),[](const size_t& acc,const T1& cur) { return acc+getByteSize(cur); });
     }
- 
+
     template <typename T1,typename T2>
     inline void serialize(const std::vector<T1,T2>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
@@ -876,26 +877,26 @@ namespace igl
         serialization::serialize(cur,buffer,iter);
       }
     }
- 
+
     template <typename T1,typename T2>
     inline void deserialize(std::vector<T1,T2>& obj,std::vector<char>::const_iterator& iter)
     {
       size_t size;
       serialization::deserialize(size,iter);
- 
+
       obj.resize(size);
       for(T1& v : obj)
       {
         serialization::deserialize(v,iter);
       }
     }
- 
+
     template <typename T2>
     inline void deserialize(std::vector<bool,T2>& obj,std::vector<char>::const_iterator& iter)
     {
       size_t size;
       serialization::deserialize(size,iter);
- 
+
       obj.resize(size);
       for(int i=0;i<obj.size();i++)
       {
@@ -904,15 +905,15 @@ namespace igl
         obj[i] = val;
       }
     }
- 
+
     //std::set
- 
+
     template <typename T>
     inline size_t getByteSize(const std::set<T>& obj)
     {
       return std::accumulate(obj.begin(),obj.end(),getByteSize(obj.size()),[](const size_t& acc,const T& cur) { return acc+getByteSize(cur); });
     }
- 
+
     template <typename T>
     inline void serialize(const std::set<T>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
@@ -922,13 +923,13 @@ namespace igl
         serialization::serialize(cur,buffer,iter);
       }
     }
- 
+
     template <typename T>
     inline void deserialize(std::set<T>& obj,std::vector<char>::const_iterator& iter)
     {
       size_t size;
       serialization::deserialize(size,iter);
- 
+
       obj.clear();
       for(size_t i=0; i<size; ++i)
       {
@@ -937,15 +938,15 @@ namespace igl
         obj.insert(val);
       }
     }
- 
+
     // std::map
- 
+
     template <typename T1,typename T2>
     inline size_t getByteSize(const std::map<T1,T2>& obj)
     {
       return std::accumulate(obj.begin(),obj.end(),sizeof(size_t),[](const size_t& acc,const std::pair<T1,T2>& cur) { return acc+getByteSize(cur); });
     }
- 
+
     template <typename T1,typename T2>
     inline void serialize(const std::map<T1,T2>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
@@ -955,13 +956,13 @@ namespace igl
         serialization::serialize(cur,buffer,iter);
       }
     }
- 
+
     template <typename T1,typename T2>
     inline void deserialize(std::map<T1,T2>& obj,std::vector<char>::const_iterator& iter)
     {
       size_t size;
       serialization::deserialize(size,iter);
- 
+
       obj.clear();
       for(size_t i=0; i<size; ++i)
       {
@@ -970,15 +971,15 @@ namespace igl
         obj.insert(pair);
       }
     }
- 
+
     //std::list
- 
+
     template <typename T>
     inline size_t getByteSize(const std::list<T>& obj)
     {
         return std::accumulate(obj.begin(), obj.end(), getByteSize(obj.size()), [](const size_t& acc, const T& cur) { return acc + getByteSize(cur); });
     }
- 
+
     template <typename T>
     inline void serialize(const std::list<T>& obj, std::vector<char>& buffer, std::vector<char>::iterator& iter)
     {
@@ -988,13 +989,13 @@ namespace igl
             serialization::serialize(cur, buffer, iter);
         }
     }
- 
+
     template <typename T>
     inline void deserialize(std::list<T>& obj, std::vector<char>::const_iterator& iter)
     {
         size_t size;
         serialization::deserialize(size, iter);
- 
+
         obj.clear();
         for (size_t i = 0; i < size; ++i)
         {
@@ -1003,8 +1004,8 @@ namespace igl
             obj.emplace_back(val);
         }
     }
- 
- 
+
+
     // Eigen types
     template<typename T,int R,int C,int P,int MR,int MC>
     inline size_t getByteSize(const Eigen::Matrix<T,R,C,P,MR,MC>& obj)
@@ -1012,7 +1013,7 @@ namespace igl
       // space for numbers of rows,cols and data
       return 2*sizeof(typename Eigen::Matrix<T,R,C,P,MR,MC>::Index)+sizeof(T)*obj.rows()*obj.cols();
     }
- 
+
     template<typename T,int R,int C,int P,int MR,int MC>
     inline void serialize(const Eigen::Matrix<T,R,C,P,MR,MC>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
@@ -1022,7 +1023,7 @@ namespace igl
       auto ptr = reinterpret_cast<const uint8_t*>(obj.data());
       iter = std::copy(ptr,ptr+size,iter);
     }
- 
+
     template<typename T,int R,int C,int P,int MR,int MC>
     inline void deserialize(Eigen::Matrix<T,R,C,P,MR,MC>& obj,std::vector<char>::const_iterator& iter)
     {
@@ -1035,14 +1036,14 @@ namespace igl
       std::copy(iter,iter+size,ptr);
       iter+=size;
     }
- 
+
     template<typename T,int R,int C,int P,int MR,int MC>
     inline size_t getByteSize(const Eigen::Array<T,R,C,P,MR,MC>& obj)
     {
       // space for numbers of rows,cols and data
       return 2*sizeof(typename Eigen::Array<T,R,C,P,MR,MC>::Index)+sizeof(T)*obj.rows()*obj.cols();
     }
- 
+
     template<typename T,int R,int C,int P,int MR,int MC>
     inline void serialize(const Eigen::Array<T,R,C,P,MR,MC>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
@@ -1052,7 +1053,7 @@ namespace igl
       auto ptr = reinterpret_cast<const uint8_t*>(obj.data());
       iter = std::copy(ptr,ptr+size,iter);
     }
- 
+
     template<typename T,int R,int C,int P,int MR,int MC>
     inline void deserialize(Eigen::Array<T,R,C,P,MR,MC>& obj,std::vector<char>::const_iterator& iter)
     {
@@ -1065,7 +1066,7 @@ namespace igl
       std::copy(iter,iter+size,ptr);
       iter+=size;
     }
- 
+
     template<typename T,int P,typename I>
     inline size_t getByteSize(const Eigen::SparseMatrix<T,P,I>& obj)
     {
@@ -1073,14 +1074,14 @@ namespace igl
       size_t size = sizeof(typename Eigen::SparseMatrix<T,P,I>::Index);
       return 3*size+(sizeof(T)+2*size)*obj.nonZeros();
     }
- 
+
     template<typename T,int P,typename I>
     inline void serialize(const Eigen::SparseMatrix<T,P,I>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
       serialization::serialize(obj.rows(),buffer,iter);
       serialization::serialize(obj.cols(),buffer,iter);
       serialization::serialize(obj.nonZeros(),buffer,iter);
- 
+
       for(int k=0;k<obj.outerSize();++k)
       {
         for(typename Eigen::SparseMatrix<T,P,I>::InnerIterator it(obj,k);it;++it)
@@ -1091,7 +1092,7 @@ namespace igl
         }
       }
     }
- 
+
     template<typename T,int P,typename I>
     inline void deserialize(Eigen::SparseMatrix<T,P,I>& obj,std::vector<char>::const_iterator& iter)
     {
@@ -1099,10 +1100,10 @@ namespace igl
       serialization::deserialize(rows,iter);
       serialization::deserialize(cols,iter);
       serialization::deserialize(nonZeros,iter);
- 
+
       obj.resize(rows,cols);
       obj.setZero();
- 
+
       std::vector<Eigen::Triplet<T,I> > triplets;
       for(int i=0;i<nonZeros;i++)
       {
@@ -1115,13 +1116,13 @@ namespace igl
       }
       obj.setFromTriplets(triplets.begin(),triplets.end());
     }
- 
+
     template<typename T,int P>
     inline size_t getByteSize(const Eigen::Quaternion<T,P>& obj)
     {
       return sizeof(T)*4;
     }
- 
+
     template<typename T,int P>
     inline void serialize(const Eigen::Quaternion<T,P>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
@@ -1130,7 +1131,7 @@ namespace igl
       serialization::serialize(obj.y(),buffer,iter);
       serialization::serialize(obj.z(),buffer,iter);
     }
- 
+
     template<typename T,int P>
     inline void deserialize(Eigen::Quaternion<T,P>& obj,std::vector<char>::const_iterator& iter)
     {
@@ -1139,35 +1140,35 @@ namespace igl
       serialization::deserialize(obj.y(),iter);
       serialization::deserialize(obj.z(),iter);
     }
- 
+
     // pointers
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_pointer<T>::value,size_t>::type getByteSize(const T& obj)
     {
       size_t size = sizeof(bool);
- 
+
       if(obj)
         size += getByteSize(*obj);
- 
+
       return size;
     }
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_pointer<T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
       serialization::serialize(obj == nullptr,buffer,iter);
- 
+
       if(obj)
         serialization::serialize(*obj,buffer,iter);
     }
- 
+
     template <typename T>
     inline typename std::enable_if<std::is_pointer<T>::value>::type deserialize(T& obj,std::vector<char>::const_iterator& iter)
     {
       bool isNullPtr;
       serialization::deserialize(isNullPtr,iter);
- 
+
       if(isNullPtr)
       {
         if(obj)
@@ -1189,27 +1190,27 @@ namespace igl
         serialization::deserialize(*obj,iter);
       }
     }
- 
+
     // std::shared_ptr and std::unique_ptr
- 
+
     template <typename T>
     inline typename std::enable_if<serialization::is_smart_ptr<T>::value,size_t>::type getByteSize(const T& obj)
     {
       return getByteSize(obj.get());
     }
- 
+
     template <typename T>
     inline typename std::enable_if<serialization::is_smart_ptr<T>::value>::type serialize(const T& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
       serialize(obj.get(),buffer,iter);
     }
- 
+
     template <template<typename> class T0,typename T1>
     inline typename std::enable_if<serialization::is_smart_ptr<T0<T1> >::value>::type deserialize(T0<T1>& obj,std::vector<char>::const_iterator& iter)
     {
       bool isNullPtr;
       serialization::deserialize(isNullPtr,iter);
- 
+
       if(isNullPtr)
       {
         obj.reset();
@@ -1220,42 +1221,42 @@ namespace igl
         serialization::deserialize(*obj,iter);
       }
     }
- 
+
     // std::weak_ptr
- 
+
     template <typename T>
     inline size_t getByteSize(const std::weak_ptr<T>& obj)
     {
       return sizeof(size_t);
     }
- 
+
     template <typename T>
     inline void serialize(const std::weak_ptr<T>& obj,std::vector<char>& buffer,std::vector<char>::iterator& iter)
     {
- 
+
     }
- 
+
     template <typename T>
     inline void deserialize(std::weak_ptr<T>& obj,std::vector<char>::const_iterator& iter)
     {
- 
+
     }
- 
+
     // functions to overload for non-intrusive serialization
     template <typename T>
     inline void serialize(const T& obj,std::vector<char>& buffer)
     {
       std::cerr << typeid(obj).name() << " is not serializable: derive from igl::Serializable or specialize the template function igl::serialization::serialize(const T& obj,std::vector<char>& buffer)" << std::endl;
     }
- 
+
     template <typename T>
     inline void deserialize(T& obj,const std::vector<char>& buffer)
     {
       std::cerr << typeid(obj).name() << " is not deserializable: derive from igl::Serializable or specialize the template function igl::serialization::deserialize(T& obj, const std::vector<char>& buffer)" << std::endl;
     }
- 
+
     // helper functions
- 
+
     template <typename T>
     inline void updateMemoryMap(T& obj,size_t size,std::map<std::uintptr_t,IndexedPointerBase*>& memoryMap)
     {
@@ -1266,7 +1267,7 @@ namespace igl
       startBasePtr->Type = IndexedPointerBase::BEGIN;
       auto startAddress = reinterpret_cast<std::uintptr_t>(&obj);
       auto p = std::pair<std::uintptr_t,IndexedPointerBase*>(startAddress,startBasePtr);
- 
+
       auto el = memoryMap.insert(p);
       auto iter = ++el.first; // next elememt
       if(el.second && (iter == memoryMap.end() || iter->second->Type != IndexedPointerBase::END))
@@ -1277,14 +1278,14 @@ namespace igl
         endBasePtr->Type = IndexedPointerBase::END;
         auto endAddress = reinterpret_cast<std::uintptr_t>(&obj) + size - 1;
         auto p = std::pair<std::uintptr_t,IndexedPointerBase*>(endAddress,endBasePtr);
- 
+
         // insert end address
         memoryMap.insert(el.first,p);
       }
       else
       {
         // already serialized
- 
+
         // remove inserted address
         memoryMap.erase(el.first);
       }

--- a/tutorial/106_ViewerMenu/main.cpp
+++ b/tutorial/106_ViewerMenu/main.cpp
@@ -2,7 +2,6 @@
 #include <igl/opengl/glfw/Viewer.h>
 #include <igl/opengl/glfw/imgui/ImGuiMenu.h>
 #include <igl/opengl/glfw/imgui/ImGuiHelpers.h>
-#include <imgui/imgui.h>
 #include <iostream>
 
 int main(int argc, char *argv[])

--- a/tutorial/109_ImGuizmo/main.cpp
+++ b/tutorial/109_ImGuizmo/main.cpp
@@ -2,11 +2,6 @@
 #include <igl/opengl/glfw/Viewer.h>
 #include <igl/opengl/glfw/imgui/ImGuizmoPlugin.h>
 #include <GLFW/glfw3.h>
-#include <imgui/imgui.h>
-#include <imgui/imgui_internal.h>
-#include <imgui_impl_glfw.h>
-#include <imgui_impl_opengl3.h>
-#include <imguizmo/ImGuizmo.h>
 
 int main(int argc, char *argv[])
 {
@@ -21,7 +16,7 @@ int main(int argc, char *argv[])
   igl::opengl::glfw::imgui::ImGuizmoPlugin plugin;
   vr.plugins.push_back(&plugin);
   // Initialize ImGuizmo at mesh centroid
-  plugin.T.block(0,3,3,1) = 
+  plugin.T.block(0,3,3,1) =
     0.5*(V.colwise().maxCoeff() + V.colwise().minCoeff()).transpose().cast<float>();
   // Update can be applied relative to this remembered initial transform
   const Eigen::Matrix4f T0 = plugin.T;

--- a/tutorial/409_Kelvinlets/main.cpp
+++ b/tutorial/409_Kelvinlets/main.cpp
@@ -4,7 +4,7 @@
 #include <igl/readOFF.h>
 #include <igl/unproject.h>
 #include <igl/unproject_onto_mesh.h>
-#include <imgui/imgui.h>
+#include <imgui.h>
 #include <iostream>
 
 namespace {


### PR DESCRIPTION
Updates CMake code to use the repo imgui and imguizmo as the only include path. This avoids the hack of copying headers around and makes libigl code compatible with other codebase including imgui in their own projects.

Client code using ImGuiMenu.h should not need to include `imgui.h` (since it's already included by `ImGuiMenu.h`), but if they do, the following modifications would be required:
- `#include <imgui/imgui.h>` --> `#include <imgui.h>`
- `#include <imgui/imgui_internal.h>` --> `#include <imgui_internal.h>`
- `#include <imgui_impl_glfw.h>` --> `#include <backends/imgui_impl_glfw.h>`
- `#include <imgui_impl_opengl3.h>` --> `#include <backends/imgui_impl_opengl3.h>`