### PR TITLE
Fix compile error on gcc-12.3

### DIFF
--- a/include/igl/WindingNumberTree.h
+++ b/include/igl/WindingNumberTree.h
@@ -214,7 +214,7 @@ inline igl::WindingNumberTree<Point,DerivedV,DerivedF>::WindingNumberTree(
 }
 
 template <typename Point, typename DerivedV, typename DerivedF>
-inline igl::WindingNumberTree<Point,DerivedV,DerivedF>::~WindingNumberTree<Point,DerivedV,DerivedF>()
+inline igl::WindingNumberTree<Point,DerivedV,DerivedF>::~WindingNumberTree()
 {
   delete_children();
 }


### PR DESCRIPTION
This is a follow up fix of #2254. After #2254 gcc-12.3 reports the error "template-id not allowed for destructor".

<!-- Describe your changes and what you've already done to test it. -->


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [X] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [X] This is a minor change.
