### PR TITLE
Remove hardcoded ImGui menu width constraint

### DIFF
--- a/include/igl/opengl/glfw/imgui/ImGuiMenu.cpp
+++ b/include/igl/opengl/glfw/imgui/ImGuiMenu.cpp
@@ -40,10 +40,8 @@ IGL_INLINE void ImGuiMenu::draw()
 
 IGL_INLINE void ImGuiMenu::draw_viewer_window()
 {
-  float menu_width = 180.f * menu_scaling();
   ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowSize(ImVec2(0.0f, 0.0f), ImGuiCond_FirstUseEver);
-  ImGui::SetNextWindowSizeConstraints(ImVec2(menu_width, -1.0f), ImVec2(menu_width, -1.0f));
   bool _viewer_menu_visible = true;
   ImGui::Begin(
       "Viewer", &_viewer_menu_visible,


### PR DESCRIPTION
The `ImGuiMenu` class currently constraints the width to a hardcoded value, and also enables auto-resizing. Both of these settings overlap, in that they both prevent the user from resizing the ImGui menu, but the width constraint effectively overrides the auto-resizing feature, which sets the width at a potentially undesirable value (e.g., wide content can be truncated). Removing the width constraint and just letting ImGui resize the menu automatically seems to be a good approach. I've only tested this on some code in a private repo that I don't want to share publicly, but I am happy to write up a simple example demonstrating the change, or discuss an alternative approach (e.g., perhaps a user might want to set a maximum width constraint or manually fix the width on their end).


#### Checklist

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
