### PR TITLE
Fix bug for highdpi calculation in Viewer.cpp

### DIFF
--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -212,8 +212,8 @@ namespace glfw
     glfwGetFramebufferSize(window, &width, &height);
     int width_window, height_window;
     glfwGetWindowSize(window, &width_window, &height_window);
-    highdpiw = windowWidth/width_window;
-    highdpih = windowHeight/height_window;
+    highdpiw = (windowWidth <= 0 || width_window <= 0) ? 1 : ((double)windowWidth/width_window);
+    highdpih = (windowHeight <= 0 || height_window <= 0) ? 1 : ((double)windowHeight/height_window);
     glfw_window_size(window,width_window,height_window);
     // Initialize IGL viewer
     init();


### PR DESCRIPTION
In `Viewer.cpp` the way the `highdpi` value was calculated could lead to it being set to 0 or `inf` for certain types of window managers. (Tiling window managers). This was caused by the WM trying to resize the window to a width and height of 0 by 0, or by having the logical width/height of the window be smaller than the pyhsical one. This would later cause a glfw call to be made with `inf` as an argument, which causes an assertion to be raised in debug mode.

Fixes (no issue exists).

<!-- Describe your changes and what you've already done to test it. -->

1. I added a check in `Viewer::launch_init(...)` method to check that we don't divide by 0.
2. I fixed a problem where two `int`s would be used for a division, which would cause the value to be 0 instead of $\in [0,1]$.


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
