### PR TITLE
Fix split_nonmanifold

### DIFF
--- a/include/igl/split_nonmanifold.cpp
+++ b/include/igl/split_nonmanifold.cpp
@@ -8,6 +8,7 @@
 #include "split_nonmanifold.h"
 #include "unique_edge_map.h"
 #include "connected_components.h"
+#include "triangle_triangle_adjacency.h"
 #include <cassert>
 #include <type_traits>
 
@@ -40,6 +41,21 @@ IGL_INLINE void igl::split_nonmanifold(
   // Mesh as if all edges got cut. 
   MatrixX3I CF = VectorXI::LinSpaced(F.size(),0,F.size()-1).reshaped(F.rows(),F.cols());
 
+  // Every edge starts as a boundary edge
+  const int m = F.rows();
+  // augh, this is following gptoolbox ordering not triangle_triangle_adjacency
+  // ordering.
+  MatrixX3I CTF = MatrixX3I::Constant(m,3,-1);
+  MatrixX3I CTI = MatrixX3I::Constant(m,3,-1);
+
+  // Is maintaining triangle adjacency enough? Or do we need edge-flaps?
+  // After we zip an edge-pair we need to know if there are other unzipped edges
+  // adjacent to the zipped edge.
+  // Triangle adjacency seems like enough to circulate around the zipped edge
+  // vertices and find incident boundary edges, which are candidates for
+  // zipping. From a candidate boundary edge we can get to EMAP, which should be
+  // enough to find candidate zip-pairs using uE*.
+
   //// Empty edge-flap data
   //MatrixX2I CEF= MatrixX2I::Constant(E.rows(),2,-1);
   //MatrixX2I CEI= MatrixX2I::Constant(E.rows(),2,-1);
@@ -55,8 +71,8 @@ IGL_INLINE void igl::split_nonmanifold(
 
   std::vector<std::pair<int,int> > R;
 
-  const int m = F.rows();
-  const auto zip = [&E,&m,&seen,&F,&CF,&R](const int e1, const int e2)
+  const auto zip = 
+    [&E,&m,&seen,&F,&CF,&R,&CTF,&CTI](const int e1, const int e2, const bool verbose = true)
   {
     assert(!seen[e1]);
     assert(!seen[e2]);
@@ -76,9 +92,12 @@ IGL_INLINE void igl::split_nonmanifold(
     const int cs2 = CF(f2,(i2+2)%3);
     const int cd1 = CF(f1,(i1+2)%3);
     const int cd2 = CF(f2,(i2+1)%3);
+    if(verbose)
+    {
     //printf("%d,%d → %d,%d\n",vs1+1,vd1+1,vs2+1,vd2+1);
     //printf("  %d,%d → %d,%d\n",cs1+1,cd1+1,cs2+1,cd2+1);
-    //printf("  %d → %d\n",f1+1,f2+1);
+    printf("  %d → %d\n",f1+1,f2+1);
+    }
 
     const int cs = std::min(cs1,cs2);
     const int cd = std::min(cd1,cd2);
@@ -90,6 +109,13 @@ IGL_INLINE void igl::split_nonmanifold(
     R.emplace_back(cs2,cs);
     R.emplace_back(cd2,cd);
 
+    CTF(f1,i1) = f2;
+    CTI(f1,i1) = i2;
+    CTF(f2,i2) = f1;
+    CTI(f2,i2) = i1;
+
+    seen[e1] = true;
+    seen[e2] = true;
 
     //std::cout<<igl::matlab_format_index(CF,"CF")<<std::endl;
     //printf("\n");
@@ -117,14 +143,45 @@ IGL_INLINE void igl::split_nonmanifold(
       if(enforce_orientability && E(e1,0) == E(e2,1))
       {
         assert(E(e1,1) == E(e2,0));
-        zip(e1,e2);
-        seen[e1] = true;
-        seen[e2] = true;
+        zip(e1,e2,false);
 #warning "is `seen` every used?"
         continue;
       }
     }// else. non-manifold. Skip for now
   }
+
+  // Cutting and Stitching: Converting Sets of Polygons to Manifold Surfaces
+
+  // Outer loop over all unique edges.
+  for(int u = 0;u<uE.rows();u++)
+  {
+    const int num_incident = uEC(u+1)-uEC(u);
+    assert(num_incident > 0);
+    // boundary or internal edge handled already.
+    if(num_incident <= 2) { continue; }
+    for(int j = uEC(u);j<uEC(u+1);j++)
+    {
+      const int e1 = uEE(j); // i = j-uEC(u);
+      if(seen[e1]) { continue; }
+      // We haven't seen this half-edge yet.
+      // Try to zip it with an opposite half-edge (and start off a cascade of
+      // zipping).
+      for(int k = j+1;k<uEC(u+1);k++)
+      {
+        const int e2 = uEE(k);
+        // Can't zip if alread seen
+        if(seen[e2]) { continue; }
+        if(enforce_orientability && E(e1,0) == E(e2,1))
+        {
+          assert(E(e1,1) == E(e2,0));
+          zip(e1,e2);
+          // Don't try any more zips with e1
+          break;
+        }
+      }
+    }
+  }
+  
 
   // Now if we resolve all the equivalence records we'd have a mesh CF which is
   // "cut" along all original non-manifold edges (and non-manifold vertices
@@ -173,7 +230,26 @@ IGL_INLINE void igl::split_nonmanifold(
       CF(i) = C(CF(i));
     }
   }
-  
+
+  //{
+  //  // Did we correctly maintain CTF and CTI?
+  //  MatrixX3I CTF2,CTI2;
+  //  std::cout<<igl::matlab_format_index(CF,"CF")<<std::endl;
+  //  igl::triangle_triangle_adjacency(CF,CTF2,CTI2);
+
+  //  {
+  //    Eigen::PermutationMatrix<3,3> perm(3);
+  //    perm.indices() = Eigen::Vector3i(1,2,0);
+  //    CTF2 = (CTF2*perm).eval();
+  //    CTI2 = (CTI2*perm).eval();
+  //    for(int i=0;i<CTI2.rows();i++)
+  //      for(int j=0;j<CTI2.cols();j++)
+  //        CTI2(i,j)=CTI2(i,j)==-1?-1:(CTI2(i,j)+3-1)%3;
+  //  }
+
+  //  assert((CTF.array() == CTF2.array()).all());
+  //  assert((CTI.array() == CTI2.array()).all());
+  //}
   //std::cout<<igl::matlab_format_index(CF,"CF")<<std::endl;
 
 

--- a/include/igl/split_nonmanifold.cpp
+++ b/include/igl/split_nonmanifold.cpp
@@ -7,8 +7,9 @@
 // obtain one at http://mozilla.org/MPL/2.0/.
 #include "split_nonmanifold.h"
 #include "unique_edge_map.h"
-#include <cassert>
 #include "connected_components.h"
+#include <cassert>
+#include <type_traits>
 
 #include "is_vertex_manifold.h"
 #include "matlab_format.h"
@@ -24,9 +25,11 @@ IGL_INLINE void igl::split_nonmanifold(
   Eigen::PlainObjectBase <DerivedSF> & SF,
   Eigen::PlainObjectBase <DerivedSVI> & SVI)
 {
-  const bool enforce_manifold = true;
+  const bool enforce_orientability = true;
 #warning "Another parameter whether to try to weld together orientable cut-boundarieS"
   using Scalar = typename DerivedSF::Scalar;
+  // Scalar must allow negative values
+  static_assert(std::is_signed<Scalar>::value,"Scalar must be signed");
   using MatrixX2I = Eigen::Matrix<Scalar,Eigen::Dynamic,2>;
   using MatrixX3I = Eigen::Matrix<Scalar,Eigen::Dynamic,3>;
   using VectorXI = Eigen::Matrix< Scalar,Eigen::Dynamic,1>;
@@ -36,6 +39,11 @@ IGL_INLINE void igl::split_nonmanifold(
 
   // Mesh as if all edges got cut. 
   MatrixX3I CF = VectorXI::LinSpaced(F.size(),0,F.size()-1).reshaped(F.rows(),F.cols());
+
+  //// Empty edge-flap data
+  //MatrixX2I CEF= MatrixX2I::Constant(E.rows(),2,-1);
+  //MatrixX2I CEI= MatrixX2I::Constant(E.rows(),2,-1);
+
   //std::cout<<igl::matlab_format_index(CF,"CF")<<std::endl;
 
   // By cutting _all_ edges we also handle non-manifold vertices. We could avoid

--- a/include/igl/unique_edge_map.h
+++ b/include/igl/unique_edge_map.h
@@ -75,7 +75,7 @@ namespace igl
   /// 
   /// \code{cpp}
   /// // Using uEC,uEE
-  /// for(int u = 0;u<uE.size();u++)
+  /// for(int u = 0;u<uE.rows();u++)
   /// {
   ///   for(int j = uEC(u);j<uEC(u+1);j++)
   ///   {

--- a/tests/include/igl/split_nonmanifold.cpp
+++ b/tests/include/igl/split_nonmanifold.cpp
@@ -1,5 +1,6 @@
 #include <test_common.h>
 #include <igl/split_nonmanifold.h>
+#include <igl/facet_components.h>
 #include <igl/matlab_format.h>
 #include <iostream>
 
@@ -274,4 +275,48 @@ TEST_CASE("split_nonmanifold: non-orientable", "[igl]")
   test_common::assert_eq(SV,SVgt);
   test_common::assert_eq(SF,SFgt);
   test_common::assert_eq(SVI,SVIgt);
+}
+
+TEST_CASE("split_nonmanifold: flap", "[igl]")
+{
+  Eigen::MatrixXi F(12,3);
+  const auto check = [&F]()
+  {
+    Eigen::MatrixXi SF;
+    Eigen::VectorXi SVI;
+    igl::split_nonmanifold(F,SF,SVI);
+    {
+      Eigen::VectorXi C;
+      const int nc = igl::facet_components(SF,C);
+      REQUIRE(nc == 2);
+    }
+  };
+  F<< 
+    0,3,1,
+    3,4,1,
+    2,5,0,
+    5,3,0,
+    3,6,4,
+    5,7,3,
+    7,6,3,
+    8,0,9,
+    0,1,9,
+    2,0,8,
+    0,3,11,
+    0,11,10;
+  check();
+  F<< 
+    0,3,11,
+    0,1,9,
+    2,5,0,
+    7,6,3,
+    0,3,1,
+    3,6,4,
+    5,3,0,
+    5,7,3,
+    8,0,9,
+    3,4,1,
+    2,0,8,
+    0,11,10;
+  check();
 }

--- a/tests/include/igl/split_nonmanifold.cpp
+++ b/tests/include/igl/split_nonmanifold.cpp
@@ -1,12 +1,43 @@
 #include <test_common.h>
 #include <igl/split_nonmanifold.h>
 #include <igl/facet_components.h>
+#include <igl/is_edge_manifold.h>
+#include <igl/is_vertex_manifold.h>
+
 #include <igl/matlab_format.h>
+#include <igl/writePLY.h>
 #include <iostream>
+
+void check_same_but_manifold(
+    const Eigen::MatrixXi & F,
+    const Eigen::MatrixXi & SF,
+    const Eigen::VectorXi & I)
+{
+  // Check that new mesh has no non-manifold edges
+  REQUIRE(igl::is_edge_manifold(SF));
+  // Check that new mesh has no non-manifold vertices
+  REQUIRE(igl::is_vertex_manifold(SF));
+  // Check the new mesh references original vertex information
+  Eigen::MatrixXi ISF(SF.rows(),SF.cols());
+  for(int i = 0;i<ISF.rows();i++)
+  {
+    for(int j = 0;j<ISF.cols();j++)
+    {
+      ISF(i,j) = I(SF(i,j));
+    }
+  }
+  test_common::assert_eq(F,ISF);
+}
 
 TEST_CASE("split_nonmanifold: edge-fan", "[igl]")
 {
   using namespace igl;
+  Eigen::MatrixXi F(5,3);
+  F<<0,1,3,
+     0,3,2,
+     0,4,3,
+     0,3,5,
+     0,3,6;
   Eigen::MatrixXd V(7,3);
   V << 0,0,0,
        1,0,0,
@@ -15,43 +46,12 @@ TEST_CASE("split_nonmanifold: edge-fan", "[igl]")
        0,0,1,
        0,0,-1,
        1,0,1;
-  Eigen::MatrixXi F(5,3);
-  F<<0,1,3,
-     0,3,2,
-     0,4,3,
-     0,3,5,
-     0,3,6;
+  igl::writePLY("edge-fan.ply",V,F);
   Eigen::MatrixXd SV;
   Eigen::MatrixXi SF;
   Eigen::VectorXi SVI;
-  igl::split_nonmanifold(V,F,SV,SF,SVI);
-  Eigen::MatrixXd SVgt(13,3);
-  SVgt<<
-    0,0,0,
-    0,0,0,
-    0,0,0,
-    0,0,0,
-    1,0,0,
-    0,1,0,
-    0,0,1,
-    0,1,0,
-    0,1,0,
-    -1,0,0,
-    0,1,0,
-    0,0,-1,
-    1,0,1;
-  Eigen::MatrixXi SFgt(5,3);
-  SFgt<<
-    0,4,5,
-    0,5,9,
-    1,6,10,
-    2,7,11,
-    3,8,12;
-  Eigen::VectorXi SVIgt(13);
-  SVIgt<<0,0,0,0,1,3,4,3,3,2,3,5,6;
-  test_common::assert_eq(SV,SVgt);
-  test_common::assert_eq(SF,SFgt);
-  test_common::assert_eq(SVI,SVIgt);
+  igl::split_nonmanifold(F,SF,SVI);
+  check_same_but_manifold(F,SF,SVI);
 }
 
 TEST_CASE("split_nonmanifold: vertex-boundary", "[igl]")
@@ -66,32 +66,28 @@ TEST_CASE("split_nonmanifold: vertex-boundary", "[igl]")
   Eigen::MatrixXi F(2,3);
   F<<0,1,2,
      1,3,4;
-  Eigen::MatrixXd SV;
+  {
+    Eigen::MatrixXd V3(V.rows(),3);
+    V3<<V,Eigen::MatrixXd::Zero(V.rows(),1);
+    igl::writePLY("vertex-boundary.ply",V3,F);
+  }
   Eigen::MatrixXi SF;
   Eigen::VectorXi SVI;
-  igl::split_nonmanifold(V,F,SV,SF,SVI);
-  Eigen::MatrixXd SVgt(6,2);
-  SVgt<<
-    0,0,
-    1,0,
-    1,0,
-    2,0,
-    0,1,
-    1,1;
-  Eigen::MatrixXi SFgt(2,3);
-  SFgt<<
-    0,2,4,
-    1,3,5;
-  Eigen::VectorXi SVIgt(6);
-  SVIgt << 0, 1, 1, 3, 2, 4;
-  test_common::assert_eq(SV,SVgt);
-  test_common::assert_eq(SF,SFgt);
-  test_common::assert_eq(SVI,SVIgt);
+  igl::split_nonmanifold(F,SF,SVI);
+  REQUIRE(SVI.rows() == 6);
+  check_same_but_manifold(F,SF,SVI);
 }
 
 TEST_CASE("split_nonmanifold: edge-disk-flap", "[igl]")
 {
   using namespace igl;
+  Eigen::MatrixXi F(5,3);
+  F<<
+    0,1,2,
+    0,2,3,
+    0,3,4,
+    0,4,1,
+    0,5,1;
   Eigen::MatrixXd V(6,3);
   V<<
     0,0,0,
@@ -100,51 +96,16 @@ TEST_CASE("split_nonmanifold: edge-disk-flap", "[igl]")
     -1,0,0,
     0,-1,0,
     0,0,1;
-  Eigen::MatrixXi F(5,3);
-  F<<
-    0,1,2,
-    0,2,3,
-    0,3,4,
-    0,4,1,
-    0,5,1;
-  Eigen::MatrixXd SV;
+  igl::writePLY("edge-disk-flap.ply",V,F);
   Eigen::MatrixXi SF;
   Eigen::VectorXi SVI;
-  igl::split_nonmanifold(V,F,SV,SF,SVI);
-  Eigen::MatrixXd SVgt(8,3);
-  SVgt<<
-    0,0,0,
-    0,0,0,
-    1,0,0,
-    0,1,0,
-    -1,0,0,
-    0,-1,0,
-    0,0,1,
-    1,0,0;
-  Eigen::MatrixXi SFgt(5,3);
-  SFgt<<
-    0,2,3,
-    0,3,4,
-    0,4,5,
-    0,5,2,
-    1,6,7;
-  Eigen::VectorXi SVIgt(8);
-  SVIgt<<  0,  0,  1,  2,  3,  4,  5,  1;
-  test_common::assert_eq(SV,SVgt);
-  test_common::assert_eq(SF,SFgt);
-  test_common::assert_eq(SVI,SVIgt);
+  igl::split_nonmanifold(F,SF,SVI);
+  check_same_but_manifold(F,SF,SVI);
 }
 
 TEST_CASE("split_nonmanifold: edge-disk-tent", "[igl]")
 {
   using namespace igl;
-  Eigen::MatrixXd V(5,3);
-  V<<
-    0,0,0,
-    1,0,0,
-    -1,1,0,
-    0,-1,0,
-    0,0,1;
   Eigen::MatrixXi F(5,3);
   F<<
     0,1,2,
@@ -152,37 +113,31 @@ TEST_CASE("split_nonmanifold: edge-disk-tent", "[igl]")
     0,3,1,
     0,4,1,
     1,4,3;
-  Eigen::MatrixXd SV;
-  Eigen::MatrixXi SF;
-  Eigen::VectorXi SVI;
-  igl::split_nonmanifold(V,F,SV,SF,SVI);
-  Eigen::MatrixXd SVgt(8,3);
-  SVgt<<
+  Eigen::MatrixXd V(5,3);
+  V<<
     0,0,0,
-    0,0,0,
-    1,0,0,
     1,0,0,
     -1,1,0,
     0,-1,0,
-    0,0,1,
-    0,-1,0;
-  Eigen::MatrixXi SFgt(5,3);
-  SFgt<<
-  0,3,4,
-  0,4,5,
-  0,5,3,
-  1,6,2,
-  2,6,7;
-  Eigen::VectorXi SVIgt(8);
-  SVIgt<<  0,  0,  1,  1,  2,  3,  4,  3;
-  test_common::assert_eq(SV,SVgt);
-  test_common::assert_eq(SF,SFgt);
-  test_common::assert_eq(SVI,SVIgt);
+    0,0,1;
+  igl::writePLY("edge-disk-tent.ply",V,F);
+  Eigen::MatrixXi SF;
+  Eigen::VectorXi SVI;
+  igl::split_nonmanifold(F,SF,SVI);
+  check_same_but_manifold(F,SF,SVI);
 }
 
 TEST_CASE("split_nonmanifold: vertex-kiss", "[igl]")
 {
   using namespace igl;
+  Eigen::MatrixXi F(6,3);
+  F<<
+    0,1,3,
+    1,2,3,
+    2,0,3,
+    4,5,3,
+    5,6,3,
+    6,4,3;
   Eigen::MatrixXd V(7,3);
   V<<
     0,0,0,
@@ -192,54 +147,16 @@ TEST_CASE("split_nonmanifold: vertex-kiss", "[igl]")
     0,0,2,
     1,0,2,
     0,1,2;
-  Eigen::MatrixXi F(6,3);
-  F<<
-    0,1,3,
-    1,2,3,
-    2,0,3,
-    4,5,3,
-    5,6,3,
-    6,4,3;
-  Eigen::MatrixXd SV;
+  igl::writePLY("vertex-kiss.ply",V,F);
   Eigen::MatrixXi SF;
   Eigen::VectorXi SVI;
-  igl::split_nonmanifold(V,F,SV,SF,SVI);
-  Eigen::MatrixXd SVgt(8,3);
-  SVgt<<
-    0,0,0,
-    1,0,0,
-    0,1,0,
-    0,0,2,
-    1,0,2,
-    0,1,2,
-    0,0,1,
-    0,0,1;
-  Eigen::MatrixXi SFgt(6,3);
-  SFgt<<
-    0,1,6,
-    1,2,6,
-    2,0,6,
-    3,4,7,
-    4,5,7,
-    5,3,7;
-  Eigen::VectorXi SVIgt(8);
-  SVIgt<<  0,  1,  2,  4,  5,  6,  3,  3;
-  test_common::assert_eq(SV,SVgt);
-  test_common::assert_eq(SF,SFgt);
-  test_common::assert_eq(SVI,SVIgt);
+  igl::split_nonmanifold(F,SF,SVI);
+  check_same_but_manifold(F,SF,SVI);
 }
 
 TEST_CASE("split_nonmanifold: non-orientable", "[igl]")
 {
   using namespace igl;
-  Eigen::MatrixXd V(6,3);
-  V<<
-     6, 0, 0,
-     4, 0, 0,
-    -3, 5, 0,
-    -2, 4, 0,
-    -2,-4, 1,
-    -3,-5,-1;
   Eigen::MatrixXi F(6,3);
   F<<
     0,2,1,
@@ -248,43 +165,45 @@ TEST_CASE("split_nonmanifold: non-orientable", "[igl]")
     4,5,3,
     4,1,5,
     1,0,5;
-  Eigen::MatrixXd SV;
+  Eigen::MatrixXd V(6,3);
+  V<<
+     6, 0, 0,
+     4, 0, 0,
+    -3, 5, 0,
+    -2, 4, 0,
+    -2,-4, 1,
+    -3,-5,-1;
+  igl::writePLY("non-orientable.ply",V,F);
   Eigen::MatrixXi SF;
   Eigen::VectorXi SVI;
-  igl::split_nonmanifold(V,F,SV,SF,SVI);
-  Eigen::MatrixXd SVgt(8,3);
-  SVgt<<
-    6,0,0,
-    -3,5,0,
-    -2,-4,1,
-    4,0,0,
-    -2,4,0,
-    -3,-5,-1,
-    6,0,0,
-    4,0,0;
-  Eigen::MatrixXi SFgt(6,3);
-  SFgt<<
-    0,1,7,
-    1,4,7,
-    1,2,4,
-    2,5,4,
-    2,3,5,
-    3,6,5;
-  Eigen::VectorXi SVIgt(8);
-  SVIgt<<  0,  2,  4,  1,  3,  5,  0,  1;
-  test_common::assert_eq(SV,SVgt);
-  test_common::assert_eq(SF,SFgt);
-  test_common::assert_eq(SVI,SVIgt);
+  igl::split_nonmanifold(F,SF,SVI);
+  check_same_but_manifold(F,SF,SVI);
 }
 
 TEST_CASE("split_nonmanifold: flap", "[igl]")
 {
+  Eigen::MatrixXd V(12,3);
+V<< 
+  1.5,0,0,
+  0.75,0,0.433,
+  0.75,0,-0.433,
+  0,1.5,0,
+  0,0.75,0.433,
+  0,0.75,-0.433,
+  -1.5,0,0,
+  -0.75,0,-0.433,
+  -0,-1.5,0,
+  -0,-0.75,0.433,
+  1.5,0,1,
+  0,1.5,1;
   Eigen::MatrixXi F(12,3);
-  const auto check = [&F]()
+  const auto check = [&F,&V]()
   {
     Eigen::MatrixXi SF;
     Eigen::VectorXi SVI;
     igl::split_nonmanifold(F,SF,SVI);
+    igl::writePLY("flap.ply",V,F);
+    check_same_but_manifold(F,SF,SVI);
     {
       Eigen::VectorXi C;
       const int nc = igl::facet_components(SF,C);
@@ -305,18 +224,18 @@ TEST_CASE("split_nonmanifold: flap", "[igl]")
     0,3,11,
     0,11,10;
   check();
-  F<< 
-    0,3,11,
-    0,1,9,
-    2,5,0,
-    7,6,3,
-    0,3,1,
-    3,6,4,
-    5,3,0,
-    5,7,3,
-    8,0,9,
-    3,4,1,
-    2,0,8,
-    0,11,10;
-  check();
+  //F<< 
+  //  0,3,11,
+  //  0,1,9,
+  //  2,5,0,
+  //  7,6,3,
+  //  0,3,1,
+  //  3,6,4,
+  //  5,3,0,
+  //  5,7,3,
+  //  8,0,9,
+  //  3,4,1,
+  //  2,0,8,
+  //  0,11,10;
+  //check();
 }


### PR DESCRIPTION
The previous method (and the old one in gptoolbox) was cool cause it wouldn't just create boundaries at the non-manifold edge chains. It would identify big manifold components across non-manifold edges. Unfortunately, it was just getting lucky. It would find those if they were _in order_ in the list of faces, and fail to correctly split the mesh oetherwise. (Some of the new tests will fail the old code).

At one point I set out to implement "Cutting and Stitching: Converting Sets of Polygons to Manifold Surfaces" [Guéziec et al. 2001] but its details are a bit confusing and it's not quite written with proofs so I got nervous I'd make an elaborate implementation and still have failure cases.

Instead, I implemented the "obvious" thing. Split all the edges, then try to stitch them back. Only allow a stitch if the resulting mesh continues to be manifold. The order still matters to get nice components, so this implementation does a depth-first traversal on stitched edges as it goes.

This is purely combinatorial. It'd be cool to use geometry to prefer outputting a "solid" mesh. 

Finally, "manifold" doesn't necessarily mean orientable, but this code is assuming the output should also be orientable (I claim the common case). It shouldn't be too hard to add a flag that allows non-orientable output.
