### PR TITLE
Fixed the freezing problem when clicking on UI components in the new version of ImGui

### DIFF
--- a/cmake/recipes/external/imgui.cmake
+++ b/cmake/recipes/external/imgui.cmake
@@ -8,7 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
     imgui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
-    GIT_TAG v1.85
+    GIT_TAG v1.90
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(imgui)

--- a/cmake/recipes/external/imguizmo.cmake
+++ b/cmake/recipes/external/imguizmo.cmake
@@ -8,7 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
     imguizmo
     GIT_REPOSITORY https://github.com/CedricGuillemet/ImGuizmo.git
-    GIT_TAG a23567269f6617342bcc112394bdad937b54b2d7
+    GIT_TAG ba662b119d64f9ab700bb2cd7b2781f9044f5565
 )
 FetchContent_MakeAvailable(imguizmo)
 

--- a/include/igl/opengl/glfw/imgui/ImGuiHelpers.h
+++ b/include/igl/opengl/glfw/imgui/ImGuiHelpers.h
@@ -25,12 +25,11 @@
 namespace ImGui
 {
 
-static auto vector_getter = [](void* vec, int idx, const char** out_text)
+static auto vector_getter = [](void* vec, int idx)
 {
   auto& vector = *static_cast<std::vector<std::string>*>(vec);
-  if (idx < 0 || idx >= static_cast<int>(vector.size())) { return false; }
-  *out_text = vector.at(idx).c_str();
-  return true;
+  if (idx < 0 || idx >= static_cast<int>(vector.size())) { return (const char*)nullptr; }
+  return (const char *)vector.at(idx).c_str();
 };
 
 inline bool Combo(const char* label, int* idx, std::vector<std::string>& values)
@@ -42,11 +41,11 @@ inline bool Combo(const char* label, int* idx, std::vector<std::string>& values)
 
 inline bool Combo(const char* label, int* idx, std::function<const char *(int)> getter, int items_count)
 {
-  auto func = [](void* data, int i, const char** out_text) {
+  auto func = [](void* data, int i) {
     auto &getter = *reinterpret_cast<std::function<const char *(int)> *>(data);
     const char *s = getter(i);
-    if (s) { *out_text = s; return true; }
-    else { return false; }
+    if (s) { return s; }
+    else { return (const char*)nullptr; }
   };
   return Combo(label, idx, func, reinterpret_cast<void *>(&getter), items_count);
 }

--- a/include/igl/opengl/glfw/imgui/ImGuiPlugin.cpp
+++ b/include/igl/opengl/glfw/imgui/ImGuiPlugin.cpp
@@ -125,11 +125,11 @@ IGL_INLINE bool ImGuiPlugin::mouse_down(int button, int modifier)
 
 IGL_INLINE bool ImGuiPlugin::mouse_up(int button, int modifier)
 {
-  //return ImGui::GetIO().WantCaptureMouse;
-  // !! Should not steal mouse up
+  ImGui_ImplGlfw_MouseButtonCallback(viewer->window, button, GLFW_RELEASE, modifier);
+  if (ImGui::GetIO().WantCaptureMouse){ return true; }
   for( auto & widget : widgets)
   { 
-    widget->mouse_up(button, modifier);
+    if(widget->mouse_up(button, modifier)) { return true; }
   }
   return false;
 }


### PR DESCRIPTION
Update ImGui to v1.90
Update ImGuizmo to the latest version.

Tested the following examples
	tutorial\106_ViewerMenu
	tutorial\109_ImGuizmo

#### Checklist
- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
