### PR TITLE
Bug fix in GLVersion field Viewer.cpp

### DIFF
--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -185,7 +185,7 @@ namespace glfw
       return(-1);
     }
     #if defined(DEBUG) || defined(_DEBUG)
-      printf("OpenGL Version %d.%d loaded\n", GLVersion.major, GLVersion.minor);
+      //printf("OpenGL Version %d.%d loaded\n", GLVersion.major, GLVersion.minor);
       int major, minor, rev;
       major = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MAJOR);
       minor = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MINOR);


### PR DESCRIPTION
When I build libigl, I also encountered the problem of  #2098 and reported an error:
![image](https://user-images.githubusercontent.com/48829770/236729986-ba9d1401-8da5-4f39-bea1-52a671fe89cb.png)

In `libigl/include/igl/opengl/glfw/viewer.cpp`, when I delete line 188  `printf("OpenGL Version %d.%d loaded\n", GLVersion.major, GLVersion.minor);` , I can compile normally

<!-- Describe your changes and what you've already done to test it. -->


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
