### PR TITLE
enable mixed polygons using convention that negative indices are ignored

### DIFF
--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
@@ -65,10 +65,10 @@ IGL_INLINE void igl::copyleft::tetgen::mesh_to_tetgenio(
     f->numberofholes = 0;
     f->holelist = NULL;
     tetgenio::polygon * p = &f->polygonlist[0];
-    p->numberofvertices = F.cols();
+    p->numberofvertices = (F.row(i).array() >= 0).count();
     p->vertexlist = new int[p->numberofvertices];
     // loop around face
-    for(int j = 0;j < F.cols(); j++)
+    for(int j = 0;j < p->numberofvertices; j++)
     {
       p->vertexlist[j] = F(i,j);
     }

--- a/include/igl/copyleft/tetgen/tetrahedralize.h
+++ b/include/igl/copyleft/tetgen/tetrahedralize.h
@@ -51,6 +51,11 @@ namespace igl
       ///     holes, duplicate faces etc.)
       ///   -1 other error
       ///
+      /// \note The polygons F can contain polygons with different number of vertices.
+      /// Trailing unused columns are filled with -1. For example, triangles and
+      /// segments can be specified using a #F x 3 matrix: for segments the third 
+      /// column contains -1.
+      ///
       /// \note Tetgen mixes integer region ids in with other region data `attr
       /// = (int) in->regionlist[i + 3];`. So it's declared safe to use integer
       /// types for `TR` since this also assumes that there's a single tet

--- a/tests/include/igl/copyleft/tetgen/tetrahedralize.cpp
+++ b/tests/include/igl/copyleft/tetgen/tetrahedralize.cpp
@@ -101,3 +101,44 @@ TEST_CASE("tetrahedralize: schoenhardt", "[igl/copyleft/tetgen]")
   igl::copyleft::tetgen::tetrahedralize(V,F,"pQ",TV,TT,TF);
   REQUIRE (V.rows() <= TV.rows());
 }
+
+TEST_CASE("tetrahedralize: quad_face", "[igl/copyleft/tetgen]")
+{
+  const Eigen::MatrixXd V = (Eigen::MatrixXd(5,3)<<
+    -1.0,0.0,0.0,
+    0.0,-1.0,0.0,
+    1.0,0.0,0.0,
+    0.0,1.0,0.0,
+    0.0,0.0,1.0).finished();
+  const Eigen::MatrixXi F = (Eigen::MatrixXi(5,4)<<
+    0,1,2,3,
+    0,1,4,-1,
+    1,2,4,-1,
+    2,3,4,-1,
+    3,0,4,-1).finished();
+  Eigen::MatrixXd TV;
+  Eigen::MatrixXi TT,TF;
+  igl::copyleft::tetgen::tetrahedralize(V,F,"pQ",TV,TT,TF);
+  REQUIRE (TT.rows() == 2);
+}
+
+TEST_CASE("tetrahedralize: embedded_segment", "[igl/copyleft/tetgen]")
+{
+  const Eigen::MatrixXd V = (Eigen::MatrixXd(6,3)<<
+    -0.5,0.5,0.0,
+    0.0,-1.0,0.0,
+    0.5,0.5,0.0,
+    0.0,0.0,1.0,
+    0.0,0.0,0.2,
+    0.0,0.0,0.9).finished();
+  const Eigen::MatrixXi F = (Eigen::MatrixXi(5,3)<<
+    0,1,2,
+    1,3,2,
+    0,2,3,
+    1,0,3,
+    4,5,-1).finished();
+  Eigen::MatrixXd TV;
+  Eigen::MatrixXi TT,TF;
+  igl::copyleft::tetgen::tetrahedralize(V,F,"pQ",TV,TT,TF);
+  REQUIRE (TT.rows() == 7);
+}


### PR DESCRIPTION
Fixes #2337.

<!-- Describe your changes and what you've already done to test it. -->

This change adds support for mixed polygons, e.g. triangles and segments.


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [x] Adds corresponding unit test.
- [x] This is a minor change.
