### PR TITLE
Use box-drawing characters in comments.

### DIFF
--- a/include/igl/AABB.cpp
+++ b/include/igl/AABB.cpp
@@ -59,11 +59,11 @@ namespace
       using Scalar = typename DerivedV::Scalar;
       const Scalar epsilon = igl::EPS<Scalar>();
       static_assert(
-        DerivedV::ColsAtCompileTime == 2 || 
+        DerivedV::ColsAtCompileTime == 2 ||
         DerivedV::ColsAtCompileTime == Eigen::Dynamic,
         "V should be 2D");
       static_assert(
-        Derivedq::ColsAtCompileTime == 2 || 
+        Derivedq::ColsAtCompileTime == 2 ||
         Derivedq::ColsAtCompileTime == Eigen::Dynamic,
         "q should be 2D");
       // Barycentric coordinates
@@ -107,11 +107,11 @@ namespace
       using Scalar = typename DerivedV::Scalar;
       const Scalar epsilon = igl::EPS<Scalar>();
       static_assert(
-        DerivedV::ColsAtCompileTime == 3 || 
+        DerivedV::ColsAtCompileTime == 3 ||
         DerivedV::ColsAtCompileTime == Eigen::Dynamic,
         "V should be 2D");
       static_assert(
-        Derivedq::ColsAtCompileTime == 3 || 
+        Derivedq::ColsAtCompileTime == 3 ||
         Derivedq::ColsAtCompileTime == Eigen::Dynamic,
         "q should be 2D");
       // Barycentric coordinates
@@ -182,9 +182,9 @@ IGL_INLINE igl::AABB<DerivedV,DIM>* igl::AABB<DerivedV,DIM>::detach()
   assert(sibling);
   // Before
   //     grandparent
-  //        /
+  //        ╱
   //     parent
-  //     /    \
+  //     ╱    ╲
   // sibling  this
   //
   // After
@@ -204,7 +204,7 @@ IGL_INLINE igl::AABB<DerivedV,DIM>* igl::AABB<DerivedV,DIM>::detach()
   // Tell grandparent sibling is new child.
   if(grandparent)
   {
-    (grandparent->m_left == parent ? 
+    (grandparent->m_left == parent ?
       grandparent->m_left : grandparent->m_right) = sibling;
   }
   // Did your code just crash here? Perhaps it's because you statically
@@ -235,7 +235,7 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::refit_lineage()
 }
 
 template <typename DerivedV, int DIM>
-IGL_INLINE std::vector<igl::AABB<DerivedV,DIM>*> 
+IGL_INLINE std::vector<igl::AABB<DerivedV,DIM>*>
   igl::AABB<DerivedV,DIM>::gather_leaves(const int m)
 {
   auto * tree = this;
@@ -261,7 +261,7 @@ IGL_INLINE std::vector<igl::AABB<DerivedV,DIM>*>
 }
 
 template <typename DerivedV, int DIM>
-IGL_INLINE std::vector<igl::AABB<DerivedV,DIM>*> 
+IGL_INLINE std::vector<igl::AABB<DerivedV,DIM>*>
   igl::AABB<DerivedV,DIM>::gather_leaves()
 {
   int max_primitive = -1;
@@ -340,16 +340,16 @@ IGL_INLINE igl::AABB<DerivedV,DIM>* igl::AABB<DerivedV,DIM>::insert_as_sibling(A
   //        parent
   //          |
   //        this(C)
-  //        /  \
+  //        ╱  ╲
   //      left right
   //
   // After
   //        parent
   //          |
   //         newbie
-  //        /   \
+  //        ╱   ╲
   //     this    other
-  //     /    \
+  //     ╱    ╲
   //   left  right
   //
 
@@ -383,11 +383,11 @@ IGL_INLINE typename DerivedV::Scalar igl::AABB<DerivedV,DIM>::rotate(const bool 
   // ever returns true.
   //
   //        grandparent
-  //        /         \
+  //        ╱         ╲
   //     parent       pibling°
-  //     /    \         /    \
+  //     ╱    ╲         ╱    ╲
   // sibling  this   cuz1°  cuz2°
-  //  /    \
+  //  ╱    ╲
   // nib1° nib2°
 
   // There is a _ton_ of repeated computation of surface areas and new-boxes in
@@ -418,24 +418,24 @@ IGL_INLINE typename DerivedV::Scalar igl::AABB<DerivedV,DIM>::rotate_across(cons
 {
   // Before
   //        grandparent
-  //        /         \
+  //        ╱         ╲
   //     parent       pibling
-  //     /    \         /    \
+  //     ╱    ╲         ╱    ╲
   // sibling  this    cuz1  cuz2
   //
   //
   // Candidates
   //        grandparent
-  //        /         \
+  //        ╱         ╲
   //     parent       pibling
-  //     /    \         /    \
+  //     ╱    ╲         ╱    ╲
   // sibling  cuz1   this   cuz2
   //
   // Or
   //        grandparent
-  //        /         \
+  //        ╱         ╲
   //     parent       pibling
-  //     /    \         /    \
+  //     ╱    ╲         ╱    ╲
   // sibling  cuz2    cuz1  this
 
   auto * parent = this->m_parent;
@@ -456,17 +456,17 @@ IGL_INLINE typename DerivedV::Scalar igl::AABB<DerivedV,DIM>::rotate_across(cons
   {
     // Before
     //        grandparent
-    //        /         \
+    //        ╱         ╲
     //     parent       pibling
-    //     /    \         /    \
+    //     ╱    ╲         ╱    ╲
     // sibling  this    cuz  other_cuz
     //
     //
     // Candidates
     //        grandparent
-    //        /         \
+    //        ╱         ╲
     //     parent       pibling
-    //     /    \         /    \
+    //     ╱    ╲         ╱    ╲
     // sibling  cuz   this   other_cuz
     if(!cuz){ return 0.0; }
 
@@ -475,7 +475,7 @@ IGL_INLINE typename DerivedV::Scalar igl::AABB<DerivedV,DIM>::rotate_across(cons
     new_parent_box.extend(cuz->m_box);
     Eigen::AlignedBox<Scalar,DIM> new_pibling_box = this->m_box;
     if(other_cuz) { new_pibling_box.extend(other_cuz->m_box); }
-    const Scalar new_sa = 
+    const Scalar new_sa =
       box_surface_area(new_parent_box) + box_surface_area(new_pibling_box);
     if(current_sa <= new_sa)
     {
@@ -514,17 +514,17 @@ IGL_INLINE typename DerivedV::Scalar igl::AABB<DerivedV,DIM>::rotate_up(const bo
 {
   // Before
   //    grandparent
-  //       /    \
+  //       ╱    ╲
   //     other  parent
-  //            /  \
+  //            ╱  ╲
   //         this  sibling
-  //         
+  //
   //
   // Candidate
   //    grandparent
-  //       /    \
+  //       ╱    ╲
   //    this    parent
-  //            /  \
+  //            ╱  ╲
   //        other  sibling
   //
   auto * challenger = this;
@@ -544,26 +544,26 @@ IGL_INLINE typename DerivedV::Scalar igl::AABB<DerivedV,DIM>::rotate_down(const 
 {
   // Before
   //       parent
-  //       /    \
+  //       ╱    ╲
   //     this   sibling
-  //            /  \
+  //            ╱  ╲
   //         left  right
-  //         
+  //
   //
   // Candidates
   //       parent
-  //       /    \
+  //       ╱    ╲
   //   left     sibling
-  //            /  \
+  //            ╱  ╲
   //        this   right
   //
   // Or
   //
   //       parent
-  //       /    \
+  //       ╱    ╲
   //   right    sibling
-  //            /  \
-  //        left   this 
+  //            ╱  ╲
+  //        left   this
   auto * parent = this->m_parent;
   if(!parent) { return false; }
   auto * sibling = parent->m_left == this ? parent->m_right : parent->m_left;
@@ -596,17 +596,17 @@ IGL_INLINE typename DerivedV::Scalar igl::AABB<DerivedV,DIM>::rotate_up(
   if(!sibling) { return false; }
   // Before
   //    grandparent
-  //       /      \
+  //       ╱      ╲
   //  reining      parent
-  //               /    \
+  //               ╱    ╲
   //        challenger  sibling
-  //         
+  //
   //
   // Candidate
   //    grandparent
-  //       /      \
+  //       ╱      ╲
   // challenger    parent
-  //               /    \
+  //               ╱    ╲
   //          reining   sibling
   //
 
@@ -614,7 +614,7 @@ IGL_INLINE typename DerivedV::Scalar igl::AABB<DerivedV,DIM>::rotate_up(
   // Sibling doesn't actually need to exist but probably should if parent is a
   // true internal node.
   if(sibling)
-  { 
+  {
     sibling_sa = box_surface_area(sibling->m_box);
   }
 
@@ -724,7 +724,7 @@ IGL_INLINE typename DerivedV::Scalar igl::AABB<DerivedV,DIM>::internal_surface_a
 }
 
 template <typename DerivedV, int DIM>
-IGL_INLINE void igl::AABB<DerivedV,DIM>::validate() const 
+IGL_INLINE void igl::AABB<DerivedV,DIM>::validate() const
 {
   if(this->is_leaf())
   {
@@ -771,8 +771,8 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::print(const int depth) const
 template <typename DerivedV, int DIM>
 IGL_INLINE int igl::AABB<DerivedV,DIM>::size() const
 {
-  return 1 + 
-    (this->m_left ? this->m_left ->size():0) + 
+  return 1 +
+    (this->m_left ? this->m_left ->size():0) +
     (this->m_right? this->m_right->size():0);
 }
 template <typename DerivedV, int DIM>
@@ -1005,11 +1005,11 @@ IGL_INLINE igl::AABB<DerivedV,DIM>* igl::AABB<DerivedV,DIM>::insert(AABB * other
 {
   // test if this is the same pointer as other
   if(this == other)
-  { 
+  {
     // Only expecting this to happen when this/other are a singleton tree
     assert(this->is_root() && this->is_leaf());
     // Nothing changed.
-    return this; 
+    return this;
   }
 
 
@@ -1030,9 +1030,9 @@ IGL_INLINE igl::AABB<DerivedV,DIM>* igl::AABB<DerivedV,DIM>::insert(AABB * other
   left_grow.extend(other->m_box);
   Eigen::AlignedBox<Scalar,DIM> right_grow = this->m_right->m_box;
   right_grow.extend(other->m_box);
-  const auto left_surface_area_increase =  
+  const auto left_surface_area_increase =
     box_surface_area(left_grow) - box_surface_area(this->m_left->m_box);
-  const auto right_surface_area_increase = 
+  const auto right_surface_area_increase =
     box_surface_area(right_grow) - box_surface_area(this->m_right->m_box);
   assert(left_surface_area_increase >= 0);
   assert(right_surface_area_increase >= 0);
@@ -1564,7 +1564,7 @@ template <
   typename DerivedUV>
 IGL_INLINE void igl::AABB<DerivedV,DIM>::intersect_ray(
   const Eigen::MatrixBase<DerivedV> & V,
-  const Eigen::MatrixBase<DerivedEle> & Ele, 
+  const Eigen::MatrixBase<DerivedEle> & Ele,
   const Eigen::MatrixBase<DerivedOrigin> & origin,
   const Eigen::MatrixBase<DerivedDir> & dir,
   const Scalar min_t,
@@ -1599,7 +1599,7 @@ template <
   typename DerivedDir>
 IGL_INLINE void igl::AABB<DerivedV,DIM>::intersect_ray(
   const Eigen::MatrixBase<DerivedV> & V,
-  const Eigen::MatrixBase<DerivedEle> & Ele, 
+  const Eigen::MatrixBase<DerivedEle> & Ele,
   const Eigen::MatrixBase<DerivedOrigin> & origin,
   const Eigen::MatrixBase<DerivedDir> & dir,
   std::vector<std::vector<igl::Hit<typename DerivedV::Scalar>>> & hits)

--- a/include/igl/AABB.h
+++ b/include/igl/AABB.h
@@ -1,9 +1,9 @@
 // This file is part of libigl, a simple c++ geometry processing library.
-// 
+//
 // Copyright (C) 2015 Alec Jacobson <alecjacobson@gmail.com>
-// 
-// This Source Code Form is subject to the terms of the Mozilla Public License 
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 #ifndef IGL_AABB_H
 #define IGL_AABB_H
@@ -27,7 +27,7 @@ namespace igl
   /// @tparam DerivedV  Matrix type of vertex positions (e.g., `Eigen::MatrixXd`)
   /// @tparam DIM Dimension of mesh vertex positions (2 or 3)
   template <typename DerivedV, int DIM>
-    class AABB 
+    class AABB
     {
 public:
 ///////////////////////////////////////////////////////////////////////////////
@@ -43,7 +43,7 @@ public:
       typedef Eigen::Matrix<Scalar,Eigen::Dynamic,DIM> MatrixXDIMS;
       /// Pointer to "left" child node (`nullptr` if leaf)
       // Shared pointers are slower...
-      AABB * m_left; 
+      AABB * m_left;
       /// Pointer to "right" child node (`nullptr` if leaf)
       AABB * m_right;
       /// Pointer to "parent" node (`nullptr` if root)
@@ -106,7 +106,7 @@ public:
       /// @private
       AABB(AABB&& other):
         // initialize via default constructor
-        AABB() 
+        AABB()
       {
         swap(*this,other);
       }
@@ -139,25 +139,25 @@ public:
           {
             // Before
             //     grandparent
-            //        /    \
+            //        ╱     ╲
             //    parent   pibling
-            //      /   \
+            //      ╱    ╲
             // sibling  this
             //
-            // After 
+            // After
             //     grandparent
-            //        /    \
+            //        ╱     ╲
             //    sibling®  pibling
           }else
           {
             // Before
             //    parent=root
-            //      /   \
+            //      ╱    ╲
             // sibling  this
             //
-            // After 
+            // After
             //     grandparent
-            //        /    \
+            //        ╱     ╲
             //    sibling®  pibling
           }
         }
@@ -190,7 +190,7 @@ public:
       /// @returns pointer to (potentially new) root
       IGL_INLINE AABB<DerivedV,DIM>* pad(
         const std::vector<AABB<DerivedV,DIM>*> & leaves,
-        const Scalar pad, 
+        const Scalar pad,
         const int polish_rotate_passes=0);
       /// @returns `this` if no update was needed, otherwise returns pointer to
       /// (potentially new) root
@@ -216,7 +216,7 @@ public:
       /// `other`'s box is contained in this AABB's box then insert it as a child recursively.
       ///
       /// If `other`'s box is not contained in this AABB's box then insert it as a
-      /// sibling. 
+      /// sibling.
       ///
       /// It's a very good idea to call either `rotate` (faster, less good) or `rotate_lineage` (slower, better)
       /// after insertion. Rotating continues to improve the tree's quality so
@@ -228,14 +228,14 @@ public:
       /// longest dimension. When initializing a tree, `init` seems to result in
       /// great trees (small height and small total internal surface area).
       ///
-      /// @param[in] other pointer to another AABB node 
+      /// @param[in] other pointer to another AABB node
       /// @returns pointer to the parent of `other` or `other` itself. This
       /// could be == to a `new`ly created internal node or to `other` if
       /// `this==other`. Calling ->root() on this returned node will give you
       /// the root of the tree.
       ///
       /// ##### Example
-      /// 
+      ///
       /// ```cpp
       /// // Create a tree (use pointer to track changes to root)
       /// auto * tree = new igl::AABB<DerivedV,3>::AABB();
@@ -254,34 +254,34 @@ public:
       ///
       ///     Before
       ///              parent
-      ///              /    \
+      ///              ╱     ╲
       ///          this(C)  sibling
-      ///            /  \
+      ///            ╱   ╲
       ///          left right
-      ///    
+      ///
       ///     After
       ///              parent
-      ///              /    \
+      ///              ╱     ╲
       ///           newbie   sibling
-      ///            /   \
+      ///            ╱    ╲
       ///         this    other
-      ///         /    \
+      ///         ╱     ╲
       ///       left  right
-      ///    
       ///
-      /// @param[in] other pointer to another AABB node 
+      ///
+      /// @param[in] other pointer to another AABB node
       /// @returns pointer to the new shared parent.
       IGL_INLINE AABB<DerivedV,DIM>* insert_as_sibling(AABB * other);
       /// Try to swap this node with its close relatives if it will decrease
       /// total internal surface area.
-      ///    
+      ///
       ///
       ///            grandparent
-      ///            /         \
+      ///            ╱          ╲
       ///         parent       pibling°
-      ///         /    \         /    \
+      ///         ╱     ╲          ╱     ╲
       ///     sibling  this   cuz1°  cuz2°
-      ///      /    \
+      ///      ╱     ╲
       ///     nib1° nib2°
       ///
       ///     °Swap Candidates
@@ -292,53 +292,53 @@ public:
       IGL_INLINE Scalar rotate(const bool dry_run = false);
       /// Try to swap this node with its cousins if it will decrease
       /// total internal surface area.
-      ///    
+      ///
       /// @param[in] dry_run  if true then don't actually swap
       /// @return[in] the change in total internal surface area, 0 if no
       /// improvement and rotate won't be carried out.
-      ///    
+      ///
       ///     Before
       ///            grandparent
-      ///            /         \
+      ///            ╱          ╲
       ///         parent       pibling
-      ///         /    \         /    \
+      ///         ╱     ╲          ╱     ╲
       ///     sibling  this    cuz1  cuz2
-      ///    
-      ///    
+      ///
+      ///
       ///     Candidates
       ///            grandparent
-      ///            /         \
+      ///            ╱          ╲
       ///         parent       pibling
-      ///         /    \         /    \
+      ///         ╱     ╲          ╱     ╲
       ///     sibling  cuz1   this   cuz2
-      ///    
+      ///
       ///     Or
       ///            grandparent
-      ///            /         \
+      ///            ╱          ╲
       ///         parent       pibling
-      ///         /    \         /    \
+      ///         ╱     ╲          ╱     ╲
       ///     sibling  cuz2    cuz1  this
       IGL_INLINE Scalar rotate_across(const bool dry_run = false);
       /// Try to swap this node with its pibling if it will decrease
       /// total internal surface area.
-      ///    
+      ///
       /// @param[in] dry_run  if true then don't actually swap
       /// @return[in] the change in total internal surface area, 0 if no
       /// improvement and rotate won't be carried out.
       ///
       ///     Before
       ///        grandparent
-      ///           /    \
+      ///           ╱     ╲
       ///         other  parent
-      ///                /  \
+      ///                ╱   ╲
       ///             this  sibling
-      ///             
-      ///    
+      ///
+      ///
       ///     Candidate
       ///        grandparent
-      ///           /    \
+      ///           ╱     ╲
       ///        this    parent
-      ///                /  \
+      ///                ╱   ╲
       ///            other  sibling
       IGL_INLINE Scalar rotate_up(const bool dry_run = false);
       /// Try to swap this node with one of its niblings if it will decrease
@@ -347,45 +347,45 @@ public:
       /// @param[in] dry_run  if true then don't actually swap
       /// @return[in] the change in total internal surface area, 0 if no
       /// improvement and rotate won't be carried out.
-      /// 
+      ///
       ///     Before
       ///           parent
-      ///           /    \
+      ///           ╱     ╲
       ///         this   sibling
-      ///                /  \
+      ///                ╱   ╲
       ///             left  right
-      ///             
+      ///
       ///
       ///     Candidates
       ///           parent
-      ///           /    \
+      ///           ╱     ╲
       ///       left     sibling
-      ///                /  \
+      ///                ╱   ╲
       ///            this   right
       ///
       ///     Or
       ///
       ///           parent
-      ///           /    \
+      ///           ╱     ╲
       ///       right    sibling
-      ///                /  \
-      ///            left   this 
+      ///                ╱   ╲
+      ///            left   this
       IGL_INLINE Scalar rotate_down(const bool dry_run = false);
       /// "Rotate" (swap) `reining` with `challenger`.
       ///
       ///     Before
       ///        grandparent
-      ///           /      \
+      ///           ╱       ╲
       ///      reining      parent
-      ///                   /    \
+      ///                   ╱     ╲
       ///            challenger  sibling
-      ///             
-      ///    
+      ///
+      ///
       ///     Candidate
       ///        grandparent
-      ///           /      \
+      ///           ╱       ╲
       ///     challenger    parent
-      ///                   /    \
+      ///                   ╱     ╲
       ///              reining   sibling
       /// @param[in] reining  pointer to AABB node to be rotated
       /// @param[in] grandparent  pointer to challenger's grandparent
@@ -427,7 +427,7 @@ public:
       IGL_INLINE void print(const int depth = 0) const;
       /// @returns Actual size of tree. Total number of nodes in tree. A singleton root
       /// has size 1.
-      /// 
+      ///
       /// \see subtree_size
       IGL_INLINE int size() const;
       /// @returns Height of the tree. A singleton root has height 1.
@@ -464,8 +464,8 @@ public:
       /// Build an Axis-Aligned Bounding Box tree for a given mesh and given
       /// serialization of a previous AABB tree.
       ///
-      /// @param[in] V  #V by dim list of mesh vertex positions. 
-      /// @param[in] Ele  #Ele by dim+1 list of mesh indices into #V. 
+      /// @param[in] V  #V by dim list of mesh vertex positions.
+      /// @param[in] Ele  #Ele by dim+1 list of mesh indices into #V.
       /// @param[in] bb_mins  max_tree by dim list of bounding box min corner
       ///   positions
       /// @param[in] bb_maxs  max_tree by dim list of bounding box max corner
@@ -474,13 +474,13 @@ public:
       ///   into Ele
       /// @param[in] i  recursive call index {0}
       template <
-        typename DerivedEle, 
-        typename Derivedbb_mins, 
+        typename DerivedEle,
+        typename Derivedbb_mins,
         typename Derivedbb_maxs,
         typename Derivedelements>
         IGL_INLINE void init(
             const Eigen::MatrixBase<DerivedV> & V,
-            const Eigen::MatrixBase<DerivedEle> & Ele, 
+            const Eigen::MatrixBase<DerivedEle> & Ele,
             const Eigen::MatrixBase<Derivedbb_mins> & bb_mins,
             const Eigen::MatrixBase<Derivedbb_maxs> & bb_maxs,
             const Eigen::MatrixBase<Derivedelements> & elements,
@@ -488,27 +488,27 @@ public:
       /// Build an Axis-Aligned Bounding Box tree for a given mesh and given
       /// serialization of a previous AABB tree.
       ///
-      /// @param[in] V  #V by dim list of mesh vertex positions. 
-      /// @param[in] Ele  #Ele by dim+1 list of mesh indices into #V. 
+      /// @param[in] V  #V by dim list of mesh vertex positions.
+      /// @param[in] Ele  #Ele by dim+1 list of mesh indices into #V.
       template <typename DerivedEle>
       IGL_INLINE void init(
           const Eigen::MatrixBase<DerivedV> & V,
           const Eigen::MatrixBase<DerivedEle> & Ele);
       /// Build an Axis-Aligned Bounding Box tree for a given mesh.
       ///
-      /// @param[in] V  #V by dim list of mesh vertex positions. 
-      /// @param[in] Ele  #Ele by dim+1 list of mesh indices into #V. 
+      /// @param[in] V  #V by dim list of mesh vertex positions.
+      /// @param[in] Ele  #Ele by dim+1 list of mesh indices into #V.
       /// @param[in] SI  #Ele by dim list revealing for each coordinate where
       ///   Ele's barycenters would be sorted: SI(e,d) = i --> the dth
       ///   coordinate of the barycenter of the eth element would be placed at
       ///   position i in a sorted list.
       /// @param[in] I  #I list of indices into Ele of elements to include (for
       ///   recursive calls)
-      /// 
+      ///
       template <typename DerivedEle, typename DerivedSI, typename DerivedI>
       IGL_INLINE void init(
           const Eigen::MatrixBase<DerivedV> & V,
-          const Eigen::MatrixBase<DerivedEle> & Ele, 
+          const Eigen::MatrixBase<DerivedEle> & Ele,
           const Eigen::MatrixBase<DerivedSI> & SI,
           const Eigen::MatrixBase<DerivedI>& I);
       /// @returns `this` if no update was needed, otherwise returns pointer to
@@ -532,7 +532,7 @@ public:
       template <typename DerivedEle, typename Derivedq>
       IGL_INLINE std::vector<int> find(
           const Eigen::MatrixBase<DerivedV> & V,
-          const Eigen::MatrixBase<DerivedEle> & Ele, 
+          const Eigen::MatrixBase<DerivedEle> & Ele,
           const Eigen::MatrixBase<Derivedq> & q,
           const bool first=false) const;
 
@@ -546,7 +546,7 @@ public:
       ///   indices into Ele
       /// @param[in]  i  recursive call index into these arrays {0}
       template <
-        typename Derivedbb_mins, 
+        typename Derivedbb_mins,
         typename Derivedbb_maxs,
         typename Derivedelements>
         IGL_INLINE void serialize(
@@ -558,7 +558,7 @@ public:
       ///
       /// @param[in]  V  #V by dim list of vertex positions
       /// @param[in]  Ele  #Ele by dim list of simplex indices
-      /// @param[in]  p  dim-long query point 
+      /// @param[in]  p  dim-long query point
       /// @param[out]  i  facet index corresponding to smallest distances
       /// @param[out]  c  closest point
       /// @return squared distance
@@ -568,7 +568,7 @@ public:
       template <typename DerivedEle>
       IGL_INLINE Scalar squared_distance(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const RowVectorDIMS & p,
         int & i,
         Eigen::PlainObjectBase<RowVectorDIMS> & c) const;
@@ -577,9 +577,9 @@ public:
       ///
       /// @param[in] V  #V by dim list of vertex positions
       /// @param[in] Ele  #Ele by dim list of simplex indices
-      /// @param[in] p  dim-long query point 
+      /// @param[in] p  dim-long query point
       /// @param[in] low_sqr_d  lower bound on squared distance, specified
-      ///   maximum squared distance 
+      ///   maximum squared distance
       /// @param[in] up_sqr_d  current upper bounded on squared distance,
       ///   current minimum squared distance (only consider distances less than
       ///   this), see output.
@@ -592,7 +592,7 @@ public:
       template <typename DerivedEle>
       IGL_INLINE Scalar squared_distance(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const RowVectorDIMS & p,
         const Scalar low_sqr_d,
         const Scalar up_sqr_d,
@@ -602,7 +602,7 @@ public:
       ///
       /// @param[in] V  #V by dim list of vertex positions
       /// @param[in] Ele  #Ele by dim list of simplex indices
-      /// @param[in] p  dim-long query point 
+      /// @param[in] p  dim-long query point
       /// @param[in] up_sqr_d  current upper bounded on squared distance,
       ///   current minimum squared distance (only consider distances less than
       ///   this), see output.
@@ -613,7 +613,7 @@ public:
       template <typename DerivedEle>
       IGL_INLINE Scalar squared_distance(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const RowVectorDIMS & p,
         const Scalar up_sqr_d,
         int & i,
@@ -629,7 +629,7 @@ public:
       template <typename DerivedEle>
       IGL_INLINE bool intersect_ray(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const RowVectorDIMS & origin,
         const RowVectorDIMS & dir,
         std::vector<igl::Hit<typename DerivedV::Scalar>> & hits) const;
@@ -644,7 +644,7 @@ public:
       template <typename DerivedEle>
       IGL_INLINE bool intersect_ray(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const RowVectorDIMS & origin,
         const RowVectorDIMS & dir,
         igl::Hit<typename DerivedV::Scalar> & hit) const;
@@ -661,7 +661,7 @@ public:
       template <typename DerivedEle>
       IGL_INLINE bool intersect_ray(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const RowVectorDIMS & origin,
         const RowVectorDIMS & dir,
         const Scalar min_t,
@@ -670,7 +670,7 @@ public:
       ///
       /// @param[in]  V  #V by dim list of vertex positions
       /// @param[in]  Ele  #Ele by dim list of simplex indices
-      /// @param[in]  origin #ray by dim+1 list of ray origins 
+      /// @param[in]  origin #ray by dim+1 list of ray origins
       /// @param[in]  dir #ray by dim list of ray directions
       /// @param[in]  min_t  minimum t value to consider
       /// @param[out]  I #ray list of indices into Ele of closest primitives
@@ -686,7 +686,7 @@ public:
         typename DerivedUV>
       IGL_INLINE void intersect_ray(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const Eigen::MatrixBase<DerivedOrigin> & origin,
         const Eigen::MatrixBase<DerivedDir> & dir,
         const Scalar min_t,
@@ -699,7 +699,7 @@ public:
         typename DerivedDir>
       IGL_INLINE void intersect_ray(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const Eigen::MatrixBase<DerivedOrigin> & origin,
         const Eigen::MatrixBase<DerivedDir> & dir,
         std::vector<std::vector<igl::Hit<typename DerivedV::Scalar>>> & hits);
@@ -715,13 +715,13 @@ public:
       /// @param[out] C  #P by dim list of closest points
       template <
         typename DerivedEle,
-        typename DerivedP, 
-        typename DerivedsqrD, 
-        typename DerivedI, 
+        typename DerivedP,
+        typename DerivedsqrD,
+        typename DerivedI,
         typename DerivedC>
       IGL_INLINE void squared_distance(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const Eigen::MatrixBase<DerivedP> & P,
         Eigen::PlainObjectBase<DerivedsqrD> & sqrD,
         Eigen::PlainObjectBase<DerivedI> & I,
@@ -739,36 +739,36 @@ public:
       /// @param[out] sqrD  #P list of squared distances
       /// @param[out] I  #P list of indices into Ele of closest primitives
       /// @param[out] C  #P by dim list of closest points
-      template < 
+      template <
         typename DerivedEle,
         typename Derivedother_V,
         typename Derivedother_Ele,
-        typename DerivedsqrD, 
-        typename DerivedI, 
+        typename DerivedsqrD,
+        typename DerivedI,
         typename DerivedC>
       IGL_INLINE void squared_distance(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const AABB<Derivedother_V,DIM> & other,
         const Eigen::MatrixBase<Derivedother_V> & other_V,
-        const Eigen::MatrixBase<Derivedother_Ele> & other_Ele, 
+        const Eigen::MatrixBase<Derivedother_Ele> & other_Ele,
         Eigen::PlainObjectBase<DerivedsqrD> & sqrD,
         Eigen::PlainObjectBase<DerivedI> & I,
         Eigen::PlainObjectBase<DerivedC> & C) const;
 private:
-      template < 
+      template <
         typename DerivedEle,
         typename Derivedother_V,
         typename Derivedother_Ele,
-        typename DerivedsqrD, 
-        typename DerivedI, 
+        typename DerivedsqrD,
+        typename DerivedI,
         typename DerivedC>
       IGL_INLINE Scalar squared_distance_helper(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const AABB<Derivedother_V,DIM> * other,
         const Eigen::MatrixBase<Derivedother_V> & other_V,
-        const Eigen::MatrixBase<Derivedother_Ele>& other_Ele, 
+        const Eigen::MatrixBase<Derivedother_Ele>& other_Ele,
         const Scalar up_sqr_d,
         Eigen::PlainObjectBase<DerivedsqrD> & sqrD,
         Eigen::PlainObjectBase<DerivedI> & I,
@@ -791,7 +791,7 @@ private:
       template <typename DerivedEle>
       IGL_INLINE void leaf_squared_distance(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const RowVectorDIMS & p,
         const Scalar low_sqr_d,
         Scalar & sqr_d,
@@ -801,7 +801,7 @@ private:
       template <typename DerivedEle>
       IGL_INLINE void leaf_squared_distance(
         const Eigen::MatrixBase<DerivedV> & V,
-        const Eigen::MatrixBase<DerivedEle> & Ele, 
+        const Eigen::MatrixBase<DerivedEle> & Ele,
         const RowVectorDIMS & p,
         Scalar & sqr_d,
         int & i,

--- a/include/igl/HalfEdgeIterator.cpp
+++ b/include/igl/HalfEdgeIterator.cpp
@@ -63,10 +63,10 @@ IGL_INLINE bool igl::HalfEdgeIterator<DerivedF,DerivedFF,DerivedFFi>::isBorder()
 /*!
  * Returns the next edge skipping the border
  *      _________
- *     /\ c | b /\
- *    /  \  |  /  \
- *   / d  \ | / a  \
- *  /______\|/______\
+ *     ╱╲ c | b ╱╲
+ *    ╱  ╲  |  ╱  ╲
+ *   ╱ d  ╲ | ╱ a  ╲
+ *  ╱______╲|╱______╲
  *          v
  * In this example, if a and d are of-border and the pos is iterating counterclockwise, this method iterate through the faces incident on vertex v,
  * producing the sequence a, b, c, d, a, b, c, ...

--- a/include/igl/HalfEdgeIterator.h
+++ b/include/igl/HalfEdgeIterator.h
@@ -69,10 +69,10 @@ namespace igl
 
     /// Change to next edge skipping the border
     ///      _________
-    ///     /\ c | b /\
-    ///    /  \  |  /  \
-    ///   / d  \ | / a  \
-    ///  /______\|/______\
+    ///     ╱╲ c | b ╱╲
+    ///    ╱  ╲  |  ╱  ╲
+    ///   ╱ d  ╲ | ╱ a  ╲
+    ///  ╱______╲|╱______╲
     ///          v
     /// In this example, if a and d are of-border and the pos is iterating
     /// counterclockwise, this method iterate through the faces incident on vertex

--- a/include/igl/circulation.cpp
+++ b/include/igl/circulation.cpp
@@ -1,9 +1,9 @@
 // This file is part of libigl, a simple c++ geometry processing library.
-// 
+//
 // Copyright (C) 2015 Alec Jacobson <alecjacobson@gmail.com>
-// 
-// This Source Code Form is subject to the terms of the Mozilla Public License 
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 #include "circulation.h"
 #include "list_to_matrix.h"
@@ -23,9 +23,9 @@ IGL_INLINE std::vector<int> igl::circulation(
   const int m = EMAP.size()/3;
   assert(m*3 == EMAP.size());
   const auto & step = [&](
-    const int e, 
+    const int e,
     const int ff,
-    int & ne, 
+    int & ne,
     int & nf)
   {
     assert((EF(e,1) == ff || EF(e,0) == ff) && "e should touch ff");
@@ -34,7 +34,7 @@ IGL_INLINE std::vector<int> igl::circulation(
     const int nv = EI(e,nside);
     // get next face
     nf = EF(e,nside);
-    // get next edge 
+    // get next edge
     const int dir = ccw?-1:1;
     ne = EMAP(nf+m*((nv+dir+3)%3));
   };
@@ -86,9 +86,9 @@ IGL_INLINE void igl::circulation(
   // for e --> (bf) and ccw=true
   //
   //     c---d
-  //    / \ / \
+  //    ╱ ╲ ╱ ╲
   //   a---b-e-f
-  //    \ / \ /
+  //    ╲ ╱ ╲ ╱
   //     g---h
   //
   //  // (might start with {bhf} depending on edge)
@@ -104,9 +104,9 @@ IGL_INLINE void igl::circulation(
   const int m = EMAP.size()/3;
   assert(m*3 == EMAP.size());
   const auto & step = [&](
-    const int e, 
+    const int e,
     const int ff,
-    int & ne, 
+    int & ne,
     //int & re,
     int & rv,
     int & nf)
@@ -117,7 +117,7 @@ IGL_INLINE void igl::circulation(
     const int nv = EI(e,nside);
     // get next face
     nf = EF(e,nside);
-    // get next edge 
+    // get next edge
     const int dir = ccw?-1:1;
     rv = F(nf,nv);
     ne = EMAP(nf+m*((nv+dir+3)%3));

--- a/include/igl/copyleft/cgal/trim_with_solid.cpp
+++ b/include/igl/copyleft/cgal/trim_with_solid.cpp
@@ -1,9 +1,9 @@
 // This file is part of libigl, a simple c++ geometry processing library.
-// 
+//
 // Copyright (C) 2016 Alec Jacobson <alecjacobson@gmail.com>
-// 
-// This Source Code Form is subject to the terms of the Mozilla Public License 
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 #include "trim_with_solid.h"
 #include "assign.h"
@@ -78,13 +78,13 @@ IGL_INLINE void igl::copyleft::cgal::trim_with_solid(
   // new triangulations on faces of A don't match those on faces of B.
   // Specifically it seems you can get T junctions:
   //
-  //             /|\
-  //            / | \
-  //           / B|  \
+  //             ╱|╲
+  //            ╱ | ╲
+  //           ╱ B|  ╲
   //           ---| A ⋅
-  //           \ B|  /
-  //            \ | /
-  //             \|/
+  //           ╲ B|  ╱
+  //            ╲ | ╱
+  //             ╲|╱
   // Probably intersect_other should not be attempting to output a single mesh
   // (i.e., when detect_only=false).
   //
@@ -120,7 +120,7 @@ IGL_INLINE void igl::copyleft::cgal::trim_with_solid(
   //
 
   MatrixX3E V;
-  const auto set_D_via_patches = 
+  const auto set_D_via_patches =
     [&V,&F,&D,&VB,&FB](const int num_patches, const Eigen::VectorXi & P)
   {
     // Aggregate representative query points for each patch
@@ -221,7 +221,7 @@ IGL_INLINE void igl::copyleft::cgal::trim_with_solid(
         VAB << VA,VB;
         Eigen::Matrix<typename DerivedFA::Scalar,Eigen::Dynamic,3> FAB(FA.rows() + FB.rows(),3);
         FAB << FA,FB.array()+VA.rows();
-        /// Sigh. Can't use this because of how it calls remove_unreferenced 
+        /// Sigh. Can't use this because of how it calls remove_unreferenced
         // remesh_self_intersections(VAB,FAB,params,V,F,IF,J);
         {
           Eigen::VectorXi I;
@@ -229,7 +229,7 @@ IGL_INLINE void igl::copyleft::cgal::trim_with_solid(
             VAB, FAB, params, V, F, IF, J, I);
           // Undo self-intersection remeshing in FA
           {
-            Eigen::Array<bool,Eigen::Dynamic,1> avoids_B = 
+            Eigen::Array<bool,Eigen::Dynamic,1> avoids_B =
               Eigen::Array<bool,Eigen::Dynamic,1>::Constant(FA.rows(),1,true);
             for(int p = 0;p<IF.rows();p++)
             {

--- a/include/igl/flip_edge.cpp
+++ b/include/igl/flip_edge.cpp
@@ -1,9 +1,9 @@
 // This file is part of libigl, a simple c++ geometry processing library.
-// 
+//
 // Copyright (C) 2016 Qingan Zhou <qnzhou@gmail.com>
-// 
-// This Source Code Form is subject to the terms of the Mozilla Public License 
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "flip_edge.h"
@@ -29,17 +29,17 @@ IGL_INLINE void igl::flip_edge(
   // Before:
   // F(f1,:) = [v1,v2,v4] // in some cyclic order
   // F(f2,:) = [v1,v3,v2] // in some cyclic order
-  // After: 
-  // F(f1,:) = [v1,v3,v4] // in *this* order 
+  // After:
+  // F(f1,:) = [v1,v3,v4] // in *this* order
   // F(f2,:) = [v2,v4,v3] // in *this* order
   //
   //          v1                 v1
-  //          /|\                / \
-  //         / | \              /f1 \
-  //     v3 /f2|f1\ v4  =>  v3 /_____\ v4
-  //        \  |  /            \ f2  /
-  //         \ | /              \   /
-  //          \|/                \ /
+  //          ╱|╲                ╱ ╲
+  //         ╱ | ╲              ╱f1 ╲
+  //     v3 ╱f2|f1╲ v4  =>  v3 ╱_____╲ v4
+  //        ╲  |  ╱            ╲ f2  ╱
+  //         ╲ | ╱              ╲   ╱
+  //          ╲|╱                ╲ ╱
   //          v2                 v2
   auto& half_edges = uE2E[uei];
   if (half_edges.size() != 2) {

--- a/include/igl/grad_intrinsic.cpp
+++ b/include/igl/grad_intrinsic.cpp
@@ -32,10 +32,10 @@ IGL_INLINE void igl::grad_intrinsic(
   typedef Eigen::Matrix<Gtype,Eigen::Dynamic,Eigen::Dynamic> MatrixX2S;
   MatrixX2S V2 = MatrixX2S::Zero(3*m,2);
   //     1=[x,y]
-  //     /\
-  // l3 /   \ l2
-  //   /      \
-  //  /         \
+  //     ╱ ╲
+  // l3 ╱   ╲l2
+  //   ╱      ╲
+  //  ╱        ╲
   // 2-----------3
   //       l1
   //

--- a/include/igl/intrinsic_delaunay_triangulation.cpp
+++ b/include/igl/intrinsic_delaunay_triangulation.cpp
@@ -1,9 +1,9 @@
 // This file is part of libigl, a simple c++ geometry processing library.
-// 
+//
 // Copyright (C) 2018 Alec Jacobson <alecjacobson@gmail.com>
-// 
-// This Source Code Form is subject to the terms of the Mozilla Public License 
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 #include "intrinsic_delaunay_triangulation.h"
 #include "is_intrinsic_delaunay.h"
@@ -65,7 +65,7 @@ IGL_INLINE void igl::intrinsic_delaunay_triangulation(
   // Vector is faster than queue...
   std::vector<Index> Q;
   Q.reserve(uE2E.size());
-  for (size_t uei=0; uei<uE2E.size(); uei++) 
+  for (size_t uei=0; uei<uE2E.size(); uei++)
   {
     Q.push_back(uei);
   }
@@ -83,7 +83,7 @@ IGL_INLINE void igl::intrinsic_delaunay_triangulation(
       {
         inQ(uei) = true;
       }
-      for (Index uei=0; uei<uE2E.size(); uei++) 
+      for (Index uei=0; uei<uE2E.size(); uei++)
       {
         if(!inQ(uei) && !is_intrinsic_delaunay(l,uE2E,num_faces,uei))
         {
@@ -95,38 +95,38 @@ IGL_INLINE void igl::intrinsic_delaunay_triangulation(
 
     const Index uei = Q.back();
     Q.pop_back();
-    if (uE2E[uei].size() == 2) 
+    if (uE2E[uei].size() == 2)
     {
-      if(!is_intrinsic_delaunay(l,uE2E,num_faces,uei)) 
+      if(!is_intrinsic_delaunay(l,uE2E,num_faces,uei))
       {
         // update l just before flipping edge
         //      .        //
-        //     /|\       //
-        //   a/ | \d     //
-        //   /  e  \     //
-        //  /   |   \    //
+        //     ╱|╲       //
+        //   a╱ | ╲d     //
+        //   ╱  e  ╲     //
+        //  ╱   |   ╲    //
         // .----|-f--.   //
-        //  \   |   /    //
-        //   \  |  /     //
-        //   b\α|δ/c     //
-        //     \|/       //
+        //  ╲   |   ╱    //
+        //   ╲  |  ╱     //
+        //   b╲α|δ╱c     //
+        //     ╲|╱       //
         //      .        //
         // Annotated from flip_edge:
         // Edge to flip [v1,v2] --> [v3,v4]
         // Before:
         // F(f1,:) = [v1,v2,v4] // in some cyclic order
         // F(f2,:) = [v1,v3,v2] // in some cyclic order
-        // After: 
-        // F(f1,:) = [v1,v3,v4] // in *this* order 
+        // After:
+        // F(f1,:) = [v1,v3,v4] // in *this* order
         // F(f2,:) = [v2,v4,v3] // in *this* order
         //
         //          v1                 v1
-        //          /|\                / \
-        //        c/ | \b            c/f1 \b
-        //     v3 /f2|f1\ v4  =>  v3 /__f__\ v4
-        //        \  e  /            \ f2  /
-        //        d\ | /a            d\   /a
-        //          \|/                \ /
+        //          ╱|╲                ╱ ╲
+        //        c╱ | ╲b            c╱f1 ╲b
+        //     v3 ╱f2|f1╲ v4  =>  v3 ╱__f__╲ v4
+        //        ╲  e  /            ╲ f2  /
+        //        d╲ | /a            d╲   /a
+        //          ╲|/                ╲ /
         //          v2                 v2
         //
         // Compute intrinsic length of oppposite edge
@@ -155,7 +155,7 @@ IGL_INLINE void igl::intrinsic_delaunay_triangulation(
         // tan((α+δ)/2)
         const Scalar tan_a_d_2 = (tan_a_2 + tan_d_2)/(1.0-tan_a_2*tan_d_2);
         // cos(α+δ)
-        const Scalar cos_a_d = 
+        const Scalar cos_a_d =
           (1.0 - tan_a_d_2*tan_a_d_2)/(1.0+tan_a_d_2*tan_a_d_2);
         const Scalar f = sqrt(b*b + c*c - 2.0*b*c*cos_a_d);
         l(f1,0) = f;

--- a/include/igl/kkt_inverse.h
+++ b/include/igl/kkt_inverse.h
@@ -1,9 +1,9 @@
 // This file is part of libigl, a simple c++ geometry processing library.
-// 
+//
 // Copyright (C) 2013 Alec Jacobson <alecjacobson@gmail.com>
-// 
-// This Source Code Form is subject to the terms of the Mozilla Public License 
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 #ifndef IGL_KKT_INVERSE_H
 #define IGL_KKT_INVERSE_H
@@ -22,10 +22,10 @@ namespace igl
   /// constrained quadratic minimization problem.
   ///
   /// Systems of the form:
-  ///  
-  ///      / A   Aeqᵀ \  / x \ = / b   \
-  ///      \ Aeq    0 /  \ λ /   \ beq /
-  ///     \_____.______/\__.__/ \___.___/
+  ///
+  ///      ╱ A   Aeqᵀ ╲  ╱ x ╲ = ╱ b   ╲
+  ///      ╲ Aeq    0 ╱  ╲ λ ╱   ╲ beq ╱
+  ///     ╲_____.______╱╲__.__╱ ╲___.___╱
   ///           M          z        c
   ///
   /// Arise, for example, when solve convex, linear equality constrained
@@ -38,7 +38,7 @@ namespace igl
   ///
   ///     S = [In 0] M⁻¹
   ///
-  ///     so that 
+  ///     so that
   ///
   ///     x = S c
   ///
@@ -53,7 +53,7 @@ namespace igl
   template <typename T>
   IGL_INLINE void kkt_inverse(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& A,
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& Aeq,    
+    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& Aeq,
     const bool use_lu_decomposition,
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& S);
 }

--- a/include/igl/remesh_along_isoline.cpp
+++ b/include/igl/remesh_along_isoline.cpp
@@ -1,9 +1,9 @@
 // This file is part of libigl, a simple c++ geometry processing library.
-// 
+//
 // Copyright (C) 2018 Alec Jacobson <alecjacobson@gmail.com>
-// 
-// This Source Code Form is subject to the terms of the Mozilla Public License 
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 #include "remesh_along_isoline.h"
 #include "list_to_matrix.h"
@@ -136,13 +136,13 @@ template <
         const int v01 = edgeToBirthVert[v0][v1];
         const int v12 = edgeToBirthVert[v1][v2];
         // v0
-        // |  \
-        // |   \
-        // |    \
-        // v01   \
-        // |      \
-        // |       \
-        // |        \
+        // |  ╲
+        // |   ╲
+        // |    ╲
+        // v01   ╲
+        // |      ╲
+        // |       ╲
+        // |        ╲
         // v1--v12---v2
         typedef std::vector<typename DerivedG::Scalar> Row;
         {Row row = {v01,v1,v12}; vG.push_back(row);vJ.push_back(f);vL.push_back(Psign[0]?isoval_i:isoval_i+1);}

--- a/tests/include/igl/triangle_triangle_intersect.cpp
+++ b/tests/include/igl/triangle_triangle_intersect.cpp
@@ -15,9 +15,9 @@ TEST_CASE("triangle_triangle_intersect: shared-edge", "[igl]" )
     0,1,2,
     0,2,3;
   //      2
-  //     /|\
-  //    / | \
-  //   /  |  \
+  //     ╱|╲
+  //    ╱ | ╲
+  //   ╱  |  ╲
   //  3---0---1
   const int f = 0;
   const int c = 1;
@@ -35,9 +35,9 @@ TEST_CASE("triangle_triangle_intersect: shared-edge", "[igl]" )
   for(const double epsilon : {0.,1e-15,-1e-15})
   {
     //  2
-    //  |\⟍
-    //  | \ ⟍
-    //  |  \  ⟍
+    //  |╲⟍
+    //  | ╲ ⟍
+    //  |  ╲  ⟍
     //  0---1---3
     V.row(3) << 2.0+epsilon,0,0;
     ret = igl::triangle_triangle_intersect(V,F,E,EMAP,EF,f,c,V.row(F(f,c)),g);


### PR DESCRIPTION
To avoid compiler warnings of the style:

```
include/igl/AABB.cpp:549:3: warning: multi-line comment [-Wcomment]
549 |   //            /  \
```

I've replaced comments using forward/backward slashes with unicode box-drawing characters. This avoids ending a comment with a trailing backslash, which can trigger some annoying compiler warnings.

#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
