### PR TITLE
Fix CMake package installation for igl_core

### DIFF
--- a/cmake/igl/libigl-config.cmake.in
+++ b/cmake/igl/libigl-config.cmake.in
@@ -1,3 +1,7 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(Eigen3 REQUIRED)
+find_dependency(Threads REQUIRED)
+include("${CMAKE_CURRENT_LIST_DIR}/LibiglConfigTargets.cmake")
 check_required_components(Libigl)


### PR DESCRIPTION
Fixes #2186 (or a part of it)

Fix the packaging of igl so that the core library is correctly found. Tested on WSL-Ubuntu-20.04 with GCC 9.4.0. 
```cmake
find_package(libigl CONFIG REQUIRED)
target_link_libraries(main PUBLIC igl::igl_core)
```

#### Checklist

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
