### PR TITLE
Eigen build fix, Eigen::all has been renamed.

### DIFF
--- a/include/igl/active_set.cpp
+++ b/include/igl/active_set.cpp
@@ -280,7 +280,7 @@ IGL_INLINE igl::SolverStatus igl::active_set(
       cout<<"  everything's fixed."<<endl;
 #endif
       Z.resize(A.rows(),Y_i.cols());
-      Z(known_i,Eigen::all) = Y_i;
+      Z(known_i,Eigen::placeholders::all) = Y_i;
       sol.resize(0,Y_i.cols());
       assert(Aeq_i.rows() == 0 && "All fixed but linearly constrained");
     }else
@@ -328,7 +328,7 @@ IGL_INLINE igl::SolverStatus igl::active_set(
     // Slow
     slice(A,known_i,1,Ak);
     //slice(B,known_i,Bk);
-    DerivedB Bk = B(known_i,Eigen::all);
+    DerivedB Bk = B(known_i,Eigen::placeholders::all);
     MatrixXd Lambda_known_i = -(0.5*Ak*Z + 0.5*Bk);
     // reverse the lambda values for lx
     Lambda_known_i.block(nk,0,as_lx_count,1) =

--- a/include/igl/bijective_composite_harmonic_mapping.cpp
+++ b/include/igl/bijective_composite_harmonic_mapping.cpp
@@ -50,7 +50,7 @@ IGL_INLINE bool igl::bijective_composite_harmonic_mapping(
   assert(F.cols() == 3 && "F should contain triangles");
   int nsteps = min_steps;
   Eigen::Matrix<typename Derivedbc::Scalar, Eigen::Dynamic, Eigen::Dynamic> bc0 =
-    V(b.col(0),Eigen::all);
+    V(b.col(0),Eigen::placeholders::all);
 
   // It's difficult to check for flips "robustly" in the sense that the input
   // mesh might not have positive/consistent sign to begin with.
@@ -81,7 +81,7 @@ IGL_INLINE bool igl::bijective_composite_harmonic_mapping(
         //mw.save(bct,"bct");
         //mw.write("numerical.mat");
         harmonic(Eigen::Matrix<typename DerivedU::Scalar, Eigen::Dynamic, Eigen::Dynamic>(U), F, b, bct, 1, U);
-        bct = U(b.col(0),Eigen::all);
+        bct = U(b.col(0),Eigen::placeholders::all);
         nans = (U.array() != U.array()).count();
         if(test_for_flips)
         {

--- a/include/igl/blue_noise.cpp
+++ b/include/igl/blue_noise.cpp
@@ -290,10 +290,10 @@ IGL_INLINE void igl::blue_noise(
   {
     Eigen::VectorXi I;
     igl::sortrows(decltype(Xs)(Xs),true,Xs,I);
-    X = X(I,Eigen::all).eval();
+    X = X(I,Eigen::placeholders::all).eval();
     // These two could be spun off in their own thread.
-    XB = XB(I,Eigen::all).eval();
-    XFI = XFI(I,Eigen::all).eval();
+    XB = XB(I,Eigen::placeholders::all).eval();
+    XFI = XFI(I,Eigen::placeholders::all).eval();
   }
   // Initialization
   std::unordered_map<BlueNoiseKeyType,std::vector<int> > M;

--- a/include/igl/circumradius.cpp
+++ b/include/igl/circumradius.cpp
@@ -54,7 +54,7 @@ IGL_INLINE void igl::circumradius(
   {
     Eigen::Matrix<Scalar,ACOLS,ACOLS> A(T.cols()+1,T.cols()+1);
     // Not sure if this .eval() is a good idea
-    const auto Vi = V(T.row(i),Eigen::all).eval();
+    const auto Vi = V(T.row(i),Eigen::placeholders::all).eval();
     A.topLeftCorner(T.cols(),T.cols()) = 2*(Vi*Vi.transpose());
     A.block(0,T.cols(),T.cols(),1).setConstant(1);
     A.block(T.cols(),0,1,T.cols()).setConstant(1);

--- a/include/igl/copyleft/cgal/is_self_intersecting.cpp
+++ b/include/igl/copyleft/cgal/is_self_intersecting.cpp
@@ -20,7 +20,7 @@ bool igl::copyleft::cgal::is_self_intersecting(
   const auto valid = 
     igl::find((F.array() != IGL_COLLAPSE_EDGE_NULL).rowwise().any().eval());
   // Extract only the valid faces
-  MatrixF FF = F(valid, Eigen::all);
+  MatrixF FF = F(valid, Eigen::placeholders::all);
   // Remove unreferneced vertices
   MatrixV VV;
   {

--- a/include/igl/copyleft/cgal/minkowski_sum.cpp
+++ b/include/igl/copyleft/cgal/minkowski_sum.cpp
@@ -230,22 +230,22 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   typedef Matrix<typename DerivedG::Scalar,Dynamic,1> VectorXI;
   MatrixXI GT(mp+mn,3);
   GT<< 
-    FA(igl::find(N),Eigen::all), 
-    (FA.array()+n).eval()(igl::find(P),Eigen::all);
+    FA(igl::find(N),Eigen::placeholders::all), 
+    (FA.array()+n).eval()(igl::find(P),Eigen::placeholders::all);
 
   // J indexes FA for parts at s and m+FA for parts at d
   J.derived() = igl::LinSpaced<DerivedJ >(m,0,m-1);
   DerivedJ JT(mp+mn);
   JT << 
-    J(igl::find(P),Eigen::all), 
-    J(igl::find(N),Eigen::all);
+    J(igl::find(P),Eigen::placeholders::all), 
+    J(igl::find(N),Eigen::placeholders::all);
   JT.block(mp,0,mn,1).array()+=m;
 
   // Original non-co-planar faces with positively oriented reversed
   MatrixXI BA(mp+mn,3);
   BA << 
-    FA(igl::find(P),Eigen::all).rowwise().reverse(), 
-    FA(igl::find(N),Eigen::all);
+    FA(igl::find(P),Eigen::placeholders::all).rowwise().reverse(), 
+    FA(igl::find(N),Eigen::placeholders::all);
   // Quads along **all** sides
   MatrixXI GQ((mp+mn)*3,4);
   GQ<< 

--- a/include/igl/copyleft/cgal/point_areas.cpp
+++ b/include/igl/copyleft/cgal/point_areas.cpp
@@ -68,17 +68,17 @@ namespace igl {
         igl::parallel_for(P.rows(),[&](int i)
         {
           MatrixP neighbors;
-          neighbors = P(I.row(i),Eigen::all);
+          neighbors = P(I.row(i),Eigen::placeholders::all);
           if(N.rows() && neighbors.rows() > 1){
             MatrixN neighbor_normals;
-            neighbor_normals = N(I.row(i),Eigen::all);
+            neighbor_normals = N(I.row(i),Eigen::placeholders::all);
             Eigen::Matrix<scalarN,1,3> poi_normal = neighbor_normals.row(0);
             Eigen::Matrix<scalarN,Eigen::Dynamic,1> dotprod =
                             poi_normal(0)*neighbor_normals.col(0)
             + poi_normal(1)*neighbor_normals.col(1)
             + poi_normal(2)*neighbor_normals.col(2);
             Eigen::Array<bool,Eigen::Dynamic,1> keep = dotprod.array() > 0;
-            neighbors = neighbors(igl::find(keep),Eigen::all).eval();
+            neighbors = neighbors(igl::find(keep),Eigen::placeholders::all).eval();
           }
           if(neighbors.rows() <= 2){
             A(i) = 0;
@@ -96,7 +96,7 @@ namespace igl {
               T.row(i) *= -1;
             }
             
-            MatrixP plane = scores(Eigen::all,{0,1});
+            MatrixP plane = scores(Eigen::placeholders::all,{0,1});
             
             std::vector< std::pair<Point,unsigned> > points;
             //This is where we obtain a delaunay triangulation of the points

--- a/include/igl/copyleft/cgal/point_solid_signed_squared_distance.cpp
+++ b/include/igl/copyleft/cgal/point_solid_signed_squared_distance.cpp
@@ -33,7 +33,7 @@ IGL_INLINE void igl::copyleft::cgal::point_solid_signed_squared_distance(
   // Collect queries that have non-zero distance
   Eigen::Array<bool,Eigen::Dynamic,1> NZ = D.array()!=0;
   // Compute sign for non-zero distance queries
-  DerivedQ QNZ = Q(igl::find(NZ),Eigen::all);
+  DerivedQ QNZ = Q(igl::find(NZ),Eigen::placeholders::all);
   Eigen::Array<bool,Eigen::Dynamic,1> DNZ;
   igl::copyleft::cgal::points_inside_component(VB,FB,QNZ,DNZ);
   // Apply sign to distances

--- a/include/igl/copyleft/cgal/trim_with_solid.cpp
+++ b/include/igl/copyleft/cgal/trim_with_solid.cpp
@@ -165,7 +165,7 @@ IGL_INLINE void igl::copyleft::cgal::trim_with_solid(
       igl::copyleft::cgal::intersect_other(
         VA,FA,VB,FB,{false,false,true},_1,V,F,J,_2);
       const auto keep = igl::find( (J.array()<FA.rows()).eval() );
-      F = F(keep,Eigen::all).eval();
+      F = F(keep,Eigen::placeholders::all).eval();
       J = J(keep).eval();
       {
         Eigen::VectorXi _;
@@ -262,7 +262,7 @@ IGL_INLINE void igl::copyleft::cgal::trim_with_solid(
                 keep.push_back(f);
               }
             }
-            F = F(keep,Eigen::all).eval();
+            F = F(keep,Eigen::placeholders::all).eval();
             J = J(keep).eval();
           }
 
@@ -278,7 +278,7 @@ IGL_INLINE void igl::copyleft::cgal::trim_with_solid(
       // only keep faces from A
       Eigen::Array<bool,Eigen::Dynamic,1> A = J.array()< FA.rows();
       const auto AI = igl::find(A);
-      F = F(AI,Eigen::all).eval();
+      F = F(AI,Eigen::placeholders::all).eval();
       J = J(AI).eval();
       P = P(AI).eval();
       set_D_via_patches(num_patches,P);

--- a/include/igl/copyleft/cgal/wire_mesh.cpp
+++ b/include/igl/copyleft/cgal/wire_mesh.cpp
@@ -115,7 +115,7 @@ IGL_INLINE void igl::copyleft::cgal::wire_mesh(
   const auto append_hull = 
     [&V,&vF,&vJ](const Eigen::VectorXi & I, const int j)
   {
-    MatrixX3S Vv = V(I,Eigen::all);
+    MatrixX3S Vv = V(I,Eigen::placeholders::all);
 
     if(coplanar(Vv))
     {

--- a/include/igl/decimate.cpp
+++ b/include/igl/decimate.cpp
@@ -84,7 +84,7 @@ IGL_INLINE bool igl::decimate(
     J,
     I);
   const Eigen::Array<bool,Eigen::Dynamic,1> keep = (J.array()<orig_m);
-  G = G(igl::find(keep),Eigen::all).eval();
+  G = G(igl::find(keep),Eigen::placeholders::all).eval();
   J = J(igl::find(keep)).eval();
   Eigen::VectorXi _1,I2;
   igl::remove_unreferenced(Eigen::MatrixXd(U),Eigen::MatrixXi(G),U,G,_1,I2);

--- a/include/igl/ears.cpp
+++ b/include/igl/ears.cpp
@@ -21,7 +21,7 @@ IGL_INLINE void igl::ears(
   }
   find((B.rowwise().count() == 2).eval(), ear);
   // Why do I need this .derived()?
-  Eigen::Array<bool, Eigen::Dynamic, 3> Bear = B(ear.derived(),Eigen::all);
+  Eigen::Array<bool, Eigen::Dynamic, 3> Bear = B(ear.derived(),Eigen::placeholders::all);
   Eigen::Array<bool, Eigen::Dynamic, 1> M;
   igl::min(Bear,2,M,ear_opp);
 }

--- a/include/igl/eigs.cpp
+++ b/include/igl/eigs.cpp
@@ -163,7 +163,7 @@ IGL_INLINE bool igl::eigs(
   // finally sort
   VectorXi I;
   igl::sort(S,1,false,sS,I);
-  sU = U(Eigen::all,I);
+  sU = U(Eigen::placeholders::all,I);
   sS /= rescale;
   sU /= sqrt(rescale);
   return true;

--- a/include/igl/intersection_blocking_collapse_edge_callbacks.h
+++ b/include/igl/intersection_blocking_collapse_edge_callbacks.h
@@ -59,7 +59,7 @@ namespace igl
   ///    post_collapse,
   ///    E, EMAP, EF, EI,
   ///    U, G, J, I);
-  ///  G = G(igl::find((J.array()<orig_m).eval()), Eigen::all).eval();
+  ///  G = G(igl::find((J.array()<orig_m).eval()), Eigen::placeholders::all).eval();
   ///  {
   ///    Eigen::VectorXi _;
   ///    igl::remove_unreferenced(Eigen::MatrixXd(U),Eigen::MatrixXi(G),U,G,_);

--- a/include/igl/iterative_closest_point.cpp
+++ b/include/igl/iterative_closest_point.cpp
@@ -96,7 +96,7 @@ IGL_INLINE void igl::iterative_closest_point(
       Ytree.squared_distance(VY,FY,X,sqrD,I,P);
     }
     // Use better normals?
-    MatrixXS N = NY(I,Eigen::all);
+    MatrixXS N = NY(I,Eigen::placeholders::all);
     //MatrixXS N = (X - P).rowwise().normalized();
     // fit rotation,translation
     Matrix3S Rup;

--- a/include/igl/linprog.cpp
+++ b/include/igl/linprog.cpp
@@ -76,7 +76,7 @@ IGL_INLINE bool igl::linprog(
     J.head(j) = B.head(j);
     J.tail(B.size()-j-1) = B.tail(B.size()-j-1);
     B(j) = n+m;
-    MatrixXd AJ = A(Eigen::all,J);
+    MatrixXd AJ = A(Eigen::placeholders::all,J);
     const VectorXd a = b - AJ.rowwise().sum();
     {
       MatrixXd old_A = A;
@@ -123,7 +123,7 @@ IGL_INLINE bool igl::linprog(
       }
       // reduced costs
       VectorXd sN = s(N);
-      MatrixXd AN = A(Eigen::all,N);
+      MatrixXd AN = A(Eigen::placeholders::all,N);
       VectorXd r = sN - AN.transpose() * yb;
       int q;
       // determine new basic variable
@@ -209,7 +209,7 @@ IGL_INLINE bool igl::linprog(
       }
     }
     // iterative refinement
-    xb = (xb+D*(b-A(Eigen::all,B)*xb)).eval();
+    xb = (xb+D*(b-A(Eigen::placeholders::all,B)*xb)).eval();
     // must be due to rounding
     VectorXi I;
     igl::find((xb.array()<0).eval(),I);

--- a/include/igl/min_quad_with_fixed.impl.h
+++ b/include/igl/min_quad_with_fixed.impl.h
@@ -464,7 +464,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_solve(
     }
 
     // Build right hand side
-    MatrixXT BBequlcols = BBeq(data.unknown_lagrange,Eigen::all);
+    MatrixXT BBequlcols = BBeq(data.unknown_lagrange,Eigen::placeholders::all);
     MatrixXT NB;
     if(kr == 0)
     {
@@ -515,7 +515,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_solve(
       //data.AeqTQR.colsPermutation().transpose() * (-data.Aeqk * Y + Beq);
       data.AeqTET * (-data.Aeqk * Y + Beq.replicate(1,Beq.cols()==cols?1:cols));
     // Where did this -0.5 come from? Probably the same place as above.
-    MatrixXT Bu = B(data.unknown,Eigen::all);
+    MatrixXT Bu = B(data.unknown,Eigen::placeholders::all);
     MatrixXT NB;
     NB = -0.5*(Bu.replicate(1,B.cols()==cols?1:cols) + data.preY * Y);
     // Trim eff_Beq

--- a/include/igl/normal_derivative.cpp
+++ b/include/igl/normal_derivative.cpp
@@ -40,7 +40,7 @@ IGL_INLINE void igl::normal_derivative(
     case 4:
     {
       const MatrixXi DDJ = 
-        Ele(Eigen::all,{1,0,2,0,3,0,2,1,3,1,0,1,3,2,0,2,1,2,0,3,1,3,2,3});
+        Ele(Eigen::placeholders::all,{1,0,2,0,3,0,2,1,3,1,0,1,3,2,0,2,1,2,0,3,1,3,2,3});
       MatrixXi DDI(m,24);
       for(size_t f = 0;f<4;f++)
       {
@@ -53,7 +53,7 @@ IGL_INLINE void igl::normal_derivative(
       const DiagonalMatrix<Scalar,24,24> S =
         (Matrix<Scalar,2,1>(1,-1).template replicate<12,1>()).asDiagonal();
       Matrix<Scalar,Dynamic,Dynamic> DDV =
-        C(Eigen::all,{2,2,1,1,3,3,0,0,4,4,2,2,5,5,1,1,0,0,3,3,4,4,5,5});
+        C(Eigen::placeholders::all,{2,2,1,1,3,3,0,0,4,4,2,2,5,5,1,1,0,0,3,3,4,4,5,5});
       DDV *= S;
 
       IJV.reserve(DDV.size());
@@ -70,7 +70,7 @@ IGL_INLINE void igl::normal_derivative(
     }
     case 3:
     {
-      const MatrixXi DDJ = Ele(Eigen::all,{2,0,1,0,0,1,2,1,1,2,0,2});
+      const MatrixXi DDJ = Ele(Eigen::placeholders::all,{2,0,1,0,0,1,2,1,1,2,0,2});
       MatrixXi DDI(m,12);
       for(size_t f = 0;f<3;f++)
       {
@@ -82,7 +82,7 @@ IGL_INLINE void igl::normal_derivative(
       }
       const DiagonalMatrix<Scalar,12,12> S =
         (Matrix<Scalar,2,1>(1,-1).template replicate<6,1>()).asDiagonal();
-      Matrix<Scalar,Dynamic,Dynamic> DDV = C(Eigen::all,{1,1,2,2,2,2,0,0,0,0,1,1});
+      Matrix<Scalar,Dynamic,Dynamic> DDV = C(Eigen::placeholders::all,{1,1,2,2,2,2,0,0,0,0,1,1});
       DDV *= S;
 
       IJV.reserve(DDV.size());

--- a/include/igl/predicates/find_intersections.cpp
+++ b/include/igl/predicates/find_intersections.cpp
@@ -281,7 +281,7 @@ IGL_INLINE bool igl::predicates::find_intersections(
   if(!find_intersections(tree1,V1,F1,V2,F2,false,IF,CP)) { return false; }
   std::vector<int> EI_vec = igl::find((CP.array()==false).eval());
   igl::list_to_matrix(EI_vec,EI);
-  const auto IF_EI = IF(EI_vec,Eigen::all).eval();
+  const auto IF_EI = IF(EI_vec,Eigen::placeholders::all).eval();
   igl::triangle_triangle_intersect(V1,F1,V2,F2,IF_EI,EV,EE);
   return true;
 }

--- a/include/igl/predicates/polygons_to_triangles.cpp
+++ b/include/igl/predicates/polygons_to_triangles.cpp
@@ -54,7 +54,7 @@ IGL_INLINE void igl::predicates::polygons_to_triangles(
               Eigen::Vector3d _1;
               Eigen::Vector3i I;
               igl::sort(es.eigenvalues().real().eval(),1,false,_1,I);
-              C = C(Eigen::all,I).eval();
+              C = C(Eigen::placeholders::all,I).eval();
             }
             S = P*C.leftCols(2);
             break;

--- a/include/igl/qslim.cpp
+++ b/include/igl/qslim.cpp
@@ -90,7 +90,7 @@ IGL_INLINE bool igl::qslim(
   // Remove phony boundary faces and clean up
   const Eigen::Array<bool,Eigen::Dynamic,1> keep = (J.array()<orig_m);
   const auto keep_i = igl::find(keep);
-  G = G(keep_i,Eigen::all).eval();
+  G = G(keep_i,Eigen::placeholders::all).eval();
   J = J(keep_i).eval();
   Eigen::VectorXi _1,I2;
   igl::remove_unreferenced(Eigen::MatrixXd(U),Eigen::MatrixXi(G),U,G,_1,I2);

--- a/include/igl/ramer_douglas_peucker.cpp
+++ b/include/igl/ramer_douglas_peucker.cpp
@@ -65,7 +65,7 @@ IGL_INLINE void igl::ramer_douglas_peucker(
   };
   simplify(0,n-1);
   igl::find(I,J);
-  S = P(J.derived(),Eigen::all);
+  S = P(J.derived(),Eigen::placeholders::all);
 }
 
 template <
@@ -119,7 +119,7 @@ IGL_INLINE void igl::ramer_douglas_peucker(
       T(t) = 0;
     }
   }
-  DerivedS SB = S(B,Eigen::all);
+  DerivedS SB = S(B,Eigen::placeholders::all);
   Eigen::VectorXi MB = B.array()+1;
   for(int b = 0;b<MB.size();b++)
   {
@@ -128,7 +128,7 @@ IGL_INLINE void igl::ramer_douglas_peucker(
       MB(b) = S.rows()-1;
     }
   }
-  DerivedS SMB = S(MB,Eigen::all);
+  DerivedS SMB = S(MB,Eigen::placeholders::all);
   Q = SB.array() + ((SMB.array()-SB.array()).colwise()*T.array());
 
   // Remove extra point at end

--- a/include/igl/remove_duplicate_vertices.cpp
+++ b/include/igl/remove_duplicate_vertices.cpp
@@ -32,7 +32,7 @@ IGL_INLINE void igl::remove_duplicate_vertices(
     DerivedV rV,rSV;
     round((V/(epsilon)).eval(),rV);
     unique_rows(rV,rSV,SVI,SVJ);
-    SV = V(SVI.derived(),Eigen::all);
+    SV = V(SVI.derived(),Eigen::placeholders::all);
   }else
   {
     unique_rows(V,SV,SVI,SVJ);

--- a/include/igl/remove_unreferenced.cpp
+++ b/include/igl/remove_unreferenced.cpp
@@ -46,7 +46,7 @@ IGL_INLINE void igl::remove_unreferenced(
   NF = F;
   std::for_each(NF.data(),NF.data()+NF.size(),
     [&I](typename DerivedNF::Scalar & a){a=I(a);});
-  NV = V(J.derived(),Eigen::all);
+  NV = V(J.derived(),Eigen::placeholders::all);
 }
 
 template <

--- a/include/igl/resolve_duplicated_faces.cpp
+++ b/include/igl/resolve_duplicated_faces.cpp
@@ -81,7 +81,7 @@ IGL_INLINE void igl::resolve_duplicated_faces(
   const size_t num_kept = kept_faces.size();
   J.resize(num_kept, 1);
   std::copy(kept_faces.begin(), kept_faces.end(), J.data());
-  F2 = F1(J.derived(),Eigen::all);
+  F2 = F1(J.derived(),Eigen::placeholders::all);
 }
 
 #ifdef IGL_STATIC_LIBRARY

--- a/include/igl/slice.h
+++ b/include/igl/slice.h
@@ -19,11 +19,11 @@
 /// | igl                        | Eigen v3.4                         |
 /// |-------------------0--------|------------------------------------| |
 /// `igl::slice(X,I,J,Y)`      | `Y = X(I,J)`                       | |
-/// `igl::slice(X,I,1,Y)`      | `Y = X(I,Eigen::all)`              | |
-/// `igl::slice(X,J,2,Y)`      | `Y = X(Eigen::all,J)`              | |
+/// `igl::slice(X,I,1,Y)`      | `Y = X(I,Eigen::placeholders::all)`              | |
+/// `igl::slice(X,J,2,Y)`      | `Y = X(Eigen::placeholders::all,J)`              | |
 /// `igl::slice_into(Z,I,J,X)` | `X(I,J) = Z`                       | |
-/// `igl::slice_into(Z,I,1,X)` | `X(I,Eigen::all) = Z`              | |
-/// `igl::slice_into(Z,J,2,X)` | `X(Eigen::all,J) = Z`              | |
+/// `igl::slice_into(Z,I,1,X)` | `X(I,Eigen::placeholders::all) = Z`              | |
+/// `igl::slice_into(Z,J,2,X)` | `X(Eigen::placeholders::all,J) = Z`              | |
 /// `igl::slice_mask(X,M,N,Y)` | `Y = X(igl::find(M),igl::find(N))` | | _not
 /// available_            | `X(igl::find(M),igl::find(N)) = Z` |
 ///

--- a/include/igl/sort_triangles.cpp
+++ b/include/igl/sort_triangles.cpp
@@ -46,7 +46,7 @@ IGL_INLINE void igl::sort_triangles(
       MV.template cast<Scalar>().transpose()*
        P.template cast<Scalar>().transpose().eval().col(2));
   sort(D,1,false,sD,I);
-  FF = F(I.derived(),Eigen::all);
+  FF = F(I.derived(),Eigen::placeholders::all);
 }
 
 

--- a/include/igl/spectra/eigs.cpp
+++ b/include/igl/spectra/eigs.cpp
@@ -127,7 +127,7 @@ IGL_INLINE bool igl::spectra::eigs(
 
   Eigen::VectorXi I;
   igl::sort( Eigen::VectorXd(S), 1, false, S, I);
-  U = U(Eigen::all,I).eval();
+  U = U(Eigen::placeholders::all,I).eval();
   return true;
 }
 

--- a/include/igl/split_nonmanifold.cpp
+++ b/include/igl/split_nonmanifold.cpp
@@ -468,7 +468,7 @@ IGL_INLINE void igl::split_nonmanifold(
   Eigen::PlainObjectBase <DerivedSVI> & SVI)
 {
   igl::split_nonmanifold(F,SF,SVI);
-  SV = V(SVI.derived(),Eigen::all);
+  SV = V(SVI.derived(),Eigen::placeholders::all);
 }
 
 #ifdef IGL_STATIC_LIBRARY

--- a/include/igl/straighten_seams.cpp
+++ b/include/igl/straighten_seams.cpp
@@ -74,8 +74,8 @@ IGL_INLINE void igl::straighten_seams(
   Array<bool,Dynamic,1>vBT = Map<Array<bool,Dynamic,1> >(BT.data(),BT.size(),1);
   Array<bool,Dynamic,1>vBF = Map<Array<bool,Dynamic,1> >(BF.data(),BF.size(),1);
   const auto vBT_i = igl::find(vBT);
-  MatrixX2I OF = EF(vBT_i,Eigen::all);
-  OT = EF(vBT_i,Eigen::all);
+  MatrixX2I OF = EF(vBT_i,Eigen::placeholders::all);
+  OT = EF(vBT_i,Eigen::placeholders::all);
   VectorXi OFMAP = EFMAP(vBT_i);
   // Two boundary edges on the texture-mapping are "equivalent" to each other on
   // the 3D-mesh if their 3D-mesh vertex indices match
@@ -115,7 +115,7 @@ IGL_INLINE void igl::straighten_seams(
   assert( (M.array() == 1).all() );
   VectorXi DT;
   // Map counts onto texture-vertices
-  DT = DV(I,Eigen::all);
+  DT = DV(I,Eigen::placeholders::all);
   // Boundary in 3D && UV
   Array<bool,Dynamic,1> BTF = vBF(igl::find(vBT));
 
@@ -235,14 +235,14 @@ IGL_INLINE void igl::straighten_seams(
     {
       case 1:
         {
-          MatrixX2I OTIc = OT(Ic,Eigen::all);
+          MatrixX2I OTIc = OT(Ic,Eigen::placeholders::all);
           edges_to_path(OTIc,vpath,epath,eend);
           Array<bool,Dynamic,1> SVvpath = SV(vpath);
           assert(
             (vpath(0) != vpath(vpath.size()-1) || !SVvpath.any()) && 
             "Not dealing with 1-loops touching 'sharp' corners");
           // simple open boundary
-          MatrixX2S PI = VT(vpath,Eigen::all);
+          MatrixX2S PI = VT(vpath,Eigen::placeholders::all);
           const Scalar bbd = 
             (PI.colwise().maxCoeff() - PI.colwise().minCoeff()).norm();
           // Do not collapse boundaries to fewer than 3 vertices
@@ -256,7 +256,7 @@ IGL_INLINE void igl::straighten_seams(
           {
             MatrixX2S UPI,UTvpath;
             ramer_douglas_peucker(PI,eff_tol*bbd,UPI,UIc,UTvpath);
-            UT(vpath,Eigen::all) = UTvpath;
+            UT(vpath,Eigen::placeholders::all) = UTvpath;
             if(!is_closed || allow_boundary_collapse)
             {
               break;
@@ -294,8 +294,8 @@ IGL_INLINE void igl::straighten_seams(
           }
           Array<bool,Dynamic,1> flipped;
           {
-            MatrixX2I OFIc = OF(Ic,Eigen::all);
-            MatrixX2I OFIcc = OF(Icc,Eigen::all);
+            MatrixX2I OFIc = OF(Ic,Eigen::placeholders::all);
+            MatrixX2I OFIcc = OF(Icc,Eigen::placeholders::all);
             Eigen::VectorXi XOR,IA,IB;
             setxor(OFIc,OFIcc,XOR,IA,IB);
             assert(XOR.size() == 0);
@@ -309,7 +309,7 @@ IGL_INLINE void igl::straighten_seams(
             vUE.push_back({OT(Icc(0),flipped(0)?1:0),OT(Icc(0),flipped(0)?0:1)});
           }else
           {
-            MatrixX2I OTIc = OT(Ic,Eigen::all);
+            MatrixX2I OTIc = OT(Ic,Eigen::placeholders::all);
             edges_to_path(OTIc,vpath,epath,eend);
             // Flip endpoints if needed
             for(int e = 0;e<eend.size();e++)if(flipped(e))eend(e)=1-eend(e);
@@ -335,8 +335,8 @@ IGL_INLINE void igl::straighten_seams(
             Matrix<Scalar,Dynamic,Dynamic> UPI,SI;
             VectorXi UIc;
             ramer_douglas_peucker(PI,tol*bbd,UPI,UIc,SI);
-            UT(vpath,Eigen::all) = SI.leftCols (VT.cols());
-            UT(vpathc,Eigen::all) = SI.rightCols(VT.cols());
+            UT(vpath,Eigen::placeholders::all) = SI.leftCols (VT.cols());
+            UT(vpathc,Eigen::placeholders::all) = SI.rightCols(VT.cols());
             for(int i = 0;i<UIc.size()-1;i++)
             {
               vUE.push_back({vpath(UIc(i)),vpath(UIc(i+1))});

--- a/include/igl/triangle/cdt.cpp
+++ b/include/igl/triangle/cdt.cpp
@@ -35,7 +35,7 @@ IGL_INLINE void igl::triangle::cdt(
   igl::remove_duplicate_vertices(DerivedWV(WV),DerivedWE(WE),1e-10,WV,_,J,WE);
   // Remove degenerate edges
   const Eigen::Array<bool,Eigen::Dynamic,1> keep = (WE.array().col(0) != WE.array().col(1));
-  WE = WE(keep,Eigen::all).eval();
+  WE = WE(keep,Eigen::placeholders::all).eval();
   // c flag must be present
   igl::triangle::triangulate(DerivedWV(WV),WE,DerivedWV(),flags,WV,WF);
   Eigen::VectorXi UJ;

--- a/include/igl/triangle/scaf.cpp
+++ b/include/igl/triangle/scaf.cpp
@@ -433,7 +433,7 @@ IGL_INLINE void build_surface_linear_system(const SCAFData &s, Eigen::SparseMatr
   }
   else
   {
-    MatrixXd bnd_pos = s.w_uv(bnd_ids, Eigen::all);
+    MatrixXd bnd_pos = s.w_uv(bnd_ids, Eigen::placeholders::all);
 
     ArrayXi known_ids(bnd_ids.size() * dim);
     ArrayXi unknown_ids((v_n - bnd_ids.rows()) * dim);
@@ -494,7 +494,7 @@ IGL_INLINE void build_scaffold_linear_system(const SCAFData &s, Eigen::SparseMat
 
   auto bnd_n = bnd_ids.size();
   IGL_ASSERT(bnd_n > 0);
-  MatrixXd bnd_pos = s.w_uv(bnd_ids, Eigen::all);
+  MatrixXd bnd_pos = s.w_uv(bnd_ids, Eigen::placeholders::all);
 
   ArrayXi known_ids(bnd_ids.size() * dim);
   ArrayXi unknown_ids((v_n - bnd_ids.rows()) * dim);
@@ -565,7 +565,7 @@ IGL_INLINE void solve_weighted_arap(SCAFData &s, Eigen::MatrixXd &uv)
   const auto v_n = s.v_num;
   const auto bnd_n = bnd_ids.size();
   assert(bnd_n > 0);
-  MatrixXd bnd_pos = s.w_uv(bnd_ids, Eigen::all);
+  MatrixXd bnd_pos = s.w_uv(bnd_ids, Eigen::placeholders::all);
 
   ArrayXi known_ids(bnd_n * dim);
   ArrayXi unknown_ids((v_n - bnd_n) * dim);

--- a/include/igl/uniformly_sample_two_manifold.cpp
+++ b/include/igl/uniformly_sample_two_manifold.cpp
@@ -88,7 +88,7 @@ IGL_INLINE void igl::uniformly_sample_two_manifold(
   // First get sampling as best as possible on mesh
   uniformly_sample_two_manifold_at_vertices(W,k,push,S);
   verbose("Lap: %g\n",get_seconds()-start);
-  WS = W(S,Eigen::all);
+  WS = W(S,Eigen::placeholders::all);
   //cout<<"WSmesh=["<<endl<<WS<<endl<<"];"<<endl;
 
 //#ifdef EXTREME_VERBOSE
@@ -361,7 +361,7 @@ IGL_INLINE void igl::uniformly_sample_two_manifold_at_vertices(
   // Remove corners, which better be at top
   S = S.segment(W.cols(),k).eval();
 
-  MatrixXd WS = W(S,Eigen::all);
+  MatrixXd WS = W(S,Eigen::placeholders::all);
   //cout<<"WSpartition=["<<endl<<WS<<endl<<"];"<<endl;
 
   // number of vertices

--- a/tests/include/igl/AABB.cpp
+++ b/tests/include/igl/AABB.cpp
@@ -91,7 +91,7 @@ TEST_CASE("AABB: dynamic", "[igl]")
     // Load example mesh: GetParam() will be name of mesh file
     igl::read_triangle_mesh(test_common::data_path(param), V, F);
     // Make into soup
-    V = V(Eigen::Map<Eigen::VectorXi>(F.data(),F.size()), Eigen::all).eval();
+    V = V(Eigen::Map<Eigen::VectorXi>(F.data(),F.size()), Eigen::placeholders::all).eval();
     F = Eigen::Map<Eigen::MatrixXi>(igl::colon<int>(0,V.rows()-1).data(),V.rows()/3,3).eval();
     Eigen::MatrixXd BC;
     igl::barycenter(V,F,BC);
@@ -160,7 +160,7 @@ TEST_CASE("AABB: dynamic", "[igl]")
       Eigen::MatrixXd TF = 0.1*h*Eigen::MatrixXd::Random(RF.size(),3);
       Eigen::MatrixXd TV(RV.rows(),3);
       TV<<TF,TF,TF;
-      V(RV,Eigen::all) += TV;
+      V(RV,Eigen::placeholders::all) += TV;
       igl::barycenter(V,F,BC);
     }
     const int qi = RF(0);

--- a/tests/include/igl/decimate.cpp
+++ b/tests/include/igl/decimate.cpp
@@ -27,7 +27,7 @@ TEST_CASE("decimate: hemisphere", "[igl]")
   igl::decimate(V,F,F.rows()/2,false,U,G,J,I);
   // Expect that all normals still point in same direction as original
   Eigen::MatrixXd NU = U.rowwise().normalized();
-  Eigen::MatrixXd NVI = NV(I,Eigen::all);
+  Eigen::MatrixXd NVI = NV(I,Eigen::placeholders::all);
   REQUIRE (NU.rows() == NVI.rows());
   REQUIRE (NU.cols() == NVI.cols());
   // Dot product

--- a/tests/include/igl/slice.cpp
+++ b/tests/include/igl/slice.cpp
@@ -19,13 +19,13 @@ TEST_CASE("slice: eigen-simple", "[igl]")
   {
     Eigen::MatrixXd Yigl;
     igl::slice(X,I,1,Yigl);
-    Eigen::MatrixXd Yeigen  = X(I,Eigen::all);
+    Eigen::MatrixXd Yeigen  = X(I,Eigen::placeholders::all);
     test_common::assert_eq(Yigl,Yeigen);
   }
   {
     Eigen::MatrixXd Yigl;
     igl::slice(X,I,2,Yigl);
-    Eigen::MatrixXd Yeigen  = X(Eigen::all,I);
+    Eigen::MatrixXd Yeigen  = X(Eigen::placeholders::all,I);
     test_common::assert_eq(Yigl,Yeigen);
   }
 }
@@ -48,13 +48,13 @@ TEST_CASE("slice: eigen-random", "[igl]")
   {
     Eigen::MatrixXd Yigl;
     igl::slice(X,I,1,Yigl);
-    Eigen::MatrixXd Yeigen = X(I,Eigen::all);
+    Eigen::MatrixXd Yeigen = X(I,Eigen::placeholders::all);
     test_common::assert_eq(Yigl,Yeigen);
   }
   {
     Eigen::MatrixXd Yigl;
     igl::slice(X,J,2,Yigl);
-    Eigen::MatrixXd Yeigen = X(Eigen::all,J);
+    Eigen::MatrixXd Yeigen = X(Eigen::placeholders::all,J);
     test_common::assert_eq(Yigl,Yeigen);
   }
 }

--- a/tests/include/igl/slice_into.cpp
+++ b/tests/include/igl/slice_into.cpp
@@ -27,7 +27,7 @@ TEST_CASE("slice_into: eigen-random", "[igl]")
     Eigen::MatrixXd Yigl = X;
     igl::slice_into(Z,I,1,Yigl);
     Eigen::MatrixXd Yeigen = X;
-    Yeigen(I,Eigen::all) = Z;
+    Yeigen(I,Eigen::placeholders::all) = Z;
     test_common::assert_eq(Yigl,Yeigen);
   }
   {
@@ -35,7 +35,7 @@ TEST_CASE("slice_into: eigen-random", "[igl]")
     Eigen::MatrixXd Yigl = X;
     igl::slice_into(Z,J,2,Yigl);
     Eigen::MatrixXd Yeigen = X;
-    Yeigen(Eigen::all,J) = Z;
+    Yeigen(Eigen::placeholders::all,J) = Z;
     test_common::assert_eq(Yigl,Yeigen);
   }
   

--- a/tests/include/igl/slice_mask.cpp
+++ b/tests/include/igl/slice_mask.cpp
@@ -25,13 +25,13 @@ TEST_CASE("slice_mask/find: random", "[igl]")
   {
     Eigen::MatrixXd Yigl;
     igl::slice_mask(X,M,1,Yigl);
-    Eigen::MatrixXd Yfind = X(igl::find(M),Eigen::all);
+    Eigen::MatrixXd Yfind = X(igl::find(M),Eigen::placeholders::all);
     test_common::assert_eq(Yigl,Yfind);
   }
   {
     Eigen::MatrixXd Yigl;
     igl::slice_mask(X,N,2,Yigl);
-    Eigen::MatrixXd Yfind = X(Eigen::all,igl::find(N));
+    Eigen::MatrixXd Yfind = X(Eigen::placeholders::all,igl::find(N));
     test_common::assert_eq(Yigl,Yfind);
   }
 }

--- a/tutorial/301_Slice/main.cpp
+++ b/tutorial/301_Slice/main.cpp
@@ -28,13 +28,13 @@ int main(int argc, char *argv[])
   // Red for each in K
   MatrixXd R = RowVector3d(1.0,0.3,0.3).replicate(K.rows(),1);
   // C(K,:) = R
-  C(K,Eigen::all) = R;
+  C(K,Eigen::placeholders::all) = R;
   // igl::slice_into(R,K,1,C); no longer needed
 
   Eigen::Array<bool,Eigen::Dynamic,1> W = Eigen::VectorXd::Random(F.rows()).array()>0.5;
   // Set 1/4 of the colors  to blue
   MatrixXd B = RowVector3d(0.3,0.3,1.0).replicate(W.count(),1);
-  C(igl::find(W),Eigen::all) = B;
+  C(igl::find(W),Eigen::placeholders::all) = B;
 
   // Plot the mesh with pseudocolors
   igl::opengl::glfw::Viewer viewer;

--- a/tutorial/406_FastAutomaticSkinningTransformations/main.cpp
+++ b/tutorial/406_FastAutomaticSkinningTransformations/main.cpp
@@ -146,7 +146,7 @@ int main(int argc, char *argv[])
   // Plot the mesh with pseudocolors
   igl::opengl::glfw::Viewer viewer;
   viewer.data().set_mesh(U, F);
-  viewer.data().add_points(V(b,Eigen::all),sea_green);
+  viewer.data().add_points(V(b,Eigen::placeholders::all),sea_green);
   viewer.data().show_lines = false;
   viewer.callback_pre_draw = &pre_draw;
   viewer.callback_key_down = &key_down;

--- a/tutorial/407_BiharmonicCoordinates/main.cpp
+++ b/tutorial/407_BiharmonicCoordinates/main.cpp
@@ -67,7 +67,7 @@ int main(int argc, char * argv[])
     // with the vertices in high resolution. b is the list of vertices
     // corresponding to the indices in high resolution which has closest
     // distance to the points in low resolution
-    low.V = high.V(b,Eigen::all);
+    low.V = high.V(b,Eigen::placeholders::all);
 
     // list of points --> list of singleton lists
     std::vector<std::vector<int> > S;
@@ -90,8 +90,8 @@ int main(int argc, char * argv[])
     igl::remove_unreferenced(high.V.rows(),high.F,I,J);
     for_each(high.F.data(),high.F.data()+high.F.size(),[&I](int & a){a=I(a);});
     for_each(b.data(),b.data()+b.size(),[&I](int & a){a=I(a);});
-    high.V = high.V(J,Eigen::all).eval();
-    W = W(J,Eigen::all).eval();
+    high.V = high.V(J,Eigen::placeholders::all).eval();
+    W = W(J,Eigen::placeholders::all).eval();
   }
 
   // Resize low res (high res will also be resized by affine precision of W)

--- a/tutorial/504_Planarization/main.cpp
+++ b/tutorial/504_Planarization/main.cpp
@@ -90,19 +90,19 @@ int main(int argc, char *argv[])
   FQCtri.resize(2*FQC.rows(), 3);
   FQCtri <<  FQC.col(0),FQC.col(1),FQC.col(2),
              FQC.col(2),FQC.col(3),FQC.col(0);
-  PQC0 = VQC(FQC.col(0).eval(), Eigen::all);
-  PQC1 = VQC(FQC.col(1).eval(), Eigen::all);
-  PQC2 = VQC(FQC.col(2).eval(), Eigen::all);
-  PQC3 = VQC(FQC.col(3).eval(), Eigen::all);
+  PQC0 = VQC(FQC.col(0).eval(), Eigen::placeholders::all);
+  PQC1 = VQC(FQC.col(1).eval(), Eigen::placeholders::all);
+  PQC2 = VQC(FQC.col(2).eval(), Eigen::placeholders::all);
+  PQC3 = VQC(FQC.col(3).eval(), Eigen::placeholders::all);
 
   // Planarize it
   igl::planarize_quad_mesh(VQC, FQC, 100, 0.005, VQCplan);
 
   // Convert the planarized mesh to triangles
-  PQC0plan = VQCplan(FQC.col(0).eval(), Eigen::all);
-  PQC1plan = VQCplan(FQC.col(1).eval(), Eigen::all);
-  PQC2plan = VQCplan(FQC.col(2).eval(), Eigen::all);
-  PQC3plan = VQCplan(FQC.col(3).eval(), Eigen::all);
+  PQC0plan = VQCplan(FQC.col(0).eval(), Eigen::placeholders::all);
+  PQC1plan = VQCplan(FQC.col(1).eval(), Eigen::placeholders::all);
+  PQC2plan = VQCplan(FQC.col(2).eval(), Eigen::placeholders::all);
+  PQC3plan = VQCplan(FQC.col(3).eval(), Eigen::placeholders::all);
 
   // Launch the viewer
   igl::opengl::glfw::Viewer viewer;

--- a/tutorial/803_ShapeUp/main.cpp
+++ b/tutorial/803_ShapeUp/main.cpp
@@ -110,10 +110,10 @@ int main(int argc, char *argv[])
   FQCtri.resize(2*FQC.rows(), 3);
   FQCtri <<  FQC.col(0),FQC.col(1),FQC.col(2),
              FQC.col(2),FQC.col(3),FQC.col(0);
-  PQC0 = VQC(FQC.col(0).eval(), Eigen::all);
-  PQC1 = VQC(FQC.col(1).eval(), Eigen::all);
-  PQC2 = VQC(FQC.col(2).eval(), Eigen::all);
-  PQC3 = VQC(FQC.col(3).eval(), Eigen::all);
+  PQC0 = VQC(FQC.col(0).eval(), Eigen::placeholders::all);
+  PQC1 = VQC(FQC.col(1).eval(), Eigen::placeholders::all);
+  PQC2 = VQC(FQC.col(2).eval(), Eigen::placeholders::all);
+  PQC3 = VQC(FQC.col(3).eval(), Eigen::placeholders::all);
 
   // Create a planar version with ShapeUp
   //igl::planarize_quad_mesh(VQC, FQC, 100, 0.005, VQCregular);
@@ -137,10 +137,10 @@ int main(int argc, char *argv[])
 
 
   // Convert the planarized mesh to triangles
-  PQC0regular = VQCregular(FQC.col(0).eval(), Eigen::all);
-  PQC1regular = VQCregular(FQC.col(1).eval(), Eigen::all);
-  PQC2regular = VQCregular(FQC.col(2).eval(), Eigen::all);
-  PQC3regular = VQCregular(FQC.col(3).eval(), Eigen::all);
+  PQC0regular = VQCregular(FQC.col(0).eval(), Eigen::placeholders::all);
+  PQC1regular = VQCregular(FQC.col(1).eval(), Eigen::placeholders::all);
+  PQC2regular = VQCregular(FQC.col(2).eval(), Eigen::placeholders::all);
+  PQC3regular = VQCregular(FQC.col(3).eval(), Eigen::placeholders::all);
 
   // Launch the viewer
   igl::opengl::glfw::Viewer viewer;

--- a/tutorial/805_MeshImplicitFunction/contours.cpp
+++ b/tutorial/805_MeshImplicitFunction/contours.cpp
@@ -194,7 +194,7 @@ void contours(
       Q.col(2), Q.col(3), 
       Q.col(3), Q.col(0);
     igl::per_face_normals(V,I,C,N,VV,FF,J);
-    NN = N(J,Eigen::all);
+    NN = N(J,Eigen::placeholders::all);
     igl::per_corner_normals(V,I,C,20,N,VV,FF,J,NN);
   }
 

--- a/tutorial/907_DynamicAABB/main.cpp
+++ b/tutorial/907_DynamicAABB/main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char *argv[])
   igl::read_triangle_mesh(
     argc>1?argv[1]:TUTORIAL_SHARED_PATH "/decimated-knight.off",V,F);
   // Make mesh into disconnected soup
-  V = V(Eigen::Map<Eigen::VectorXi>(F.data(),F.size()), Eigen::all).eval();
+  V = V(Eigen::Map<Eigen::VectorXi>(F.data(),F.size()), Eigen::placeholders::all).eval();
   F = Eigen::Map<Eigen::MatrixXi>(igl::colon<int>(0,V.rows()-1).data(),V.rows()/3,3).eval();
   // Cache normals
   igl::per_face_normals(V,F,N);
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   Eigen::VectorXi TD;
   const auto update_edges = [&]()
   {
-    Eigen::MatrixXi TQd = TQ(igl::find((TD.array()==depth).eval()),Eigen::all);
+    Eigen::MatrixXi TQd = TQ(igl::find((TD.array()==depth).eval()),Eigen::placeholders::all);
     Eigen::MatrixXi TE;
     igl::quad_edges(TQd,TE);
     vr.data().set_edges(TV,TE,Eigen::RowVector3d(1,1,1));

--- a/tutorial/908_IntersectionBlockingDecimation/main.cpp
+++ b/tutorial/908_IntersectionBlockingDecimation/main.cpp
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
       post_collapse,
       E, EMAP, EF, EI,
       U, G, J, I);
-    G = G(igl::find((J.array()<orig_m).eval()), Eigen::all).eval();
+    G = G(igl::find((J.array()<orig_m).eval()), Eigen::placeholders::all).eval();
     {
       Eigen::VectorXi _;
       igl::remove_unreferenced(Eigen::MatrixXd(U),Eigen::MatrixXi(G),U,G,_);
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
       }
       printf("  # self-intersections: %d\n",(int)BI.size());
       dC[pass] = gray.replicate(dF[pass].rows(),1);
-      dC[pass](BI,Eigen::all) = 
+      dC[pass](BI,Eigen::placeholders::all) = 
         Eigen::RowVector3d(0.95,0.15,0.15).replicate(BI.size(),1);
     }
   }


### PR DESCRIPTION
This fixes the build for recent Eigen versions. `Eigen::all `was first deprecated and is now only available as `Eigen::placeholders:all`.

This commit is simply the result of a search-and-replace, `gsed -i 's/Eigen::all/Eigen::placeholders::all/' **/*(.)`


<!-- Describe your changes and what you've already done to test it. -->


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
