### PR TITLE
Fixes a race condition in the dual contouring code.

### DIFF
--- a/include/igl/dual_contouring.cpp
+++ b/include/igl/dual_contouring.cpp
@@ -214,14 +214,18 @@ namespace igl
           t = (isovalue - f0)/delta;
           p = e0+t*(e1-e0);
         }
-        // insert vertex at this point to triangulate quad face
-        const typename decltype(V)::Index ev = triangles ? new_vertex() : -1;
-        if(triangles)
+        typename decltype(V)::Index ev;
+
         {
-          const std::lock_guard<std::mutex> lock(Vmut);
-          vV[ev] = p;
-          vcount[ev] = 1;
-          vI[ev] = Eigen::RowVector3i(-1,-1,-1);
+            const std::lock_guard<std::mutex> lock(Vmut);
+            // insert vertex at this point to triangulate quad face
+            ev = triangles ? new_vertex() : -1;
+            if (triangles)
+            {
+                vV[ev] = p;
+                vcount[ev] = 1;
+                vI[ev] = Eigen::RowVector3i(-1, -1, -1);
+            }
         }
         // edge normal from function handle (could use grid finite
         // differences/interpolation gradients)


### PR DESCRIPTION
The previous version of the code would call new_vertex() outside of the mutex right below it, which would in turn trigger a call to resize a bunch of std::vector<>s. The patch addresses the issue by moving the vertex such that the initialization of ev is contained within the mutex.

Fixes #2044.

<!-- Describe your changes and what you've already done to test it. -->

Tested by meshing a handful of signed distance fields created using Chris Batty's SDF generator.

#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
