### PR TITLE
Add missing <cstdint> header for gcc 13

### DIFF
--- a/include/igl/read_file_binary.h
+++ b/include/igl/read_file_binary.h
@@ -11,6 +11,7 @@
 
 #include "igl_inline.h"
 
+#include <cstdint>
 #include <streambuf>
 #include <istream>
 #include <string>


### PR DESCRIPTION
Fixes # .

Added missing headers <cstdint> in order to fix build with GCC 13.
ref: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
