### PR TITLE
Cmake option to delete tutorials as built

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -132,6 +132,7 @@ jobs:
             -DLIBIGL_USE_STATIC_LIBRARY=${{ matrix.build-params.static }} ^
             -DLIBIGL_COPYLEFT_CGAL=ON ^
             -DLIBIGL_BUILD_TUTORIALS=${{ matrix.build-params.tutorials }} ^
+            -DLIBIGL_DELETE_TUTORIALS_IMMEDIATELY=ON ^
             -DLIBIGL_BUILD_TESTS=${{ matrix.build-params.tests }} ^
             -B build ^
             -S .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,10 @@ option(LIBIGL_RESTRICTED_MOSEK    "Build target igl_restricted::mosek"    ${LIBI
 option(LIBIGL_RESTRICTED_TRIANGLE "Build target igl_restricted::triangle" ${LIBIGL_TOPLEVEL_PROJECT})
 
 
+# Option to immediately delete tutorials as their built (an attempt to make the
+# Windows build on github actions run out of memory less often/quickly).
+option(LIBIGL_DELETE_TUTORIALS_IMMEDIATELY "Delete tutorials as they are built" OFF)
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")

--- a/cmake/igl/igl_add_tutorial.cmake
+++ b/cmake/igl/igl_add_tutorial.cmake
@@ -16,6 +16,7 @@ function(igl_add_tutorial name)
 
     set_target_properties(${name} PROPERTIES FOLDER Libigl_Tutorials)
     if(LIBIGL_DELETE_TUTORIALS_IMMEDIATELY)
+      message(STATUS "Adding command to remove ${name} immediately after build")
       add_custom_command(
        TARGET ${name}
        POST_BUILD

--- a/cmake/igl/igl_add_tutorial.cmake
+++ b/cmake/igl/igl_add_tutorial.cmake
@@ -15,4 +15,11 @@ function(igl_add_tutorial name)
     )
 
     set_target_properties(${name} PROPERTIES FOLDER Libigl_Tutorials)
+    if(LIBIGL_DELETE_TUTORIALS_IMMEDIATELY)
+      add_custom_command(
+       TARGET ${name}
+       POST_BUILD
+       COMMAND ${CMAKE_COMMAND} -E remove $<TARGET_FILE:${name}>
+       COMMENT "Removing ${name}.")
+    endif()
 endfunction()


### PR DESCRIPTION
Attempt to get that windows header only tutorial build to fail less often on github actions.
