### PR TITLE
Update voxel_grid.h documentation

### DIFF
--- a/include/igl/voxel_grid.h
+++ b/include/igl/voxel_grid.h
@@ -31,7 +31,10 @@ namespace igl
     Eigen::PlainObjectBase<DerivedGV> & GV,
     Eigen::PlainObjectBase<Derivedside> & side);
   /// \overload
-  /// @param[in]  offset  offset to add to each cell center
+  /// Constructs the voxel grid to fit around a given set of points.
+  ///
+  /// @param[in] V  points that must lie within the grid
+  /// @param[in] offset  distance to pad each side of V's bounding box when determining the extents of the voxel grid.
   template <
     typename DerivedV,
     typename DerivedGV,


### PR DESCRIPTION
Clarify the documentation of `voxel_grid.h`. The `offset` parameter does something different (and more useful) than the current documentation suggests.

#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
