### PR TITLE
allow shared edge to be conflictingly oriented

### DIFF
--- a/include/igl/predicates/find_intersections.cpp
+++ b/include/igl/predicates/find_intersections.cpp
@@ -77,8 +77,12 @@ IGL_INLINE bool igl::predicates::find_intersections(
       int d = F1(f,(c+2)%3);
       for(int e = 0;e<3;e++)
       {
-        // Find in opposite direction on jth face
-        if(F1(g,e) == d && F1(g,(e+1)%3) == s)
+        //// Find in opposite direction on gth face
+        //if(F1(g,e) == d && F1(g,(e+1)%3) == s)
+        // Find in either direction on gth face
+        if(
+            (F1(g,e) == d && F1(g,(e+1)%3) == s) ||
+            (F1(g,e) == s && F1(g,(e+1)%3) == d))
         {
           return c;
         }


### PR DESCRIPTION
This non-manifold input was generating false positives in find_self_intersections. It was because shared_edge was assuming consistent orientations.  No need for this assumption. 

[two_cubes.obj.zip](https://github.com/user-attachments/files/15808916/two_cubes.obj.zip)
