### PR TITLE
Fix typo in test that caused test failure in Debug mode

### DIFF
--- a/include/igl/writePLY.cpp
+++ b/include/igl/writePLY.cpp
@@ -141,7 +141,7 @@ bool writePLY(
 
     if(ED.cols()>0)
     {
-        assert(ED.rows()==F.rows());
+        assert(ED.rows()==E.rows());
         assert(ED.cols() == EDheader.size());
 
         _ed.resize(ED.size());


### PR DESCRIPTION
Signed-off-by: BruegelN <BruegelN@crashing.systems>

~~Fixes # .~~

This is likely a typo as comparing the size of the edge data and faces doesn't make much sense.
When compiling libigl in debug mode this test failed with:
```
165/204 Testing: writePLY: bunny.ply
165/204 Test: writePLY: bunny.ply
Command: "~/libigl/Debug/tests/test_igl_core" "writePLY: bunny.ply"
Directory: ~/libigl/Debug
"writePLY: bunny.ply" start time: Jan 03 19:45 CET
Output:
----------------------------------------------------------
test_igl_core:~/libigl/include/igl/writePLY.cpp:144: bool igl::writePLY(std::ostream&, const Eigen::MatrixBase<Derived>&, const Eigen::MatrixBase<U>&, const Eigen::MatrixBase<DerivedE>&, const Eigen::MatrixBase<DerivedN>&, const Eigen::MatrixBase<DerivedUV>&, const Eigen::MatrixBase<DerivedVD>&, const std::vector<std::__cxx11::basic_string<char> >&, const Eigen::MatrixBase<DerivedFD>&, const std::vector<std::__cxx11::basic_string<char> >&, const Eigen::MatrixBase<DerivedED>&, const std::vector<std::__cxx11::basic_string<char> >&, const std::vector<std::__cxx11::basic_string<char> >&, FileEncoding) [with DerivedV = Eigen::Matrix<double, -1, -1>; DerivedF = Eigen::Matrix<int, -1, -1>; DerivedE = Eigen::Matrix<int, -1, -1>; DerivedN = Eigen::Matrix<double, -1, -1>; DerivedUV = Eigen::Matrix<double, -1, -1>; DerivedVD = Eigen::Matrix<double, -1, -1>; DerivedFD = Eigen::Matrix<double, -1, -1>; DerivedED = Eigen::Matrix<double, -1, -1>; std::ostream = std::basic_ostream<char>]: Assertion `ED.rows()==F.rows()' failed.
Filters: writePLY: bunny.ply

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test_igl_core is a Catch v2.13.8 host application.
Run with -? for options

-------------------------------------------------------------------------------
writePLY: bunny.ply
-------------------------------------------------------------------------------
~/libigl/tests/include/igl/writePLY.cpp:9
...............................................................................

~/libigl/tests/include/igl/writePLY.cpp:9: FAILED:
  {Unknown expression after the reported line}
due to a fatal error condition:
  SIGABRT - Abort (abnormal termination) signal

===============================================================================
test cases: 1 | 1 failed
```

Steps to reproduce the error:
```
mkdir build
cd build
cmake -DCMAKE_BUILD_TYPE=Debug ..
make
```

Is there a particular reason CI runs tests (an builds for that matter) only in Release mode and not in in Debug mode?
`assert()`-macros are disabled in Release mode.


<!-- Describe your changes and what you've already done to test it. -->


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
