### PR TITLE
CoMISo-MRosy solver: compatibility with newer CoMISo:

### DIFF
--- a/include/igl/copyleft/comiso/nrosy.cpp
+++ b/include/igl/copyleft/comiso/nrosy.cpp
@@ -390,7 +390,8 @@ void igl::copyleft::comiso::NRosyField::solveRoundings()
   gmm::row_matrix< gmm::wsvector< double > > gmm_C(0, n);
 
   COMISO::ConstrainedSolver cs;
-  cs.solve(gmm_C, gmm_A, x, gmm_b, ids_to_round, 0.0, false, true);
+  cs.solve(gmm_C, gmm_A, x, gmm_b, ids_to_round, 0.0, false);
+
 
   // Copy the result back
   for(unsigned i=0; i<F.rows(); ++i)


### PR DESCRIPTION
Omit last (show_timings) argument for ConstraintedSolver::solve call.
This was optional before, and has been removed in CoMISo
[174ef38344e09a9547f8a684bf6520cdc8fbe3ba](https://gitlab.vci.rwth-aachen.de:9000/CoMISo/CoMISo/-/commit/174ef38344e09a9547f8a684bf6520cdc8fbe3ba)


<!-- Describe your changes and what you've already done to test it. -->


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
