### PR TITLE
Disable glad on apple

### DIFF
--- a/include/igl/opengl/gl.h
+++ b/include/igl/opengl/gl.h
@@ -20,6 +20,10 @@
 //     #include <GL/gl.h>
 //
 
+#ifdef __APPLE__
+#include <OpenGL/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 #endif

--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -177,11 +177,13 @@ namespace glfw
     }
     glfwMakeContextCurrent(window);
     // Load OpenGL and its extensions
+#ifndef __APPLE__
     if (!gladLoadGLLoader((GLADloadproc) glfwGetProcAddress))
     {
       printf("Failed to load OpenGL and its extensions\n");
       return(-1);
     }
+#endif
     #if defined(DEBUG) || defined(_DEBUG)
       printf("OpenGL Version %d.%d loaded\n", GLVersion.major, GLVersion.minor);
       int major, minor, rev;

--- a/include/igl/opengl/glfw/background_window.cpp
+++ b/include/igl/opengl/glfw/background_window.cpp
@@ -17,10 +17,12 @@ IGL_INLINE bool igl::opengl::glfw::background_window(GLFWwindow* & window)
   window = glfwCreateWindow(1, 1,"", NULL, NULL);
   if(!window) return false;
   glfwMakeContextCurrent(window);
+#ifndef __APPLE__
   if (!gladLoadGLLoader((GLADloadproc) glfwGetProcAddress))
   {
     printf("Failed to load OpenGL and its extensions");
   }
+#endif
   glGetError(); // pull and safely ignore unhandled errors like GL_INVALID_ENUM
   return true;
 }


### PR DESCRIPTION
Fixes #751.

We should either merge this or a libtool/cmake flag fix discussed on #751 as a stopgap. Especially if we can't identify any need for glad on Apple. Unless a need for glad on Apple is raised, I'm inclined to avoid compilation flags.

(So far, this PR doesn't remove glad from the cmake fetching and building on mac.)

(Might also fix https://github.com/libigl/libigl-example-project/issues/33 but not tested)