### PR TITLE
laplace equation tutorial - fixed bug with slice/lazy eval

### DIFF
--- a/tutorial/303_LaplaceEquation/main.cpp
+++ b/tutorial/303_LaplaceEquation/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   // Solve PDE
   SimplicialLLT<SparseMatrix<double > > solver(-L_in_in);
   // slice into solution
-  Z(in) = solver.solve(L_in_b*bc);
+  Z(in) = solver.solve(L_in_b*bc).eval();
 
   // Alternative, short hand
   igl::min_quad_with_fixed_data<double> mqwf;


### PR DESCRIPTION
Fixes Laplace equation tutorial code for the linear solver approach.

Need to comment out the alternate method for the quadratic energy minimization approach (`igl::min_quad_*`) to expose bug.

Corresponds to [Chapter 3: Matrices And Linear Algebra > Laplace Equation](https://libigl.github.io/tutorial/#laplace-equation).

Bugged camel head:
![laplace-bugged](https://github.com/user-attachments/assets/90dd162d-26e7-4d45-859b-b22b2d390596)

Fixed camel head:
![laplace-fixed](https://github.com/user-attachments/assets/522d55ee-22a4-44cc-bb91-eac1a0c4f65a)


#### Checklist

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
