### PR TITLE
use our boost-cmake which uses slow, non-jfrog url

### DIFF
--- a/cmake/recipes/external/boost.cmake
+++ b/cmake/recipes/external/boost.cmake
@@ -7,8 +7,8 @@ message(STATUS "Third-party: creating targets 'Boost::boost'...")
 include(FetchContent)
 FetchContent_Declare(
     boost-cmake
-    GIT_REPOSITORY https://github.com/Orphis/boost-cmake.git
-    GIT_TAG 7f97a08b64bd5d2e53e932ddf80c40544cf45edf
+    GIT_REPOSITORY https://github.com/libigl/boost-cmake.git
+    GIT_TAG 6bcae68ffbaaefad4583a2642ce9ea53e5e01707
 )
 
 set(PREVIOUS_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})


### PR DESCRIPTION
Boost's jfrog artifactory servers went bad somehow over the new year. It seems that if we ever bump boost to a modern version we should just use their github releases. I also don't really understand what role this extra `boost-cmake` repo is playing for us now. Is it needed? In any case, for now I forked it and changed the 1.71.0 url to something that doesn't crash.