### PR TITLE
Expose cutoff parameter for CGAL intersections; better default

### DIFF
--- a/include/igl/copyleft/cgal/RemeshSelfIntersectionsParam.h
+++ b/include/igl/copyleft/cgal/RemeshSelfIntersectionsParam.h
@@ -29,16 +29,22 @@ namespace igl
         bool stitch_all;
         /// whether to use slow and more precise rounding (see assign_scalar)
         bool slow_and_more_precise_rounding;
+        /// cutoff parameter for box_self_intersection_d (based on some casual
+        /// testing 1000 works better than 1,10,100,10000 etc. and better than
+        /// the recommended √n)
+        int cutoff;
         inline RemeshSelfIntersectionsParam(
           bool _detect_only=false, 
           bool _first_only=false,
           bool _stitch_all=false,
-          bool _slow_and_more_precise_rounding=false
+          bool _slow_and_more_precise_rounding=false,
+          int _cutoff=1000
           ):
           detect_only(_detect_only),
           first_only(_first_only),
           stitch_all(_stitch_all),
-          slow_and_more_precise_rounding(_slow_and_more_precise_rounding)
+          slow_and_more_precise_rounding(_slow_and_more_precise_rounding),
+          cutoff(_cutoff)
         {};
       };
     }

--- a/include/igl/copyleft/cgal/SelfIntersectMesh.h
+++ b/include/igl/copyleft/cgal/SelfIntersectMesh.h
@@ -379,8 +379,8 @@ inline igl::copyleft::cgal::SelfIntersectMesh<
 #ifdef IGL_SELFINTERSECTMESH_TIMING
   log_time("box_and_bind");
 #endif
-  // Run the self intersection algorithm with all defaults
-  CGAL::box_self_intersection_d(boxes.begin(), boxes.end(),cb);
+  // Run the self intersection algorithm with given cutoff size
+  CGAL::box_self_intersection_d(boxes.begin(), boxes.end(),cb,std::ptrdiff_t(params.cutoff));
 #ifdef IGL_SELFINTERSECTMESH_TIMING
   log_time("box_intersection_d");
 #endif

--- a/include/igl/copyleft/cgal/intersect_other.cpp
+++ b/include/igl/copyleft/cgal/intersect_other.cpp
@@ -137,7 +137,7 @@ namespace igl
             A_boxes.begin(), A_boxes.end(),
             B_boxes.begin(), B_boxes.end(),
             cb,
-            params.cutoff);
+            std::ptrdiff_t(params.cutoff));
         }catch(int e)
         {
           // Rethrow if not FIRST_HIT_EXCEPTION

--- a/include/igl/copyleft/cgal/intersect_other.cpp
+++ b/include/igl/copyleft/cgal/intersect_other.cpp
@@ -136,7 +136,8 @@ namespace igl
           CGAL::box_intersection_d(
             A_boxes.begin(), A_boxes.end(),
             B_boxes.begin(), B_boxes.end(),
-            cb);
+            cb,
+            params.cutoff);
         }catch(int e)
         {
           // Rethrow if not FIRST_HIT_EXCEPTION


### PR DESCRIPTION
Fixes #270

CGAL weirdly uses a pretty bad default for the somewhat mysterious `cutoff` parameter in box_intersections_d and box_self_intersections_d

I tired 1,10,100,1000,10000,100000 and √n for all the tutorial data models (not a particularly good test set) and 1000 was the clear winner.

So, this now uses that as the default and exposes the parameter for users to tweak if needed.

The speedups are modest (like 1.1-1.2x).