### PR TITLE
point GMPXX_INCLUDE_DIR to locally built gmp

### DIFF
--- a/cmake/recipes/external/cgal.cmake
+++ b/cmake/recipes/external/cgal.cmake
@@ -34,8 +34,10 @@ function(cgal_import_target)
     include(boost)
 
     ignore_package(GMP 5.0.1)
-    set(GMP_INCLUDE_DIR "")
+    set(GMP_INCLUDE_DIR ${gmp_INCLUDE_DIR})
     set(GMP_LIBRARIES gmp::gmp)
+    set(GMPXX_INCLUDE_DIR ${GMP_INCLUDE_DIR})
+    set(GMPXX_LIBRARIES ${GMP_LIBRARIES})
 
     ignore_package(MPFR 3.0.0)
     set(MPFR_INCLUDE_DIR "")

--- a/cmake/recipes/external/cgal.cmake
+++ b/cmake/recipes/external/cgal.cmake
@@ -34,9 +34,10 @@ function(cgal_import_target)
     include(boost)
 
     ignore_package(GMP 5.0.1)
-    set(GMP_INCLUDE_DIR ${gmp_INCLUDE_DIR})
+    set(GMP_INCLUDE_DIR "")
     set(GMP_LIBRARIES gmp::gmp)
-    set(GMPXX_INCLUDE_DIR ${GMP_INCLUDE_DIR})
+    ignore_package(GMPXX 5.0.1)
+    set(GMPXX_INCLUDE_DIR "")
     set(GMPXX_LIBRARIES ${GMP_LIBRARIES})
 
     ignore_package(MPFR 3.0.0)

--- a/cmake/recipes/external/cgal.cmake
+++ b/cmake/recipes/external/cgal.cmake
@@ -36,7 +36,6 @@ function(cgal_import_target)
     ignore_package(GMP 5.0.1)
     set(GMP_INCLUDE_DIR ${gmp_INCLUDE_DIR})
     set(GMP_LIBRARIES gmp::gmp)
-    ignore_package(GMPXX 5.0.1)
     set(GMPXX_INCLUDE_DIR ${GMP_INCLUDE_DIR})
     set(GMPXX_LIBRARIES ${GMP_LIBRARIES})
 

--- a/cmake/recipes/external/cgal.cmake
+++ b/cmake/recipes/external/cgal.cmake
@@ -34,10 +34,10 @@ function(cgal_import_target)
     include(boost)
 
     ignore_package(GMP 5.0.1)
-    set(GMP_INCLUDE_DIR "")
+    set(GMP_INCLUDE_DIR ${gmp_INCLUDE_DIR})
     set(GMP_LIBRARIES gmp::gmp)
     ignore_package(GMPXX 5.0.1)
-    set(GMPXX_INCLUDE_DIR "")
+    set(GMPXX_INCLUDE_DIR ${GMP_INCLUDE_DIR})
     set(GMPXX_LIBRARIES ${GMP_LIBRARIES})
 
     ignore_package(MPFR 3.0.0)

--- a/cmake/recipes/external/gmp.cmake
+++ b/cmake/recipes/external/gmp.cmake
@@ -17,7 +17,10 @@ else()
   set(prefix ${FETCHCONTENT_BASE_DIR}/gmp)
   set(gmp_INSTALL ${prefix}/install)
   set(gmp_LIB_DIR ${gmp_INSTALL}/lib)
-  set(gmp_LIBRARY ${gmp_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gmp${CMAKE_STATIC_LIBRARY_SUFFIX})
+  set(gmp_LIBRARY 
+    ${gmp_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gmp${CMAKE_STATIC_LIBRARY_SUFFIX}
+    ${gmp_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gmpxx${CMAKE_STATIC_LIBRARY_SUFFIX}
+    )
   set(gmp_INCLUDE_DIR ${gmp_INSTALL}/include)
 
   ExternalProject_Add(gmp


### PR DESCRIPTION
Fixes #2029

gmpxx is part of gmp and we're building it via cmake. Previously we weren't telling cgal where to find it and on some machines (mine at least) it was finding it at /usr/local/include. This caused /usr/local/include to be added to include paths which caused #2029 to happen (cgal was also found there and confused).

This should tell cgal where to find gmpxx and subsequently _not_ add /usr/local/include. 