### PR TITLE
chore(cmake): use GIT_SHALLOW for imgui

### DIFF
--- a/cmake/recipes/external/imgui.cmake
+++ b/cmake/recipes/external/imgui.cmake
@@ -9,6 +9,7 @@ FetchContent_Declare(
     imgui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
     GIT_TAG v1.85
+    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(imgui)
 


### PR DESCRIPTION
Fixes # .

<!-- Describe your changes and what you've already done to test it. -->

fix imgui costs much time to clone by adding "GIT_SHALLOW TRUE"

#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [x] Adds new .cpp file.
- [x] Adds corresponding unit test.
- [x] This is a minor change.
