### PR TITLE
Allow use of external Eigen3 build indicated by Eigen3_DIR

### DIFF
--- a/cmake/recipes/external/eigen.cmake
+++ b/cmake/recipes/external/eigen.cmake
@@ -2,6 +2,16 @@ if(TARGET Eigen3::Eigen)
     return()
 endif()
 
+if(Eigen3_DIR)
+    message(STATUS "Looking for Eigen in: ${Eigen3_DIR}")
+    find_package(Eigen3 CONFIG HINTS ${Eigen3_DIR})
+    message(STATUS "Found Eigen in given directory: ${Eigen3_FOUND}")
+
+    if(TARGET Eigen3::Eigen)
+        return()
+    endif()
+endif()
+
 message(STATUS "Third-party: creating target 'Eigen3::Eigen'")
 
 include(FetchContent)


### PR DESCRIPTION
In projects where Eigen3 is built externally (for other dependencies also linked in), it is preferrable to use the same source. Specifying the CMake variable Eigen3_DIR at configuration will trigger a search for Eigen3 in that directory. If successful, Eigen will not be downloaded as a dependency. If unsuccessful, the download will still occur.  If Eigen3_DIR is blank, no search occurs.

Fixes # .

<!-- Describe your changes and what you've already done to test it. -->


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] This is a minor change.
