### PR TITLE
Add missing include <cassert> in AABB.h

### DIFF
--- a/include/igl/AABB.h
+++ b/include/igl/AABB.h
@@ -10,6 +10,7 @@
 
 #include "Hit.h"
 #include "igl_inline.h"
+#include <cassert>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <vector>


### PR DESCRIPTION
This fixes a build error on g++-14 RISC-V toolchain. Just a missing include.
