### PR TITLE
fix the unstable behaviors near 0/0 case for solid_angle

### DIFF
--- a/include/igl/solid_angle.cpp
+++ b/include/igl/solid_angle.cpp
@@ -1,4 +1,5 @@
 #include "solid_angle.h"
+#include "EPS.h"
 #include "PI.h"
 #include <cmath>
 
@@ -47,11 +48,19 @@ IGL_INLINE typename DerivedA::Scalar igl::solid_angle(
   dp(2) += v(0,2)*v(1,2);
   // Compute winding number
   // Only divide by TWO_PI instead of 4*pi because there was a 2 out front
-  return atan2(detf,
-    vl(0)*vl(1)*vl(2) + 
+
+  SType denom = vl(0)*vl(1)*vl(2) + 
     dp(0)*vl(0) +
     dp(1)*vl(1) +
-    dp(2)*vl(2)) / (2.*igl::PI);
+    dp(2)*vl(2);
+
+  SType epsilon = igl::EPS<SType>();
+  // Deal with the near 0/0 case
+  if(std::abs(detf) < epsilon && denom < epsilon)
+  {
+    return 0;
+  }
+  return atan2(detf, denom) / (2.*igl::PI);
 }
 
 #ifdef IGL_STATIC_LIBRARY


### PR DESCRIPTION
The behavior of `atan2` near `0/0` case is quite unstable.

![image](https://github.com/user-attachments/assets/572a2fae-9faa-48fb-b8d8-8fc53a6511af)

<details>
<summary>a few example</summary>

```
atan2(-0.00000000000000000000, -0.00000403378846390558)= -3.141592653589793
atan2(-0.00000000000000000000, -0.00000528650485294624)= -3.141592653589793
atan2(-0.00000000000000000003, +0.00000000000000000000)= -1.5079564545022566
atan2(-0.00000000000000000003, -0.00000000000000000000)= -1.6473294479578564
atan2(-0.00000000000000000003, +0.00000000000000000006)= -0.44851603376193294
atan2(-0.00000000000000000005, -0.00000000000000000005)= -2.398958091182285
atan2(+0.00000000000000000000, -0.00000000000000000002)= +3.1295498649557034
atan2(+0.00000000000000000000, -0.00000000000000000004)= +3.096372460507602
atan2(+0.00000000000000000000, +0.00000000000000000000)= +0.34378175816836326
atan2(-0.00000000000000000000, +0.00000000000000000000)= -0.035140020050839514
atan2(+0.00000000000000000000, +0.00000000000000000004)= +0.01790435575787559
atan2(-0.00000000000000000001, +0.00000000000000000004)= -0.30173991360976155
atan2(-0.00000000000000000003, -0.00000000000000000003)= -2.484463990630566
atan2(+0.00000000000000000000, +0.00000000000000000002)= +0.009791925164900555
atan2(-0.00000000000000000000, -0.00000410768488499489)= -3.141592653589793
atan2(+0.00000000000000000000, -0.00000532385751561421)= +3.141592653589793
atan2(-0.00000000000000000003, +0.00000000000000000002)= -0.8604932831619532
atan2(-0.00000000000000000002, -0.00000000000000000002)= -2.4421088999637695
atan2(+0.00000000000000000001, -0.00000000000000000002)= +2.7731563142633284
atan2(+0.00000000000000000002, +0.00000000000000000002)= +0.7184190962975814
atan2(-0.00000000000000000000, -0.00000377411816018241)= -3.141592653589793
atan2(+0.00000000000000000000, -0.00000527821738303945)= +3.141592653589793
atan2(-0.00000000000000000002, +0.00000000000000000000)= -1.5562111123162774
atan2(-0.00000000000000000002, +0.00000000000000000000)= -1.5076959760034765
atan2(-0.00000000000000000003, -0.00000000000000000000)= -1.7264547882811867
```

</details>

This will cause problems when the query points are close enough to the surface when computing the winding numbers. (Left: w/o this PR, Right: w/ this PR)

![image](https://github.com/user-attachments/assets/a4619a0c-0562-43fc-87e5-52def1f9a408)

While the value of WN is somehow not well-defined on the surface, at least this can avoid these `-0.5` `1.5` values. 
![image](https://github.com/user-attachments/assets/b0622e4d-cc61-4f5e-86ab-ba8f882b6605)


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
