### PR TITLE
Make CONFIGURE_HANDLED_BY_BUILD optional dependent on cmake version

### DIFF
--- a/cmake/recipes/external/cgal.cmake
+++ b/cmake/recipes/external/cgal.cmake
@@ -48,6 +48,8 @@ function(cgal_import_target)
     # Prefer Config mode before Module mode to prevent CGAL from loading its own FindXXX.cmake
     set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
 
+    # https://stackoverflow.com/a/71714947/148668
+    set(CGAL_DATA_DIR "unspecified")
     find_package(CGAL CONFIG COMPONENTS Core PATHS ${cgal_SOURCE_DIR} NO_DEFAULT_PATH)
 endfunction()
 

--- a/cmake/recipes/external/gmp.cmake
+++ b/cmake/recipes/external/gmp.cmake
@@ -20,6 +20,15 @@ else()
   set(gmp_LIBRARY ${gmp_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gmp${CMAKE_STATIC_LIBRARY_SUFFIX})
   set(gmp_INCLUDE_DIR ${gmp_INSTALL}/include)
 
+  # Try to use CONFIGURE_HANDLED_BY_BUILD ON to avoid constantly reconfiguring
+  if(${CMAKE_VERSION} VERSION_LESS 3.20)
+    # CMake < 3.20, do not use any extra option
+    set(gmp_ExternalProject_Add_extra_options)
+  else()
+    # CMake >= 3.20
+    set(gmp_ExternalProject_Add_extra_options "CONFIGURE_HANDLED_BY_BUILD;ON")
+  endif()
+
   ExternalProject_Add(gmp
     PREFIX ${prefix}
     URL  https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz
@@ -27,7 +36,7 @@ else()
     UPDATE_DISCONNECTED true  # need this to avoid constant rebuild
     PATCH_COMMAND 
       curl "https://gmplib.org/repo/gmp/raw-rev/5f32dbc41afc" "|" git apply -v
-    CONFIGURE_HANDLED_BY_BUILD ON  # avoid constant reconfigure
+    ${gmp_ExternalProject_Add_extra_options}
     CONFIGURE_COMMAND 
       ${prefix}/src/gmp/configure 
       --disable-debug --disable-dependency-tracking --enable-cxx --with-pic

--- a/cmake/recipes/external/mpfr.cmake
+++ b/cmake/recipes/external/mpfr.cmake
@@ -23,13 +23,22 @@ else()
   set(mpfr_LIBRARY ${mpfr_INSTALL}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}mpfr${CMAKE_STATIC_LIBRARY_SUFFIX})
   set(mpfr_INCLUDE_DIR ${mpfr_INSTALL}/include)
 
+  # Try to use CONFIGURE_HANDLED_BY_BUILD ON to avoid constantly reconfiguring
+  if(${CMAKE_VERSION} VERSION_LESS 3.20)
+    # CMake < 3.20, do not use any extra option
+    set(mpfr_ExternalProject_Add_extra_options)
+  else()
+    # CMake >= 3.20
+    set(mpfr_ExternalProject_Add_extra_options "CONFIGURE_HANDLED_BY_BUILD;ON")
+  endif()
+
   ExternalProject_Add(mpfr
     PREFIX ${prefix}
     DEPENDS gmp
     URL  https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz
     URL_MD5 bdd3d5efba9c17da8d83a35ec552baef
     UPDATE_DISCONNECTED true  # need this to avoid constant rebuild
-    CONFIGURE_HANDLED_BY_BUILD ON  # avoid constant reconfigure
+    ${mpfr_ExternalProject_Add_extra_options} # avoid constant reconfigure
     CONFIGURE_COMMAND 
       ${prefix}/src/mpfr/configure 
       --disable-debug --disable-dependency-tracking  --disable-silent-rules --enable-cxx --with-pic


### PR DESCRIPTION
Fixes #2014

(also circumvents pesky cmake warning from cgal)