### PR TITLE
Update Catch2 to latest version (v2.13.8)

### DIFF
--- a/cmake/recipes/external/catch2.cmake
+++ b/cmake/recipes/external/catch2.cmake
@@ -8,7 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
     catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v2.13.3
+    GIT_TAG v2.13.8
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(catch2)


### PR DESCRIPTION
The previously used Catch2 version fails to build with glibc >= 2.34.
As MINSIGSTKSZ can no longer be assumed to be constant:
* https://sourceware.org/git/?p=glibc.git;a=commit;h=6c57d320484988e87e446e2e60ce42816bf51d53
* https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html

It's fixed in Catch2 since 2.13.5: https://github.com/catchorg/Catch2/releases/tag/v2.13.5

The upcoming Ubuntu LTS (22.04) will ship with an incompatible glibc version.

<!-- Describe your changes and what you've already done to test it. -->


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] This is a minor change.
