### PR TITLE
exact_geodesic: fix bugs, clean up asserts, allow 2D

### DIFF
--- a/tests/include/igl/exact_geodesic.cpp
+++ b/tests/include/igl/exact_geodesic.cpp
@@ -1,0 +1,25 @@
+#include <test_common.h>
+#include <igl/exact_geodesic.h>
+
+TEST_CASE("exact_geodesic: square", "[igl]")
+{
+  using namespace igl;
+  Eigen::MatrixXd V(4,2);
+  V << 0,0,
+       1,0,
+       1,1,
+       0,1;
+  Eigen::MatrixXi F(2,3);
+  F << 0,1,2,
+       0,2,3;
+  Eigen::VectorXi VS(1);
+  VS<<0;
+  Eigen::VectorXi VT(4);
+  VT<<0,1,2,3;
+  Eigen::VectorXi FS,FT;
+  Eigen::VectorXd D;
+  igl::exact_geodesic(V,F,VS,FS,VT,FT,D);
+  Eigen::VectorXd Dgt(4);
+  Dgt<<0,1,1.4142135624,1;
+  test_common::assert_near(D,Dgt,1e-10);
+}


### PR DESCRIPTION
This PR allows 2D input to exact_geodesic (trivially by appending 0s during the copy that's already there). I also noticed a bug in how the targets were setup (overwriting each other), which I fixed along the way. Added a test case and removed a weird template.

> `igl::exact_geodesic` belongs to the set of "this is a libigl wrapper of an external piece of code". I'm not sure how much has been done on the original code for this wrapper and this PR doesn't change that.