### PR TITLE
BUG: readMESH stuck in endless loop

### DIFF
--- a/include/igl/readMESH.cpp
+++ b/include/igl/readMESH.cpp
@@ -48,7 +48,7 @@ IGL_INLINE bool igl::readMESH(
     while(still_comments)
     {
       has_line = fgets(line,LINE_MAX,mesh_file) != NULL;
-      still_comments = (line[0] == '#' || line[0] == '\n' || line[0] == '\r');
+      still_comments = has_line && (line[0] == '#' || line[0] == '\n' || line[0] == '\r');
     }
     return has_line;
   };


### PR DESCRIPTION
Fixes #2141 

<!-- Describe your changes and what you've already done to test it. -->

The readMESH function is caught in an endless loop (while ignoring comments/empty lines). It fails to get a new line, and continues to check the previous line.
The mesh was ceeated with tetgen (libigl wrapper) and saved using writeMESH.


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
