### PR TITLE
Support libigl in other projects that export targets via add_subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,6 @@ endif()
 ################################################################################
 # Install CMake config files
 ################################################################################
-
 if(LIBIGL_INSTALL)
     include(GNUInstallDirs)
     set(project_config_in "${PROJECT_SOURCE_DIR}/cmake/igl/libigl-config.cmake.in")
@@ -147,12 +146,33 @@ if(LIBIGL_INSTALL)
     set(version_config_file "${CMAKE_CURRENT_BINARY_DIR}/LibiglConfigVersion.cmake")
     set(export_dest_dir "${CMAKE_INSTALL_LIBDIR}/cmake/igl")
 
-    foreach(suffix IN ITEMS "") #"_restricted" "_copyleft")
+    # If install/export is called for all suffixes, it will cause an error when
+    # there are not restricted and/or copyleft targets. LIBIGL_INSTALLED_* are
+    # set in the igl_install file, allowing only the applicable suffixes to be
+    # considered for install/export.
+    set(suffixes "EMPTY")
+    if(LIBIGL_INSTALLED_COPYLEFT)
+        list(APPEND suffixes "_copyleft")
+    endif()
+    if(LIBIGL_INSTALLED_RESTRICTED)
+        list(APPEND suffixes "_restricted")
+    endif()
+    foreach(suffix IN ITEMS ${suffixes})
+        if(suffix STREQUAL "EMPTY")
+            set(suffix "")
+        endif()
+
         install(EXPORT LibiglTargets${suffix}
             DESTINATION ${export_dest_dir}
             NAMESPACE igl${suffix}::
             FILE ${config_targets_base}${suffix}.cmake
             COMPONENT LibiglDevelopment
+        )
+
+        export(
+            EXPORT LibiglTargets${suffix}
+            FILE ${CMAKE_CURRENT_BINARY_DIR}/LibiglTargets${suffix}-targets.cmake
+            NAMESPACE igl${suffix}::
         )
     endforeach()
 

--- a/cmake/igl/igl_install.cmake
+++ b/cmake/igl/igl_install.cmake
@@ -6,8 +6,10 @@ function(igl_install module_name)
     # Check if category is `copyleft` or `restricted`
     if(${module_name} MATCHES "^igl_copyleft")
         set(suffix "_copyleft")
+        set(LIBIGL_INSTALLED_COPYLEFT TRUE CACHE INTERNAL "")
     elseif(${module_name} MATCHES "^igl_restricted")
         set(suffix "_restricted")
+        set(LIBIGL_INSTALLED_RESTRICTED TRUE CACHE INTERNAL "")
     else()
         set(suffix "")
     endif()
@@ -61,3 +63,10 @@ function(igl_install module_name)
         )
     endforeach()
 endfunction()
+
+# These two variables keep track whether a restricted or copyleft target
+# was installed, so that the corresponding install/export call can be made
+# at the time of project installation.
+# See top level CMakeLists.txt in root folder of the libigl repo.
+set(LIBIGL_INSTALLED_RESTRICTED  FALSE CACHE INTERNAL "Tracks whether a restricted target was installed")
+set(LIBIGL_INSTALLED_COPYLEFT    FALSE CACHE INTERNAL "Tracks whether a copyleft target was installed")

--- a/cmake/igl/modules/copyleft/cgal.cmake
+++ b/cmake/igl/modules/copyleft/cgal.cmake
@@ -13,7 +13,10 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/cgal/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/cgal/*.cpp")
 igl_target_sources(igl_copyleft_cgal ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 4. Install target & headers
+igl_install(igl_copyleft_cgal ${INC_FILES} ${SRC_FILES})
+
+# 5. Dependencies
 include(cgal)
 igl_include(copyleft core)
 target_link_libraries(igl_copyleft_cgal ${IGL_SCOPE}
@@ -23,7 +26,7 @@ target_link_libraries(igl_copyleft_cgal ${IGL_SCOPE}
     CGAL::CGAL_Core
 )
 
-# 5. Unit tests
+# 6. Unit tests
 file(GLOB SRC_FILES
     "${libigl_SOURCE_DIR}/tests/include/igl/copyleft/boolean/*.cpp"
     "${libigl_SOURCE_DIR}/tests/include/igl/copyleft/cgal/*.cpp"

--- a/cmake/igl/modules/copyleft/comiso.cmake
+++ b/cmake/igl/modules/copyleft/comiso.cmake
@@ -13,8 +13,12 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/comiso/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/comiso/*.cpp")
 igl_target_sources(igl_copyleft_comiso ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 5. Install target & headers
+igl_install(igl_copyleft_comiso ${INC_FILES} ${SRC_FILES})
+
+# 6. Dependencies
 include(comiso)
+igl_install(CoMISo)
 igl_include(copyleft core)
 target_link_libraries(igl_copyleft_comiso ${IGL_SCOPE}
     igl::core
@@ -22,6 +26,6 @@ target_link_libraries(igl_copyleft_comiso ${IGL_SCOPE}
     CoMISo::CoMISo
 )
 
-# 5. Unit tests
+# 7. Unit tests
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/tests/include/igl/copyleft/comiso/*.cpp")
 igl_add_test(igl_copyleft_comiso ${SRC_FILES})

--- a/cmake/igl/modules/copyleft/core.cmake
+++ b/cmake/igl/modules/copyleft/core.cmake
@@ -13,7 +13,10 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/*.cpp")
 igl_target_sources(igl_copyleft_core ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 4. Install target & headers
+igl_install(igl_copyleft_core ${INC_FILES} ${SRC_FILES})
+
+# 5. Dependencies
 target_link_libraries(igl_copyleft_core ${IGL_SCOPE}
     igl::core
 )

--- a/cmake/igl/modules/copyleft/tetgen.cmake
+++ b/cmake/igl/modules/copyleft/tetgen.cmake
@@ -13,8 +13,12 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/tetgen/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/tetgen/*.cpp")
 igl_target_sources(igl_copyleft_tetgen ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 4. Install target & headers
+igl_install(igl_copyleft_tetgen ${INC_FILES} ${SRC_FILES})
+
+# 5. Dependencies
 include(tetgen)
+igl_install(tetgen)
 igl_include(copyleft core)
 target_link_libraries(igl_copyleft_tetgen ${IGL_SCOPE}
     igl::core
@@ -22,6 +26,6 @@ target_link_libraries(igl_copyleft_tetgen ${IGL_SCOPE}
     tetgen::tetgen
 )
 
-# 5. Unit tests
+# 6. Unit tests
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/tests/include/igl/copyleft/tetgen/*.cpp")
 igl_add_test(igl_copyleft_tetgen ${SRC_FILES})

--- a/cmake/igl/modules/embree.cmake
+++ b/cmake/igl/modules/embree.cmake
@@ -13,13 +13,16 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/embree/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/embree/*.cpp")
 igl_target_sources(igl_embree ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 4. Install target & headers
+igl_install(igl_embree ${INC_FILES} ${SRC_FILES})
+
+# 5. Dependencies
 include(embree)
 target_link_libraries(igl_embree ${IGL_SCOPE}
     igl::core
     embree::embree
 )
 
-# 5. Unit tests
+# 6. Unit tests
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/tests/include/igl/embree/*.cpp")
 igl_add_test(igl_embree ${SRC_FILES})

--- a/cmake/igl/modules/glfw.cmake
+++ b/cmake/igl/modules/glfw.cmake
@@ -13,8 +13,12 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/glfw/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/glfw/*.cpp")
 igl_target_sources(igl_glfw ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 4. Install target & headers
+igl_install(igl_glfw ${INC_FILES} ${SRC_FILES})
+
+# 5. Dependencies
 include(glfw)
+igl_install(glfw)
 igl_include(opengl)
 target_link_libraries(igl_glfw ${IGL_SCOPE}
     igl::core

--- a/cmake/igl/modules/imgui.cmake
+++ b/cmake/igl/modules/imgui.cmake
@@ -13,10 +13,16 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/glfw/imgui/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/glfw/imgui/*.cpp")
 igl_target_sources(igl_imgui ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 4. Install target & headers
+igl_install(igl_imgui ${INC_FILES} ${SRC_FILES})
+
+# 5. Dependencies
 include(imgui)
+igl_install(imgui)
 include(imguizmo)
+igl_install(imguizmo)
 include(libigl_imgui_fonts)
+igl_install(igl_imgui_fonts)
 igl_include(glfw)
 target_link_libraries(igl_imgui ${IGL_SCOPE}
     igl::core

--- a/cmake/igl/modules/opengl.cmake
+++ b/cmake/igl/modules/opengl.cmake
@@ -13,8 +13,12 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/*.cpp")
 igl_target_sources(igl_opengl ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 4. Install target & headers
+igl_install(igl_opengl ${INC_FILES} ${SRC_FILES})
+
+# 5. Dependencies
 include(glad)
+igl_install(glad)
 find_package(OpenGL REQUIRED OPTIONAL_COMPONENTS OpenGL)
 target_link_libraries(igl_opengl ${IGL_SCOPE}
     igl::core

--- a/cmake/igl/modules/png.cmake
+++ b/cmake/igl/modules/png.cmake
@@ -13,8 +13,12 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/png/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/png/*.cpp")
 igl_target_sources(igl_png ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 4. Install target & headers
+igl_install(igl_png ${INC_FILES} ${SRC_FILES})
+
+# 5. Dependencies
 include(stb)
+igl_install(stb)
 igl_include(opengl)
 target_link_libraries(igl_png ${IGL_SCOPE}
     igl::core

--- a/cmake/igl/modules/predicates.cmake
+++ b/cmake/igl/modules/predicates.cmake
@@ -13,13 +13,17 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/predicates/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/predicates/*.cpp")
 igl_target_sources(igl_predicates ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 4. Install target & headers
+igl_install(igl_predicates ${INC_FILES} ${SRC_FILES})
+
+# 5. Dependencies
 include(predicates)
+igl_install(predicates)
 target_link_libraries(igl_predicates ${IGL_SCOPE}
     igl::core
     predicates::predicates
 )
 
-# 5. Unit tests
+# 6. Unit tests
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/tests/include/igl/predicates/*.cpp")
 igl_add_test(igl_predicates ${SRC_FILES})

--- a/cmake/igl/modules/restricted/triangle.cmake
+++ b/cmake/igl/modules/restricted/triangle.cmake
@@ -13,14 +13,18 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/triangle/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/triangle/*.cpp")
 igl_target_sources(igl_restricted_triangle ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 4. Install target & headers
+igl_install(igl_restricted_triangle ${INC_FILES} ${SRC_FILES})
+
+# 5. Dependencies
 include(triangle)
+igl_install(triangle)
 target_link_libraries(igl_restricted_triangle ${IGL_SCOPE}
     igl::core
     triangle::triangle
 )
 
-# 5. Unit tests
+# 6. Unit tests
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/tests/include/igl/triangle/*.cpp")
 igl_add_test(igl_restricted_triangle ${SRC_FILES})
 if(TARGET test_igl_restricted_triangle)

--- a/cmake/igl/modules/xml.cmake
+++ b/cmake/igl/modules/xml.cmake
@@ -13,8 +13,12 @@ file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/xml/*.h")
 file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/xml/*.cpp")
 igl_target_sources(igl_xml ${INC_FILES} ${SRC_FILES})
 
-# 4. Dependencies
+# 4. Install target & headers
+igl_install(igl_xml ${INC_FILES} ${SRC_FILES})
+
+# 5. Dependencies
 include(tinyxml2)
+igl_install(tinyxml2)
 target_link_libraries(igl_xml ${IGL_SCOPE}
     igl::core
     tinyxml2::tinyxml2

--- a/cmake/recipes/external/comiso.cmake
+++ b/cmake/recipes/external/comiso.cmake
@@ -7,8 +7,8 @@ message(STATUS "Third-party: creating target 'CoMISo::CoMISo'")
 include(FetchContent)
 FetchContent_Declare(
     comiso
-    GIT_REPOSITORY https://github.com/libigl/CoMISo.git
-    GIT_TAG 536440e714f412e7ef6c0b96b90ba37b1531bb39
+    GIT_REPOSITORY https://github.com/KeithBallard/CoMISo.git
+    GIT_TAG ea18352
 )
 
 include(eigen)
@@ -26,6 +26,8 @@ foreach(filepath IN ITEMS ${INC_FILES})
     configure_file(${filepath} "${output_folder}/${filename}" COPYONLY)
 endforeach()
 
-target_include_directories(CoMISo PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/CoMISo/include)
+target_include_directories(CoMISo PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/CoMISo/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/CoMISo/include>)
 
 set_target_properties(CoMISo PROPERTIES FOLDER ThirdParty)

--- a/cmake/recipes/external/embree.cmake
+++ b/cmake/recipes/external/embree.cmake
@@ -51,3 +51,11 @@ set_target_properties(simd PROPERTIES FOLDER "ThirdParty//Embree")
 set_target_properties(sys PROPERTIES FOLDER "ThirdParty//Embree")
 set_target_properties(tasking PROPERTIES FOLDER "ThirdParty//Embree")
 set_target_properties(uninstall PROPERTIES FOLDER "ThirdParty//Embree")
+
+# Export in case some projects include libigl via add_subdirectory
+foreach(lib IN ITEMS "embree" "lexers" "math" "simd" "sys" "tasking")
+    export(
+        EXPORT ${lib}-targets
+        FILE ${CMAKE_CURRENT_BINARY_DIR}/${lib}-targets.cmake
+    )
+endforeach()

--- a/cmake/recipes/external/glad.cmake
+++ b/cmake/recipes/external/glad.cmake
@@ -7,8 +7,8 @@ message(STATUS "Third-party: creating target 'glad::glad'")
 include(FetchContent)
 FetchContent_Declare(
     glad
-    GIT_REPOSITORY https://github.com/libigl/libigl-glad.git
-    GIT_TAG        ceef55fcd08bdd16e985370a99cfb60e69623221
+    GIT_REPOSITORY https://github.com/KeithBallard/libigl-glad.git
+    GIT_TAG        09a93ab
 )
 
 FetchContent_MakeAvailable(glad)

--- a/cmake/recipes/external/imgui.cmake
+++ b/cmake/recipes/external/imgui.cmake
@@ -37,7 +37,9 @@ add_library(imgui ${IMGUI_SRC})
 add_library(imgui::imgui ALIAS imgui)
 
 # Include headers
-target_include_directories(imgui PUBLIC "${imgui_SOURCE_DIR}")
+target_include_directories(imgui PUBLIC
+    $<BUILD_INTERFACE:${imgui_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # Compile definitions
 target_compile_definitions(imgui PUBLIC

--- a/cmake/recipes/external/imguizmo.cmake
+++ b/cmake/recipes/external/imguizmo.cmake
@@ -22,7 +22,9 @@ add_library(imguizmo::imguizmo ALIAS imguizmo)
 
 target_compile_features(imguizmo PUBLIC cxx_std_11)
 
-target_include_directories(imguizmo PUBLIC "${imguizmo_SOURCE_DIR}")
+target_include_directories(imguizmo PUBLIC
+    $<BUILD_INTERFACE:${imguizmo_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 include(imgui)
 target_link_libraries(imguizmo PUBLIC imgui::imgui)

--- a/cmake/recipes/external/predicates.cmake
+++ b/cmake/recipes/external/predicates.cmake
@@ -7,8 +7,8 @@ message(STATUS "Third-party: creating target 'predicates::predicates'")
 include(FetchContent)
 FetchContent_Declare(
     predicates
-    GIT_REPOSITORY https://github.com/libigl/libigl-predicates.git
-    GIT_TAG        488242fa2b1f98a9c5bd1441297fb4a99a6a9ae4
+    GIT_REPOSITORY https://github.com/KeithBallard/libigl-predicates.git
+    GIT_TAG        d6c04da
 )
 
 FetchContent_MakeAvailable(predicates)

--- a/cmake/recipes/external/stb.cmake
+++ b/cmake/recipes/external/stb.cmake
@@ -27,6 +27,8 @@ configure_file(${stb_BINARY_DIR}/stb_image.cpp.in ${stb_BINARY_DIR}/stb_image.cp
 add_library(stb ${stb_BINARY_DIR}/stb_image.cpp)
 add_library(stb::stb ALIAS stb)
 
-target_include_directories(stb PUBLIC "${stb_SOURCE_DIR}")
+target_include_directories(stb PUBLIC
+    $<BUILD_INTERFACE:${stb_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 set_target_properties(stb PROPERTIES FOLDER ThirdParty)

--- a/cmake/recipes/external/tetgen.cmake
+++ b/cmake/recipes/external/tetgen.cmake
@@ -14,6 +14,8 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(tetgen)
 add_library(tetgen::tetgen ALIAS tetgen)
 
-target_include_directories(tetgen INTERFACE "${tetgen_SOURCE_DIR}")
+target_include_directories(tetgen PUBLIC
+    $<BUILD_INTERFACE:${tetgen_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 set_target_properties(tetgen PROPERTIES FOLDER ThirdParty)

--- a/cmake/recipes/external/tinyxml2.cmake
+++ b/cmake/recipes/external/tinyxml2.cmake
@@ -18,7 +18,9 @@ endif()
 
 add_library(tinyxml2 STATIC ${tinyxml2_SOURCE_DIR}/tinyxml2.cpp ${tinyxml2_SOURCE_DIR}/tinyxml2.h)
 add_library(tinyxml2::tinyxml2 ALIAS tinyxml2)
-target_include_directories(tinyxml2 PUBLIC ${tinyxml2_SOURCE_DIR})
+target_include_directories(tinyxml2 PUBLIC
+    $<BUILD_INTERFACE:${tinyxml2_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 set_target_properties(tinyxml2 PROPERTIES DEFINE_SYMBOL "TINYXML2_EXPORT")
 
 set_target_properties(tinyxml2 PROPERTIES FOLDER ThirdParty)

--- a/cmake/recipes/external/triangle.cmake
+++ b/cmake/recipes/external/triangle.cmake
@@ -14,6 +14,8 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(triangle)
 add_library(triangle::triangle ALIAS triangle)
 
-target_include_directories(triangle INTERFACE "${triangle_SOURCE_DIR}")
+target_include_directories(triangle PUBLIC
+    $<BUILD_INTERFACE:${triangle_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 set_target_properties(triangle PROPERTIES FOLDER ThirdParty)


### PR DESCRIPTION
If libigl is included in another project that exports its own targets, an issue arises in that libigl does not export its targets (besides igl_core) nor are several third party libraries exported.  This PR is my attempt to export all components of libigl and relevant 3rd party libraries.  

This is part 1 of 2 for supporting the CMake installation interface.  If the targets are exported correctly, that resolves most of the work.  Part 2 would include ensuring all files are installed correctly.  This capability has been discussed across many issues.  Any input would be welcome.  I have developed the CMake code to the point that my own project needs at this time, but I would be happy to help get it the rest of the way.

To be clear: I am not advocating changing the integration method recommended by igl.  I have come around to the argument by @jdumas made in https://github.com/libigl/libigl/pull/2175.  However, I do think supporting an installation interface is necessary for some uses cases, like my own.  If library A integrates libigl and exports itself for use downstream, then libigl must correctly export its own targets for A to be consumed. 

I have tested it by setting up a project with libigl as a submodule (in external/libigl) with the following CMakeLists.txt:
```cmake
set(LIBIGL_BUILD_TESTS           OFF CACHE BOOL "" FORCE)
set(LIBIGL_BUILD_TUTORIALS       OFF CACHE BOOL "" FORCE)
set(LIBIGL_INSTALL               ON  CACHE BOOL "" FORCE)

set(LIBIGL_PREDICATES            ON  CACHE BOOL "" FORCE)
set(LIBIGL_EMBREE                ON  CACHE BOOL "" FORCE)
set(LIBIGL_GLFW                  ON  CACHE BOOL "" FORCE)
set(LIBIGL_IMGUI                 ON  CACHE BOOL "" FORCE)
set(LIBIGL_OPENGL                ON  CACHE BOOL "" FORCE)
set(LIBIGL_PNG                   ON  CACHE BOOL "" FORCE)
set(LIBIGL_XML                   ON  CACHE BOOL "" FORCE)
set(LIBIGL_COPYLEFT_CGAL         ON  CACHE BOOL "" FORCE)
set(LIBIGL_COPYLEFT_COMISO       ON  CACHE BOOL "" FORCE)
set(LIBIGL_COPYLEFT_TETGEN       ON  CACHE BOOL "" FORCE)
set(LIBIGL_RESTRICTED_MATLAB     ON  CACHE BOOL "" FORCE)
set(LIBIGL_RESTRICTED_MOSEK      ON  CACHE BOOL "" FORCE)
set(LIBIGL_RESTRICTED_TRIANGLE   ON  CACHE BOOL "" FORCE)

add_subdirectory(external/libigl)

add_library(test_igl_linkage main.cpp)

target_link_libraries(test_igl_linkage PRIVATE igl_core igl_predicates igl_png igl_xml)
target_link_libraries(test_igl_linkage PRIVATE igl_embree igl_glfw igl_opengl igl_imgui)
target_link_libraries(test_igl_linkage PRIVATE igl_copyleft_cgal igl_copyleft_comiso )
target_link_libraries(test_igl_linkage PRIVATE igl_copyleft_tetgen)
target_link_libraries(test_igl_linkage PRIVATE igl_restricted_triangle)
```

Important notes:
* I do not have Matlab or Mosek available to test those targets
* The targets are exported correctly for build interface, but I have not tested the install interface. It is quite likely that relevant 3rd party header files are not marked to be copied to the installation include directory.
* This PR currently points to my forks of some of projects mirrored by igl since I had to make changes in those projects as well (just the CMakeLists).  Before this PR is accepted, the 3rd party mirror PRs need to be accepted and the URLs updated for fetchcontent in this project.

#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds corresponding unit test.  (I don't know how to create an automated test for this)
- [x] [predicates mirror PR](https://github.com/libigl/libigl-predicates/pull/2) accepted
- [x] [glad mirror PR](https://github.com/libigl/libigl-glad/pull/1) accepted
- [x] [comiso mirror PR](https://github.com/libigl/CoMISo/pull/13) accepted
- [ ] FetchContent URLs updated
Are there other tasks for this?