### PR TITLE
try to use j2 on windows CI

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -135,7 +135,7 @@ jobs:
             -DLIBIGL_BUILD_TESTS=${{ matrix.build-params.tests }} ^
             -B build ^
             -S .
-          cmake --build build -j1
+          cmake --build build -j2
 
       - name: Tests
         run: cd build; ctest --verbose -j2


### PR DESCRIPTION
The hope is that now that the build is more split up after https://github.com/libigl/libigl/pull/2165 we can restore https://github.com/libigl/libigl/pull/2161 . I think there's a theory that the "out of heap space" errors are when two threads are using a ton of memory at the same time. If that's the case, the simple split of tests and tutorial won't necessarily change. I think I roughly know which units take tons of memory (in the header only it's usually the CGAL module ones). So I guess a further idea would be to see if we can force CMAKE to be serial for just those.

Maybe an even better option would be to see if we can use https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners