### PR TITLE
Avoid converting exact input to inexact when detecting intersections

### DIFF
--- a/include/igl/copyleft/cgal/intersect_other.cpp
+++ b/include/igl/copyleft/cgal/intersect_other.cpp
@@ -255,7 +255,12 @@ IGL_INLINE bool igl::copyleft::cgal::intersect_other(
     Eigen::PlainObjectBase<DerivedJAB>  & JAB,
     Eigen::PlainObjectBase<DerivedIMAB> & IMAB)
 {
-  if(params.detect_only)
+  typedef typename DerivedVA::Scalar VAScalar;
+  typedef typename DerivedVB::Scalar VBScalar;
+  if(params.detect_only && ! (
+    std::is_same<VAScalar,CGAL::Epeck::FT>::value ||
+    std::is_same<VBScalar,CGAL::Epeck::FT>::value
+    ))
   {
     return intersect_other_helper<CGAL::Epick>
       (VA,FA,VB,FB,params,IF,VVAB,FFAB,JAB,IMAB);

--- a/include/igl/copyleft/cgal/remesh_self_intersections.cpp
+++ b/include/igl/copyleft/cgal/remesh_self_intersections.cpp
@@ -30,7 +30,8 @@ IGL_INLINE void igl::copyleft::cgal::remesh_self_intersections(
   Eigen::PlainObjectBase<DerivedIM> & IM)
 {
   using namespace std;
-  if(params.detect_only)
+  typedef typename DerivedV::Scalar VScalar;
+  if(params.detect_only && ! std::is_same<VScalar,CGAL::Epeck::FT>::value)
   {
     //// This is probably a terrible idea, but CGAL is throwing floating point
     //// exceptions.


### PR DESCRIPTION
The previous `remesh_self_intersections.cpp` and `intersect_other.cpp` had a branch

```
if detect_only
  use Epick to find intersections
else
  use Epeck to find and resolve intersections
```

This _only_ depended on the boolean flag `detect_only`. Unfortunately, that meant if the caller's input vertices were in the exact type `CGAL::Epeck::FT` and `detect_only=true`, then the input would be converted (i.e., rounded) to `CGAL::Epick::FT` (aka `double`) before looking for intersections. This leads to **false positives**.

This PR replaces the branch with `if detect_only and not Epeck input`.

Hopefully this merges easily so I can get it in before finishing #1539 1895
