### PR TITLE
remove or hide cerr<< behind ifdef

### DIFF
--- a/include/igl/active_set.cpp
+++ b/include/igl/active_set.cpp
@@ -290,11 +290,15 @@ IGL_INLINE igl::SolverStatus igl::active_set(
 #endif
       if(!min_quad_with_fixed_precompute(A,known_i,Aeq_i,params.Auu_pd,data))
       {
+#ifdef ACTIVE_SET_CPP_DEBUG
         cerr<<"Error: min_quad_with_fixed precomputation failed."<<endl;
+#endif
         if(iter > 0 && Aeq_i.rows() > Aeq.rows())
         {
+#ifdef ACTIVE_SET_CPP_DEBUG
           cerr<<"  *Are you sure rows of [Aeq;Aieq] are linearly independent?*"<<
             endl;
+#endif
         }
         ret = SOLVER_STATUS_ERROR;
         break;
@@ -304,7 +308,9 @@ IGL_INLINE igl::SolverStatus igl::active_set(
 #endif
       if(!min_quad_with_fixed_solve(data,B,Y_i,Beq_i,Z,sol))
       {
+#ifdef ACTIVE_SET_CPP_DEBUG
         cerr<<"Error: min_quad_with_fixed solve failed."<<endl;
+#endif
         ret = SOLVER_STATUS_ERROR;
         break;
       }

--- a/include/igl/bbw.cpp
+++ b/include/igl/bbw.cpp
@@ -109,11 +109,15 @@ IGL_INLINE bool igl::bbw(
       case SOLVER_STATUS_CONVERGED:
         break;
       case SOLVER_STATUS_MAX_ITER:
+#ifdef IGL_BBW_DEBUG
         cerr<<"active_set: max iter without convergence."<<endl;
+#endif
         break;
       case SOLVER_STATUS_ERROR:
       default:
+#ifdef IGL_BBW_DEBUG
         cerr<<"active_set error."<<endl;
+#endif
         error = true;
     }
     W.col(i) = Wi;

--- a/include/igl/copyleft/cgal/SelfIntersectMesh.h
+++ b/include/igl/copyleft/cgal/SelfIntersectMesh.h
@@ -252,7 +252,6 @@ namespace igl
 #include <algorithm>
 #include <exception>
 #include <cassert>
-#include <iostream>
 
 // References:
 // http://minregret.googlecode.com/svn/trunk/skyline/src/extern/CGAL-3.3.1/examples/Polyhedron/polyhedron_self_intersection.cpp
@@ -344,7 +343,7 @@ inline igl::copyleft::cgal::SelfIntersectMesh<
     return diff;
   };
   const auto log_time = [&](const std::string& label) -> void{
-    printf("%50s: %0.5lf\n",
+    std::printf("%50s: %0.5lf\n",
       C_STR("SelfIntersectMesh." << label),tictoc());
   };
   tictoc();
@@ -630,8 +629,8 @@ inline bool igl::copyleft::cgal::SelfIntersectMesh<
       return true;
     }else
     {
-      cerr<<"Segment ∩ triangle neither point nor segment?"<<endl;
-      assert(false);
+      // Should never happen.
+      assert(false && "Segment ∩ triangle neither point nor segment?");
     }
   }
 

--- a/include/igl/copyleft/cgal/closest_facet.cpp
+++ b/include/igl/copyleft/cgal/closest_facet.cpp
@@ -154,8 +154,9 @@ IGL_INLINE void igl::copyleft::cgal::closest_facet(
       corner_idx = 0;
     } else 
     {
-      std::cerr << "s: " << s << "\t d:" << d << std::endl;
-      std::cerr << F.row(preferred_facet) << std::endl;
+      // Should never happen.
+      //std::cerr << "s: " << s << "\t d:" << d << std::endl;
+      //std::cerr << F.row(preferred_facet) << std::endl;
       throw std::runtime_error(
           "Invalid connectivity, edge does not belong to facet");
     }

--- a/include/igl/copyleft/cgal/order_facets_around_edge.cpp
+++ b/include/igl/copyleft/cgal/order_facets_around_edge.cpp
@@ -85,9 +85,8 @@ void igl::copyleft::cgal::order_facets_around_edge(
               order(1, 0) = 1;
               break;
             case CGAL::COLLINEAR:
-              std::cerr << "Degenerated triangle detected." <<
-                std::endl;
-              assert(false);
+              // Should never happen (assumes input is non-degenerate).
+              assert(false && "Degenerated triangle detected.");
               break;
             default:
               assert(false);

--- a/include/igl/copyleft/cgal/order_facets_around_edges.cpp
+++ b/include/igl/copyleft/cgal/order_facets_around_edges.cpp
@@ -95,21 +95,21 @@ igl::copyleft::cgal::order_facets_around_edges(
                     edge *= -1;
                 }
 
-                if (edge.norm() < EPS) {
-                    std::cerr << "=====================================" << std::endl;
-                    std::cerr << "  ui: " << ui << std::endl;
-                    std::cerr << "edge: " << ref_edge << std::endl;
-                    std::cerr << "face: " << ref_face << std::endl;
-                    std::cerr << "  vs: " << V.row(s) << std::endl;
-                    std::cerr << "  vd: " << V.row(d) << std::endl;
-                    std::cerr << "adj face normals: " << std::endl;
-                    std::cerr << normals << std::endl;
-                    std::cerr << "Very degenerated case detected:" << std::endl;
-                    std::cerr << "Near zero edge surrounded by "
-                        << edge_valance << " neearly colinear faces" <<
-                        std::endl;
-                    std::cerr << "=====================================" << std::endl;
-                }
+                //if (edge.norm() < EPS) {
+                //    std::cerr << "=====================================" << std::endl;
+                //    std::cerr << "  ui: " << ui << std::endl;
+                //    std::cerr << "edge: " << ref_edge << std::endl;
+                //    std::cerr << "face: " << ref_face << std::endl;
+                //    std::cerr << "  vs: " << V.row(s) << std::endl;
+                //    std::cerr << "  vd: " << V.row(d) << std::endl;
+                //    std::cerr << "adj face normals: " << std::endl;
+                //    std::cerr << normals << std::endl;
+                //    std::cerr << "Very degenerated case detected:" << std::endl;
+                //    std::cerr << "Near zero edge surrounded by "
+                //        << edge_valance << " neearly colinear faces" <<
+                //        std::endl;
+                //    std::cerr << "=====================================" << std::endl;
+                //}
             }
         } else {
             edge.normalize();

--- a/include/igl/copyleft/cgal/projected_delaunay.cpp
+++ b/include/igl/copyleft/cgal/projected_delaunay.cpp
@@ -81,7 +81,6 @@ IGL_INLINE void igl::copyleft::cgal::projected_delaunay(
     } else if(const std::vector<Point_3 > *polyp = 
         CGAL::object_cast< std::vector<Point_3 > >(&obj))
     {
-      //cerr<<REDRUM("Poly...")<<endl;
       const std::vector<Point_3 > & poly = *polyp;
       const Index m = poly.size();
       assert(m>=2);
@@ -92,8 +91,7 @@ IGL_INLINE void igl::copyleft::cgal::projected_delaunay(
       }
     }else
     {
-      cerr<<"What is this object?!"<<endl;
-      assert(false);
+      assert(false && "What is this object?!");
     }
   }
 }

--- a/include/igl/copyleft/cgal/propagate_winding_numbers.cpp
+++ b/include/igl/copyleft/cgal/propagate_winding_numbers.cpp
@@ -120,7 +120,6 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
   if (!igl::piecewise_constant_winding_number(F, uE, uEC, uEE)) 
   {
     assert(false && "Input mesh is not PWN");
-    std::cerr << "Input mesh is not PWN!" << std::endl;
     valid = false;
   }
 

--- a/include/igl/copyleft/tetgen/mesh_with_skeleton.cpp
+++ b/include/igl/copyleft/tetgen/mesh_with_skeleton.cpp
@@ -47,9 +47,7 @@ IGL_INLINE bool igl::copyleft::tetgen::mesh_with_skeleton(
   //   * has consistent orientation
   //   * has no self-intersections
   //   * has no 0-volume pieces
-  cerr<<"tetgen begin()"<<endl;
   int status = tetrahedralize( VS,F,eff_tetgen_flags,VV,TT,FF);
-  cerr<<"tetgen end()"<<endl;
   if(FF.rows() != F.rows())
   {
     // Issue a warning if the surface has changed

--- a/include/igl/eigs.cpp
+++ b/include/igl/eigs.cpp
@@ -109,10 +109,14 @@ IGL_INLINE bool igl::eigs(
             case Eigen::Success:
               break;
             case Eigen::NumericalIssue:
+#ifdef IGL_EIGS_DEBUG
               cerr<<"Error: Numerical issue."<<endl;
+#endif
               return false;
             default:
+#ifdef IGL_EIGS_DEBUG
               cerr<<"Error: Other."<<endl;
+#endif
               return false;
           }
           const VectorXS rhs = B*x;

--- a/include/igl/embree/EmbreeDevice.h
+++ b/include/igl/embree/EmbreeDevice.h
@@ -59,11 +59,16 @@ namespace igl
             {
                 embree_device = rtcNewDevice (config);
                 if(rtcGetDeviceError (embree_device) != RTC_ERROR_NONE)
-                    std::cerr << "Embree: An error occurred while initializing embree core!" << std::endl;
-            #ifdef IGL_VERBOSE
+                {
+                  assert(false && "Embree: An error occurred while initializing embree core!");
+#ifdef IGL_VERBOSE
+                  std::cerr << "Embree: An error occurred while initializing embree core!" << std::endl;
+                }
                 else
-                    std::cerr << "Embree: core initialized." << std::endl;
-            #endif
+                {
+                  std::cerr << "Embree: core initialized." << std::endl;
+#endif
+                }
             }
             ++embree_device_cntr;
             return embree_device;
@@ -74,9 +79,9 @@ namespace igl
             if(!--embree_device_cntr) {
                 rtcReleaseDevice (embree_device);
                 embree_device = nullptr;                
-            #ifdef IGL_VERBOSE
-                    std::cerr << "Embree: core released." << std::endl;
-            #endif
+#ifdef IGL_VERBOSE
+                std::cerr << "Embree: core released." << std::endl;
+#endif
             }
         }
      };

--- a/include/igl/embree/bone_heat.cpp
+++ b/include/igl/embree/bone_heat.cpp
@@ -72,10 +72,7 @@ bool igl::embree::bone_heat(
     vis_mask.col(np+j) = vj;
   }
 
-  if(CE.rows() > 0)
-  {
-    cerr<<"Error: Cage edges are not supported. Ignored."<<endl;
-  }
+  assert(CE.rows() == 0 && "Cage edges not supported.");
 
   MatrixXd PP = MatrixXd::Zero(n,m);
   VectorXd min_D;
@@ -103,10 +100,14 @@ bool igl::embree::bone_heat(
     case Eigen::Success:
       break;
     case Eigen::NumericalIssue:
+#ifdef IGL_BONE_HEAT_DEBUG
       cerr<<"Error: Numerical issue."<<endl;
+#endif
       return false;
     default:
+#ifdef IGL_BONE_HEAT_DEBUG
       cerr<<"Error: Other."<<endl;
+#endif
       return false;
   }
 

--- a/include/igl/min_quad_with_fixed.impl.h
+++ b/include/igl/min_quad_with_fixed.impl.h
@@ -154,13 +154,19 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
       case Eigen::Success:
         break;
       case Eigen::NumericalIssue:
+#ifdef IGL_MIN_QUAD_WITH_FIXED_CPP_DEBUG
         cerr<<"Error: Numerical issue."<<endl;
+#endif
         return false;
       case Eigen::InvalidInput:
+#ifdef IGL_MIN_QUAD_WITH_FIXED_CPP_DEBUG
         cerr<<"Error: Invalid input."<<endl;
+#endif
         return false;
       default:
+#ifdef IGL_MIN_QUAD_WITH_FIXED_CPP_DEBUG
         cerr<<"Error: Other."<<endl;
+#endif
         return false;
     }
     nc = data.AeqTQR.rank();
@@ -225,10 +231,14 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
         case Eigen::Success:
           break;
         case Eigen::NumericalIssue:
+#ifdef IGL_MIN_QUAD_WITH_FIXED_CPP_DEBUG
           cerr<<"Error: Numerical issue."<<endl;
+#endif
           return false;
         default:
+#ifdef IGL_MIN_QUAD_WITH_FIXED_CPP_DEBUG
           cerr<<"Error: Other."<<endl;
+#endif
           return false;
       }
       data.solver_type = min_quad_with_fixed_data<T>::LLT;
@@ -252,10 +262,14 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
           case Eigen::Success:
             break;
           case Eigen::NumericalIssue:
+#ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
             cerr<<"Error: Numerical issue."<<endl;
+#endif
             return false;
           default:
+#ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
             cerr<<"Error: Other."<<endl;
+#endif
             return false;
         }
         data.solver_type = min_quad_with_fixed_data<T>::LDLT;
@@ -273,13 +287,19 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
           case Eigen::Success:
             break;
           case Eigen::NumericalIssue:
+#ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
             cerr<<"Error: Numerical issue."<<endl;
             return false;
+#endif
           case Eigen::InvalidInput:
+#ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
             cerr<<"Error: Invalid Input."<<endl;
+#endif
             return false;
           default:
+#ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
             cerr<<"Error: Other."<<endl;
+#endif
             return false;
         }
         data.solver_type = min_quad_with_fixed_data<T>::LU;
@@ -356,10 +376,14 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
         case Eigen::Success:
           break;
         case Eigen::NumericalIssue:
+#ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
           cerr<<"Error: Numerical issue."<<endl;
+#endif
           return false;
         default:
+#ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
           cerr<<"Error: Other."<<endl;
+#endif
           return false;
       }
       data.solver_type = min_quad_with_fixed_data<T>::QR_LLT;
@@ -465,7 +489,9 @@ IGL_INLINE bool igl::min_quad_with_fixed_solve(
         sol = data.lu.solve(NB);
         break;
       default:
+#ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
         cerr<<"Error: invalid solver type"<<endl;
+#endif
         return false;
     }
     //std::cout<<"sol=["<<std::endl<<sol<<std::endl<<"];"<<std::endl;

--- a/include/igl/mvc.cpp
+++ b/include/igl/mvc.cpp
@@ -90,8 +90,12 @@ IGL_INLINE void igl::mvc(const Eigen::MatrixXd &V, const Eigen::MatrixXd &C, Eig
     for (int i = 0; i<V1.rows(); ++i)
     {
       double dist_to_plane_V = std::abs((V1.row(i)-p.transpose()).dot(n));
+#ifndef NDEBUG
       if(dist_to_plane_V>1e-10)
+      {
         std::cerr<<"Distance from V to plane of C is large..."<<std::endl;
+      }
+#endif
     }
     
     // change of basis

--- a/include/igl/planarize_quad_mesh.cpp
+++ b/include/igl/planarize_quad_mesh.cpp
@@ -116,8 +116,7 @@ inline void igl::PlanarizerShapeUp<DerivedV, DerivedF>::assembleQ()
   solver.compute(Q.transpose()*Q);
   if(solver.info()!=Eigen::Success)
   {
-    std::cerr << "Cholesky failed - PlanarizerShapeUp.cpp" << std::endl;
-    assert(0);
+    assert(false && "Cholesky failed");
   }
 }
 
@@ -205,15 +204,13 @@ inline void igl::PlanarizerShapeUp<DerivedV, DerivedF>::planarize(Eigen::PlainOb
   {
     igl::quad_planarity(Vout, Fin, planarity);
     typename DerivedV::Scalar nonPlanarity = planarity.cwiseAbs().maxCoeff();
-    //std::cerr<<"iter #"<<iter<<": max non-planarity: "<<nonPlanarity<<std::endl;
     if (nonPlanarity<threshold)
       break;
     assembleP();
     Vv = solver.solve(Q.transpose()*P);
     if(solver.info()!=Eigen::Success)
     {
-      std::cerr << "Linear solve failed - PlanarizerShapeUp.cpp" << std::endl;
-      assert(0);
+      assert(false && "Linear solve failed");
     }
     for (int i =0;i<numV;++i)
       Vout.row(i) << Vv.segment(3*i,3).transpose();

--- a/include/igl/principal_curvature.cpp
+++ b/include/igl/principal_curvature.cpp
@@ -109,11 +109,6 @@ public:
     IGL_INLINE static Quadric fit(const std::vector<Eigen::Vector3d> &VV)
     {
       assert(VV.size() >= 5);
-      if (VV.size() < 5)
-      {
-        std::cerr << "IGL_ASSERT FAILED! fit function requires at least 5 points: Only " << VV.size() << " were given." << std::endl;
-        exit(0);
-      }
 
       Eigen::MatrixXd A(VV.size(),5);
       Eigen::MatrixXd b(VV.size(),1);
@@ -351,7 +346,7 @@ IGL_INLINE void CurvatureCalculator::fitQuadric(const Eigen::Vector3d& v, const 
   }
   if (points.size() < 5)
   {
-    std::cerr << "IGL_ASSERT FAILED! fit function requires at least 5 points: Only " << points.size() << " were given." << std::endl;
+    assert(false && "fit function requires at least 5 points");
     *q = Quadric(0,0,0,0,0);
   }
   else
@@ -922,7 +917,7 @@ IGL_INLINE void igl::principal_curvature(
 
     if (PD1.row(i) * PD2.row(i).transpose() > 10e-6)
     {
-      std::cerr << "PRINCIPAL_CURVATURE: Something is wrong with vertex: " << i << std::endl;
+      assert(false && "PRINCIPAL_CURVATURE: Something is wrong with vertex");
       PD1.row(i) *= 0;
       PD2.row(i) *= 0;
     }

--- a/include/igl/rotation_matrix_from_directions.cpp
+++ b/include/igl/rotation_matrix_from_directions.cpp
@@ -28,7 +28,9 @@ IGL_INLINE Eigen::Matrix<Scalar, 3, 3> igl::rotation_matrix_from_directions(
   {
     rotM = -Eigen::Matrix<Scalar, 3, 3>::Identity();
     rotM(0,0) = 1.;
+#ifdef IGL_ROTATION_MATRIX_FROM_DIRECTIONS_DEBUG
     std::cerr<<"igl::rotation_matrix_from_directions: rotating around x axis by 180o"<<std::endl;
+#endif
     return rotM;
   }
   ///find the axis of rotation

--- a/include/igl/slim.cpp
+++ b/include/igl/slim.cpp
@@ -144,9 +144,6 @@ namespace igl
       for (int i = 0; i < s.dim; i++)
         uv.col(i) = Uc.block(i * s.v_n, 0, s.v_n, 1);
 
-      // t.stop();
-      // std::cerr << "solve: " << t.getElapsedTime() << std::endl;
-
     }
 
 

--- a/include/igl/squared_edge_lengths.cpp
+++ b/include/igl/squared_edge_lengths.cpp
@@ -63,9 +63,7 @@ IGL_INLINE void igl::squared_edge_lengths(
     }
     default:
     {
-      cerr<< "squared_edge_lengths.h: Error: Simplex size ("<<F.cols()<<
-        ") not supported"<<endl;
-      assert(false);
+      assert(false && "Simplex size not supported");
     }
   }
 }


### PR DESCRIPTION
We're not very consistent about when we fire assertions, print to stderr or throw runtime errors.

This cleans up a bunch of `cerr<<` error messages that were either already caught by `assert` in debug mode, printing messages before `return false`. Or for functions that are commonly needing debugging hides them behind appropriate `ifdef`s. There's still a bunch of error message printing in functions dealing with file IO or in modules I'm not touching (e.g., comiso).