### PR TITLE
don't crash on brew update

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew update
+          brew update || true
           brew install ccache
 
       - name: Cache Build

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -56,7 +56,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update || true
-          brew install ccache
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
 
       - name: Cache Build
         id: cache-build

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -55,13 +55,7 @@ jobs:
       - name: Dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          rm /usr/local/bin/2to3
-          rm /usr/local/bin/2to3-3.11
-          rm /usr/local/bin/idle3
-          rm /usr/local/bin/pydoc3
-          rm /usr/local/bin/python3
-          rm /usr/local/bin/python3-config
-          brew install ccache
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
 
       - name: Cache Build
         id: cache-build

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -55,9 +55,13 @@ jobs:
       - name: Dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          rm '/usr/local/bin/2to3'
-          brew update || true
-          brew install ccache || true
+          rm /usr/local/bin/2to3
+          rm /usr/local/bin/2to3-3.11
+          rm /usr/local/bin/idle3
+          rm /usr/local/bin/pydoc3
+          rm /usr/local/bin/python3
+          rm /usr/local/bin/python3-config
+          brew install ccache
 
       - name: Cache Build
         id: cache-build

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -55,8 +55,9 @@ jobs:
       - name: Dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
+          rm '/usr/local/bin/2to3'
           brew update || true
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
+          brew install ccache || true
 
       - name: Cache Build
         id: cache-build


### PR DESCRIPTION
CI is failing because I think `brew update` is sending a failing exit code. https://github.com/libigl/libigl/actions/runs/3832188849/jobs/6522212468

It seems everything is continuing to install fine but it doesn't like that it can't create python links (which I don't believe we're using).

This fix ([suggested here](https://github.com/actions/setup-python/issues/577)) just forces the update to return true. It seems that many others just run `brew install ccache` without `brew update`. Not sure if we still need `brew update` or if that was from when we used brew to get gmp and mpfr.

Another option would be to install ccache in some more reproducible way, but I don't have the bandwidth to figure that out at the moment.