### PR TITLE
bump cgal; boost; mpf4; (mpfr+gmp may no longer be needed)

### DIFF
--- a/cmake/recipes/external/boost.cmake
+++ b/cmake/recipes/external/boost.cmake
@@ -4,32 +4,22 @@ endif()
 
 message(STATUS "Third-party: creating targets 'Boost::boost'...")
 
+cmake_minimum_required(VERSION 3.24) # Ensure modern FetchContent features
+project(BoostFetchExample)
+
 include(FetchContent)
+
+# Define the Boost library to fetch
 FetchContent_Declare(
-    boost-cmake
-    GIT_REPOSITORY https://github.com/libigl/boost-cmake.git
-    GIT_TAG 6bcae68ffbaaefad4583a2642ce9ea53e5e01707
+    Boost
+    URL https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.gz
+    URL_HASH MD5=ac857d73bb754b718a039830b07b9624
 )
+# Fetch Boost
+FetchContent_MakeAvailable(Boost)
 
-set(PREVIOUS_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-set(OLD_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-# This guy will download boost using FetchContent
-FetchContent_GetProperties(boost-cmake)
-if(NOT boost-cmake_POPULATED)
-    FetchContent_Populate(boost-cmake)
-    # File lcid.cpp from Boost_locale.cpp doesn't compile on MSVC, so we exclude them from the default
-    # targets being built by the project (only targets explicitly used by other targets will be built).
-    add_subdirectory(${boost-cmake_SOURCE_DIR} ${boost-cmake_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
-
-set(CMAKE_POSITION_INDEPENDENT_CODE ${OLD_CMAKE_POSITION_INDEPENDENT_CODE})
-set(CMAKE_CXX_FLAGS "${PREVIOUS_CMAKE_CXX_FLAGS}")
-
-# Set VS target folders
-set(boost_modules
+# Add Boost libraries needed for your project
+set(BOOST_LIBRARIES
     container
     regex
     atomic
@@ -55,10 +45,10 @@ set(boost_modules
     system
     thread
     type_erasure
-)
-foreach(module IN ITEMS ${boost_modules})
-    if(TARGET Boost_${module})
-        set_target_properties(Boost_${module} PROPERTIES FOLDER ThirdParty/Boost)
-    endif()
-endforeach()
+  )
 
+foreach(lib IN LISTS BOOST_LIBRARIES)
+    add_library(boost_${lib} INTERFACE)
+    target_include_directories(boost_${lib} INTERFACE ${Boost_SOURCE_DIR})
+    target_link_libraries(boost_${lib} INTERFACE Boost::${lib})
+endforeach()

--- a/cmake/recipes/external/cgal.cmake
+++ b/cmake/recipes/external/cgal.cmake
@@ -7,8 +7,8 @@ message(STATUS "Third-party: creating target 'CGAL::CGAL'")
 include(FetchContent)
 FetchContent_Declare(
     cgal
-    URL https://github.com/CGAL/cgal/releases/download/v5.6/CGAL-5.6-library.tar.xz
-    URL_MD5 793da2d1597f3a5c0e3524f73a0b4039
+    URL https://github.com/CGAL/cgal/releases/download/v6.0.1/CGAL-6.0.1-library.tar.xz
+    URL_MD5 ea827f6778063e00554ae41f4c845492
 )
 FetchContent_GetProperties(cgal)
 if(cgal_POPULATED)

--- a/cmake/recipes/external/mpfr.cmake
+++ b/cmake/recipes/external/mpfr.cmake
@@ -51,8 +51,8 @@ else()
   ExternalProject_Add(mpfr
     PREFIX ${prefix}
     DEPENDS gmp
-    URL  https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.0.tar.xz
-    URL_MD5 a25091f337f25830c16d2054d74b5af7
+    URL  https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.1.tar.xz
+    URL_MD5 523c50c6318dde6f9dc523bc0244690a
     UPDATE_DISCONNECTED true  # need this to avoid constant rebuild
     ${mpfr_ExternalProject_Add_extra_options} # avoid constant reconfigure
     CONFIGURE_COMMAND 


### PR DESCRIPTION
Boost/mpfr could be causing some shinanigans on the python bindings build. Both are pretty out of date. If this builds smoothly on CI, I might also try to remove MPFR+GMP entirely since CGAL 6.0 only needs Boost Multiprecision.

Bumping boost previously caused chaos but I forgot why. Hope I don't hit that again.