### PR TITLE
*fix ambiguous 'Quaternion' symbol error (C2872) when using another l…

### DIFF
--- a/include/igl/column_to_quats.cpp
+++ b/include/igl/column_to_quats.cpp
@@ -21,7 +21,7 @@ IGL_INLINE bool igl::column_to_quats(
   for(int q=0;q<nQ;q++)
   {
     // Constructor uses wxyz
-    vQ[q] = Quaterniond( Q(q*4+3), Q(q*4+0), Q(q*4+1), Q(q*4+2));
+    vQ[q] = Eigen::Quaterniond( Q(q*4+3), Q(q*4+0), Q(q*4+1), Q(q*4+2));
   }
   return true;
 }

--- a/include/igl/forward_kinematics.cpp
+++ b/include/igl/forward_kinematics.cpp
@@ -81,16 +81,14 @@ IGL_INLINE void igl::forward_kinematics(
   const std::vector<Eigen::Vector3d> & dT,
   Eigen::MatrixXd & T)
 {
-  using namespace Eigen;
-  using namespace std;
-  vector< Quaterniond,aligned_allocator<Quaterniond> > vQ;
-  vector< Vector3d> vT;
+  vector< Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond> > vQ;
+  vector< Eigen::Vector3d> vT;
   forward_kinematics(C,BE,P,dQ,dT,vQ,vT);
   const int dim = C.cols();
   T.resize(BE.rows()*(dim+1),dim);
   for(int e = 0;e<BE.rows();e++)
   {
-    Affine3d a = Affine3d::Identity();
+    Eigen::Affine3d a = Eigen::Affine3d::Identity();
     a.translate(vT[e]);
     a.rotate(vQ[e]);
     T.block(e*(dim+1),0,dim+1,dim) =

--- a/include/igl/opengl/ViewerCore.cpp
+++ b/include/igl/opengl/ViewerCore.cpp
@@ -494,14 +494,12 @@ IGL_INLINE void igl::opengl::ViewerCore::draw_labels(
 IGL_INLINE void igl::opengl::ViewerCore::set_rotation_type(
   const igl::opengl::ViewerCore::RotationType & value)
 {
-  using namespace Eigen;
-  using namespace std;
   const RotationType old_rotation_type = rotation_type;
   rotation_type = value;
   if(rotation_type == ROTATION_TYPE_TWO_AXIS_VALUATOR_FIXED_UP &&
     old_rotation_type != ROTATION_TYPE_TWO_AXIS_VALUATOR_FIXED_UP)
   {
-    snap_to_fixed_up(Quaternionf(trackball_angle),trackball_angle);
+    snap_to_fixed_up(Eigen::Quaternionf(trackball_angle),trackball_angle);
   }
 }
 

--- a/include/igl/snap_to_fixed_up.cpp
+++ b/include/igl/snap_to_fixed_up.cpp
@@ -12,7 +12,6 @@ IGL_INLINE void igl::snap_to_fixed_up(
   const Eigen::Quaternion<Qtype> & q,
   Eigen::Quaternion<Qtype> & s)
 {
-  using namespace Eigen;
   typedef Eigen::Matrix<Qtype,3,1> Vector3Q;
   const Vector3Q up = q.matrix() * Vector3Q(0,1,0);
   Vector3Q proj_up(0,up(1),up(2));
@@ -21,8 +20,8 @@ IGL_INLINE void igl::snap_to_fixed_up(
     proj_up = Vector3Q(0,1,0);
   }
   proj_up.normalize();
-  Quaternion<Qtype> dq;
-  dq = Quaternion<Qtype>::FromTwoVectors(up,proj_up);
+  Eigen::Quaternion<Qtype> dq;
+  dq = Eigen::Quaternion<Qtype>::FromTwoVectors(up,proj_up);
   s = dq * q;
 }
 


### PR DESCRIPTION
 'Quaternion' symbol error (C2872)

Fixes # .

fix ambiguous 'Quaternion' symbol error (C2872) when using another library that also defines a 'Quaternion' class


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [x ] This is a minor change.
