### PR TITLE
Update MeshGL.h for successful build in Mingw Windows

### DIFF
--- a/include/igl/opengl/MeshGL.h
+++ b/include/igl/opengl/MeshGL.h
@@ -11,6 +11,7 @@
 
 #include "../igl_inline.h"
 #include <Eigen/Core>
+#include <cstdint>
 
 namespace igl
 {


### PR DESCRIPTION
Added #include <cstdint> for fixing build failure for [mingw-w64 "w64devkit"](https://www.mingw-w64.org/downloads/#w64devkit)

The reason to use w64devkit on Windows is the toolchain includes pthreads, C++11 threads, and OpenMP.

Fixes the following types of errors in libigl example project:
`libigl-example-project/build/_deps/libigl-src/include/igl/opengl/MeshGL.h:91:5: error: 'uint32_t' does not name a type
   91 |     uint32_t dirty_flag;` and
`libigl-example-project/build/_deps/libigl-src/include/igl/opengl/MeshGL.cpp:56:3: error: 'dirty' was not declared in this scope
   56 |   dirty = MeshGL::DIRTY_ALL;`

<!-- Describe your changes and what you've already done to test it. -->
After the fix, the project builds successfully. However, the following line must be added to [libigl-example-project](https://github.com/libigl/libigl-example-project) `CMakeLists.txt` to prevent the error `Fatal error: CMakeFiles/example.dir/main.cpp.obj: file too big` from happening.
`set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Og")`

#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] This is a minor change.
