### PR TITLE
Prevent accuracy degradation of signed distance computation

### DIFF
--- a/include/igl/signed_distance.cpp
+++ b/include/igl/signed_distance.cpp
@@ -111,12 +111,12 @@ namespace
             break;
           case SIGNED_DISTANCE_TYPE_DEFAULT:
           case SIGNED_DISTANCE_TYPE_WINDING_NUMBER:
-            s = 1.-2.*hier3.winding_number(q.transpose());
+            s = hier3.winding_number(q.transpose()) > 0.5 ? -1. : 1.;
             break;
           case SIGNED_DISTANCE_TYPE_FAST_WINDING_NUMBER:
           {
             Scalar w = fast_winding_number(fwn_bvh, 2, q.template cast<float>().eval());         
-            s = 1.-2.*std::abs(w);  
+            s = std::abs(w) > 0.5 ? -1. : 1.;
             break;
           }
           case SIGNED_DISTANCE_TYPE_PSEUDONORMAL:
@@ -232,7 +232,7 @@ namespace
           case SIGNED_DISTANCE_TYPE_WINDING_NUMBER:
             assert(!V.derived().IsRowMajor);
             assert(!F.derived().IsRowMajor);
-            s = 1.-2.*winding_number(V,F,q);
+            s = winding_number(V,F,q) > 0.5 ? -1. : 1.;
             break;
           case SIGNED_DISTANCE_TYPE_PSEUDONORMAL:
           {
@@ -629,7 +629,7 @@ IGL_INLINE void igl::signed_distance_winding_number(
   typedef Eigen::Matrix<typename DerivedV::Scalar,1,3> RowVector3S;
   sqrd = tree.squared_distance(V,F,RowVector3S(q),i,(RowVector3S&)c);
   const Scalar w = hier.winding_number(q.transpose());
-  s = 1.-2.*w;
+  s = w > 0.5 ? -1. : 1.;
 }
 
 template <
@@ -659,7 +659,7 @@ IGL_INLINE void igl::signed_distance_winding_number(
   // colmajor order
   assert(!V.derived().IsRowMajor);
   assert(!F.derived().IsRowMajor);
-  s = 1.-2.*winding_number(V,F,q);
+  s = winding_number(V,F,q) > 0.5 ? -1. : 1.;
 }
 
 //Multi point by parrallel for on single point
@@ -714,7 +714,7 @@ IGL_INLINE typename DerivedV::Scalar igl::signed_distance_fast_winding_number(
     sqrd = tree.squared_distance(V,F,q,i,c);
     Scalar w = fast_winding_number(fwn_bvh,2,q.template cast<float>());
     //0.5 is on surface
-    return sqrt(sqrd)*(1.-2.*std::abs(w));
+    return sqrt(sqrd)*(std::abs(w) > 0.5 ? -1. : 1.);
   }
 
 #ifdef IGL_STATIC_LIBRARY


### PR DESCRIPTION
Signed distance computation using fast winding number (i.e. `(1.0 - 2.0 * winding_num) * udist`) degrades accuracy, since fast winding number contains approximation errors. This PR replaces `(1.0 - 2.0 * winding_num)` with `winding_num > 0.5 ? -1.0 : 1.0`.

This PR also applies the above change to (non-fast) winding number for consistency with "pseudo-normal test" and patched "fast winding number".
[!NOTE] Numerical errors in (non-fast) winding number computation are very small in general, but in my random testing with double precision the largest winding number I got was 1.0000005.

Unit tests ran fine and I locally tested that "pseudo-normal test", "winding number" and "fast winding number" all give the same signed distance (if they give the same sign).

#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
