### PR TITLE
Fixes #2133

### DIFF
--- a/cmake/recipes/external/gmp.cmake
+++ b/cmake/recipes/external/gmp.cmake
@@ -38,7 +38,7 @@ else()
     URL_MD5 0b82665c4a92fd2ade7440c13fcaa42b
     UPDATE_DISCONNECTED true  # need this to avoid constant rebuild
     PATCH_COMMAND 
-      curl "https://gmplib.org/repo/gmp/raw-rev/5f32dbc41afc" "|" git apply -v
+      curl -k "https://gmplib.org/repo/gmp/raw-rev/5f32dbc41afc" "|" git apply -v
     ${gmp_ExternalProject_Add_extra_options}
     CONFIGURE_COMMAND 
       ${prefix}/src/gmp/configure 


### PR DESCRIPTION
Fixes #2133 .

This adds a very tiny hotfix to #2133 that ignores the fact that GMPlib's certificate has expired. It's probably not good practice and it's better to link to a GMP mirror like @jdumas suggested, so feel free to edit this PR with a better fix (I don't know how to swap the current .cmake file to use a github mirror)


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
