### PR TITLE
Change arg to const & to avoid MSan issue.

### DIFF
--- a/include/igl/AABB.cpp
+++ b/include/igl/AABB.cpp
@@ -787,7 +787,7 @@ template <typename DerivedV, int DIM>
 IGL_INLINE void igl::AABB<DerivedV,DIM>::set_min(
   const RowVectorDIMS & /* p */,
   const Scalar sqr_d_candidate,
-  const int i_candidate,
+  const int & i_candidate,
   const RowVectorDIMS & c_candidate,
   Scalar & sqr_d,
   int & i,

--- a/include/igl/AABB.h
+++ b/include/igl/AABB.h
@@ -451,7 +451,7 @@ private:
       IGL_INLINE void set_min(
         const RowVectorDIMS & p,
         const Scalar sqr_d_candidate,
-        const int i_candidate,
+        const int & i_candidate,
         const RowVectorDIMS & c_candidate,
         Scalar & sqr_d,
         int & i,


### PR DESCRIPTION
I'm trying to make my code run fine through MemorySanitizer. I'm running into a case where the `look_left/right` routines might call `set_min()` with an uninitialized `i_left/i_right` index. This is fine because `set_min()` is called with `sqr_d_candidate == sqr_d`, so the uninitialized index is never assigned. But changing the arg to a `const &` avoids reading the value from memory and thus makes MemorySanitizer happy.