### PR TITLE
dont use brew; download binary from github

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -55,8 +55,7 @@ jobs:
       - name: Dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew update
-          brew install ccache
+          curl -o /usr/local/bin/ccache "https://github.com/libigl/ccache-binaries/blob/main/macos_universal/bin/ccache?raw=true"
 
       - name: Cache Build
         id: cache-build

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -56,6 +56,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           curl -o /usr/local/bin/ccache "https://github.com/libigl/ccache-binaries/blob/main/macos_universal/bin/ccache?raw=true"
+          chmod a+x /usr/local/bin/ccache
 
       - name: Cache Build
         id: cache-build


### PR DESCRIPTION
Makes https://github.com/libigl/libigl/pull/2138 obsolete. Download precompiled and hosted ccache binary directly.