### PR TITLE
No longer using namespace std; and using namespace Eigen; to avoid issues with other libs

### DIFF
--- a/include/igl/AABB.cpp
+++ b/include/igl/AABB.cpp
@@ -817,7 +817,6 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::init(
     const Eigen::MatrixBase<Derivedelements> & elements,
     const int i)
 {
-  using namespace std;
   using namespace Eigen;
   clear();
   if(bb_mins.size() > 0)
@@ -897,7 +896,6 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::init(
     const Eigen::MatrixBase<DerivedI> & I)
 {
   using namespace Eigen;
-  using namespace std;
   clear();
   if(V.size() == 0 || Ele.size() == 0 || I.size() == 0)
   {
@@ -942,7 +940,7 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::init(
         const auto median = [](VectorXi A)->int
         {
           size_t n = (A.size()-1)/2;
-          nth_element(A.data(),A.data()+n,A.data()+A.size());
+          std::nth_element(A.data(),A.data()+n,A.data()+A.size());
           return A(n);
         };
         const int med = median(SIdI);
@@ -1051,7 +1049,6 @@ IGL_INLINE std::vector<int> igl::AABB<DerivedV,DIM>::find(
     const Eigen::MatrixBase<Derivedq> & q,
     const bool first) const
 {
-  using namespace std;
   using namespace Eigen;
   assert(q.size() == DIM &&
       "Query dimension should match aabb dimension");
@@ -1099,7 +1096,6 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::serialize(
     Eigen::PlainObjectBase<Derivedelements> & elements,
     const int i) const
 {
-  using namespace std;
   using namespace Eigen;
   // Calling for root then resize output
   if(i==0)
@@ -1151,7 +1147,6 @@ igl::AABB<DerivedV,DIM>::squared_distance(
   Eigen::PlainObjectBase<RowVectorDIMS> & c) const
 {
   using namespace Eigen;
-  using namespace std;
   //assert(low_sqr_d <= up_sqr_d);
   if(low_sqr_d > up_sqr_d)
   {
@@ -1331,7 +1326,6 @@ IGL_INLINE typename igl::AABB<DerivedV,DIM>::Scalar
   Eigen::PlainObjectBase<DerivedI> & I,
   Eigen::PlainObjectBase<DerivedC> & C) const
 {
-  using namespace std;
   using namespace Eigen;
 
   // This implementation is a bit disappointing. There's no major speed up. Any
@@ -1434,7 +1428,6 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::leaf_squared_distance(
   Eigen::PlainObjectBase<RowVectorDIMS> & c) const
 {
   using namespace Eigen;
-  using namespace std;
   if(low_sqr_d > sqr_d)
   {
     sqr_d = low_sqr_d;

--- a/include/igl/AABB.cpp
+++ b/include/igl/AABB.cpp
@@ -817,7 +817,6 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::init(
     const Eigen::MatrixBase<Derivedelements> & elements,
     const int i)
 {
-  using namespace Eigen;
   clear();
   if(bb_mins.size() > 0)
   {
@@ -843,7 +842,7 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::init(
     }
   }else
   {
-    VectorXi allI = colon<int>(0,Ele.rows()-1);
+    Eigen::VectorXi allI = colon<int>(0,Ele.rows()-1);
     MatrixXDIMS BC;
     if(Ele.cols() == 1)
     {
@@ -854,10 +853,10 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::init(
       // Simplices
       barycenter(V,Ele,BC);
     }
-    MatrixXi SI(BC.rows(),BC.cols());
+    Eigen::MatrixXi SI(BC.rows(),BC.cols());
     {
       MatrixXDIMS _;
-      MatrixXi IS;
+      Eigen::MatrixXi IS;
       igl::sort(BC,1,true,_,IS);
       // Need SI(i) to tell which place i would be sorted into
       const int dim = IS.cols();
@@ -879,9 +878,8 @@ void igl::AABB<DerivedV,DIM>::init(
     const Eigen::MatrixBase<DerivedV> & V,
     const Eigen::MatrixBase<DerivedEle> & Ele)
 {
-  using namespace Eigen;
   // clear will be immediately called...
-  return init(V,Ele,MatrixXDIMS(),MatrixXDIMS(),VectorXi(),0);
+  return init(V,Ele,MatrixXDIMS(),MatrixXDIMS(),Eigen::VectorXi(),0);
 }
 
   template <typename DerivedV, int DIM>
@@ -895,7 +893,6 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::init(
     const Eigen::MatrixBase<DerivedSI> & SI,
     const Eigen::MatrixBase<DerivedI> & I)
 {
-  using namespace Eigen;
   clear();
   if(V.size() == 0 || Ele.size() == 0 || I.size() == 0)
   {
@@ -903,7 +900,7 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::init(
   }
   assert(DIM == V.cols() && "V.cols() should matched declared dimension");
   //const Scalar inf = numeric_limits<Scalar>::infinity();
-  m_box = AlignedBox<Scalar,DIM>();
+  m_box = Eigen::AlignedBox<Scalar,DIM>();
   // Compute bounding box
   for(int i = 0;i<I.rows();i++)
   {
@@ -931,20 +928,20 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::init(
         m_box.diagonal().maxCoeff(&max_d);
         // Can't use median on BC directly because many may have same value,
         // but can use median on sorted BC indices
-        VectorXi SIdI(I.rows());
+        Eigen::VectorXi SIdI(I.rows());
         for(int i = 0;i<I.rows();i++)
         {
           SIdI(i) = SI(I(i),max_d);
         }
         // Pass by copy to avoid changing input
-        const auto median = [](VectorXi A)->int
+        const auto median = [](Eigen::VectorXi A)->int
         {
           size_t n = (A.size()-1)/2;
           std::nth_element(A.data(),A.data()+n,A.data()+A.size());
           return A(n);
         };
         const int med = median(SIdI);
-        VectorXi LI((I.rows()+1)/2),RI(I.rows()/2);
+        Eigen::VectorXi LI((I.rows()+1)/2),RI(I.rows()/2);
         assert(LI.rows()+RI.rows() == I.rows());
         // Distribute left and right
         {
@@ -1049,7 +1046,6 @@ IGL_INLINE std::vector<int> igl::AABB<DerivedV,DIM>::find(
     const Eigen::MatrixBase<Derivedq> & q,
     const bool first) const
 {
-  using namespace Eigen;
   assert(q.size() == DIM &&
       "Query dimension should match aabb dimension");
   assert(Ele.cols() == V.cols()+1 &&
@@ -1096,7 +1092,6 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::serialize(
     Eigen::PlainObjectBase<Derivedelements> & elements,
     const int i) const
 {
-  using namespace Eigen;
   // Calling for root then resize output
   if(i==0)
   {
@@ -1146,7 +1141,6 @@ igl::AABB<DerivedV,DIM>::squared_distance(
   int & i,
   Eigen::PlainObjectBase<RowVectorDIMS> & c) const
 {
-  using namespace Eigen;
   //assert(low_sqr_d <= up_sqr_d);
   if(low_sqr_d > up_sqr_d)
   {
@@ -1326,8 +1320,6 @@ IGL_INLINE typename igl::AABB<DerivedV,DIM>::Scalar
   Eigen::PlainObjectBase<DerivedI> & I,
   Eigen::PlainObjectBase<DerivedC> & C) const
 {
-  using namespace Eigen;
-
   // This implementation is a bit disappointing. There's no major speed up. Any
   // performance gains seem to come from accidental cache coherency and
   // diminish for larger "other" (the opposite of what was intended).
@@ -1427,7 +1419,6 @@ IGL_INLINE void igl::AABB<DerivedV,DIM>::leaf_squared_distance(
   int & i,
   Eigen::PlainObjectBase<RowVectorDIMS> & c) const
 {
-  using namespace Eigen;
   if(low_sqr_d > sqr_d)
   {
     sqr_d = low_sqr_d;

--- a/include/igl/WindingNumberAABB.h
+++ b/include/igl/WindingNumberAABB.h
@@ -108,7 +108,6 @@ inline void igl::WindingNumberAABB<Scalar,Index>::set_mesh(
 template <typename Scalar, typename Index>
 inline void igl::WindingNumberAABB<Scalar,Index>::init()
 {
-  using namespace Eigen;
   assert(max_corner.size() == 3);
   assert(min_corner.size() == 3);
   compute_min_max_corners();
@@ -149,7 +148,6 @@ inline igl::WindingNumberAABB<Scalar,Index>::WindingNumberAABB(
 template <typename Scalar, typename Index>
 inline void igl::WindingNumberAABB<Scalar,Index>::grow()
 {
-  using namespace Eigen;
   // Clear anything that already exists
   this->delete_children();
 
@@ -330,7 +328,6 @@ inline Scalar
   igl::WindingNumberAABB<Scalar,Index>::max_simple_abs_winding_number(
   const Point & p) const
 {
-  using namespace Eigen;
   // Only valid if not inside
   if(inside(p))
   {

--- a/include/igl/WindingNumberAABB.h
+++ b/include/igl/WindingNumberAABB.h
@@ -149,7 +149,6 @@ inline igl::WindingNumberAABB<Scalar,Index>::WindingNumberAABB(
 template <typename Scalar, typename Index>
 inline void igl::WindingNumberAABB<Scalar,Index>::grow()
 {
-  using namespace std;
   using namespace Eigen;
   // Clear anything that already exists
   this->delete_children();
@@ -169,7 +168,7 @@ inline void igl::WindingNumberAABB<Scalar,Index>::grow()
   // Compute longest direction
   int max_d = -1;
   Scalar max_len = 
-    -numeric_limits<Scalar>::infinity();
+    -std::numeric_limits<Scalar>::infinity();
   for(int d = 0;d<min_corner.size();d++)
   {
     if( (max_corner[d] - min_corner[d]) > max_len )
@@ -202,7 +201,7 @@ inline void igl::WindingNumberAABB<Scalar,Index>::grow()
   //cout<<"c: "<<0.5*(max_corner[max_d] + min_corner[max_d])<<" "<<
   //  "m: "<<split_value<<endl;;
 
-  vector<int> id( (this->F).rows());
+  std::vector<int> id( (this->F).rows());
   for(int i = 0;i<(this->F).rows();i++)
   {
     if(BC(i,max_d) <= split_value)
@@ -273,12 +272,11 @@ inline bool igl::WindingNumberAABB<Scalar,Index>::inside(const Point & p) const
 template <typename Scalar, typename Index>
 inline void igl::WindingNumberAABB<Scalar,Index>::compute_min_max_corners()
 {
-  using namespace std;
   // initialize corners
   for(int d = 0;d<min_corner.size();d++)
   {
-    min_corner[d] =  numeric_limits<typename Point::Scalar>::infinity();
-    max_corner[d] = -numeric_limits<typename Point::Scalar>::infinity();
+    min_corner[d] =  std::numeric_limits<typename Point::Scalar>::infinity();
+    max_corner[d] = -std::numeric_limits<typename Point::Scalar>::infinity();
   }
 
   this->center = Point(0,0,0);
@@ -317,15 +315,14 @@ template <typename Scalar, typename Index>
 inline Scalar
 igl::WindingNumberAABB<Scalar,Index>::max_abs_winding_number(const Point & p) const
 {
-  using namespace std;
   // Only valid if not inside
   if(inside(p))
   {
-    return numeric_limits<Scalar>::infinity();
+    return std::numeric_limits<Scalar>::infinity();
   }
   // Q: we know the total positive area so what's the most this could project
   // to? Remember it could be layered in the same direction.
-  return numeric_limits<Scalar>::infinity();
+  return std::numeric_limits<Scalar>::infinity();
 }
 
 template <typename Scalar, typename Index>
@@ -333,12 +330,11 @@ inline Scalar
   igl::WindingNumberAABB<Scalar,Index>::max_simple_abs_winding_number(
   const Point & p) const
 {
-  using namespace std;
   using namespace Eigen;
   // Only valid if not inside
   if(inside(p))
   {
-    return numeric_limits<Scalar>::infinity();
+    return std::numeric_limits<Scalar>::infinity();
   }
   // Max simple is the same as sum of positive winding number contributions of
   // bounding box

--- a/include/igl/WindingNumberTree.h
+++ b/include/igl/WindingNumberTree.h
@@ -184,7 +184,6 @@ inline void igl::WindingNumberTree<Scalar,Index>::set_mesh(
     const Eigen::MatrixBase<DerivedV> & _V,
     const Eigen::MatrixBase<DerivedF> & _F)
 {
-  using namespace std;
   // Remove any exactly duplicate vertices
   // Q: Can this ever increase the complexity of the boundary?
   // Q: Would we gain even more by remove almost exactly duplicate vertices?
@@ -224,9 +223,8 @@ inline igl::WindingNumberTree<Scalar,Index>::~WindingNumberTree()
 template <typename Scalar, typename Index>
 inline void igl::WindingNumberTree<Scalar,Index>::delete_children()
 {
-  using namespace std;
   // Delete children
-  typename list<WindingNumberTree<Scalar,Index>* >::iterator cit = children.begin();
+  typename std::list<WindingNumberTree<Scalar,Index>* >::iterator cit = children.begin();
   while(cit != children.end())
   {
     // clear the memory of this item
@@ -263,7 +261,6 @@ template <typename Scalar, typename Index>
 inline Scalar 
 igl::WindingNumberTree<Scalar,Index>::winding_number(const Point & p) const
 {
-  using namespace std;
   //cout<<"+"<<boundary.rows();
   // If inside then we need to be careful
   if(inside(p))
@@ -274,7 +271,7 @@ igl::WindingNumberTree<Scalar,Index>::winding_number(const Point & p) const
       // Recurse on each child and accumulate
       Scalar sum = 0;
       for(
-        typename list<WindingNumberTree<Scalar,Index>* >::const_iterator cit = children.begin();
+        typename std::list<WindingNumberTree<Scalar,Index>* >::const_iterator cit = children.begin();
         cit != children.end();
         cit++)
       {
@@ -370,17 +367,16 @@ igl::WindingNumberTree<Scalar,Index>::winding_number_boundary(const Point & p) c
 template <typename Scalar, typename Index>
 inline void igl::WindingNumberTree<Scalar,Index>::print(const char * tab)
 {
-  using namespace std;
   // Print all facets
-  cout<<tab<<"["<<endl<<F<<endl<<"]";
+  std::cout<<tab<<"["<<std::endl<<F<<std::endl<<"]";
   // Print children
   for(
-      typename list<WindingNumberTree<Scalar,Index>* >::iterator cit = children.begin();
+      typename std::list<WindingNumberTree<Scalar,Index>* >::iterator cit = children.begin();
       cit != children.end();
       cit++)
   {
-    cout<<","<<endl;
-    (*cit)->print((string(tab)+"").c_str());
+    std::cout<<","<<std::endl;
+    (*cit)->print((std::string(tab)+"").c_str());
   }
 }
 
@@ -396,8 +392,7 @@ inline Scalar
 igl::WindingNumberTree<Scalar,Index>::max_simple_abs_winding_number(
   const Point & /*p*/) const
 {
-  using namespace std;
-  return numeric_limits<Scalar>::infinity();
+  return std::numeric_limits<Scalar>::infinity();
 }
 
 template <typename Scalar, typename Index>
@@ -406,7 +401,6 @@ igl::WindingNumberTree<Scalar,Index>::cached_winding_number(
   const igl::WindingNumberTree<Scalar,Index> & that,
   const Point & p) const
 {
-  using namespace std;
   // Simple metric for `is_far`
   //
   //   this             that
@@ -437,7 +431,7 @@ igl::WindingNumberTree<Scalar,Index>::cached_winding_number(
   if(is_far)
   {
     // Not implemented yet
-    pair<const WindingNumberTree*,const WindingNumberTree*> this_that(this,&that);
+    std::pair<const WindingNumberTree*,const WindingNumberTree*> this_that(this,&that);
     // Need to compute it for first time?
     if(cached.count(this_that)==0)
     {
@@ -452,7 +446,7 @@ igl::WindingNumberTree<Scalar,Index>::cached_winding_number(
   }else
   {
     for(
-      typename list<WindingNumberTree<Scalar,Index>* >::const_iterator cit = children.begin();
+      typename std::list<WindingNumberTree<Scalar,Index>* >::const_iterator cit = children.begin();
       cit != children.end();
       cit++)
     {

--- a/include/igl/active_set.cpp
+++ b/include/igl/active_set.cpp
@@ -51,7 +51,6 @@ IGL_INLINE igl::SolverStatus igl::active_set(
 #if defined(ACTIVE_SET_CPP_DEBUG) && !defined(_MSC_VER)
 #  warning "ACTIVE_SET_CPP_DEBUG"
 #endif
-  using namespace Eigen;
   SolverStatus ret = SOLVER_STATUS_ERROR;
   const int n = A.rows();
   assert(n == A.cols() && "A must be square");
@@ -106,9 +105,9 @@ IGL_INLINE igl::SolverStatus igl::active_set(
   typedef int BOOL;
 #define TRUE 1
 #define FALSE 0
-  Matrix<BOOL,Dynamic,1> as_lx = Matrix<BOOL,Dynamic,1>::Constant(n,1,FALSE);
-  Matrix<BOOL,Dynamic,1> as_ux = Matrix<BOOL,Dynamic,1>::Constant(n,1,FALSE);
-  Matrix<BOOL,Dynamic,1> as_ieq = Matrix<BOOL,Dynamic,1>::Constant(Aieq.rows(),1,FALSE);
+  Eigen::Matrix<BOOL,Eigen::Dynamic,1> as_lx = Eigen::Matrix<BOOL,Eigen::Dynamic,1>::Constant(n,1,FALSE);
+  Eigen::Matrix<BOOL,Eigen::Dynamic,1> as_ux = Eigen::Matrix<BOOL,Eigen::Dynamic,1>::Constant(n,1,FALSE);
+  Eigen::Matrix<BOOL,Eigen::Dynamic,1> as_ieq = Eigen::Matrix<BOOL,Eigen::Dynamic,1>::Constant(Aieq.rows(),1,FALSE);
 
   // Keep track of previous Z for comparison
   PlainMatrix<DerivedZ> old_Z;
@@ -254,7 +253,7 @@ IGL_INLINE igl::SolverStatus igl::active_set(
       assert(k == as_ieq_count);
     }
     // extract active constraint rows
-    SparseMatrix<AeqT> Aeq_i,Aieq_i;
+    Eigen::SparseMatrix<AeqT> Aeq_i,Aieq_i;
     slice(Aieq,as_ieq_list,1,Aieq_i);
     // Append to equality constraints
     cat(1,Aeq,Aieq_i,Aeq_i);
@@ -264,7 +263,7 @@ IGL_INLINE igl::SolverStatus igl::active_set(
 #ifndef NDEBUG
     {
       // NO DUPES!
-      Matrix<BOOL,Dynamic,1> fixed = Matrix<BOOL,Dynamic,1>::Constant(n,1,FALSE);
+      Eigen::Matrix<BOOL ,Eigen::Dynamic,1> fixed = Eigen::Matrix<BOOL ,Eigen::Dynamic,1>::Constant(n,1,FALSE);
       for(int k = 0;k<known_i.size();k++)
       {
         assert(!fixed[known_i(k)]);
@@ -325,18 +324,18 @@ IGL_INLINE igl::SolverStatus igl::active_set(
     }
 
     // Compute Lagrange multiplier values for known_i
-    SparseMatrix<AT> Ak;
+    Eigen::SparseMatrix<AT> Ak;
     // Slow
     slice(A,known_i,1,Ak);
     //slice(B,known_i,Bk);
     PlainMatrix<DerivedB,Eigen::Dynamic> Bk = B(known_i,igl::placeholders::all);
-    MatrixXd Lambda_known_i = -(0.5*Ak*Z + 0.5*Bk);
+    Eigen::MatrixXd Lambda_known_i = -(0.5*Ak*Z + 0.5*Bk);
     // reverse the lambda values for lx
     Lambda_known_i.block(nk,0,as_lx_count,1) =
       (-1*Lambda_known_i.block(nk,0,as_lx_count,1)).eval();
 
     // Extract Lagrange multipliers for Aieq_i (always at back of sol)
-    VectorXd Lambda_Aieq_i(Aieq_i.rows(),1);
+    Eigen::VectorXd Lambda_Aieq_i(Aieq_i.rows(),1);
     for(int l = 0;l<Aieq_i.rows();l++)
     {
       Lambda_Aieq_i(Aieq_i.rows()-1-l) = sol(sol.rows()-1-l);

--- a/include/igl/active_set.cpp
+++ b/include/igl/active_set.cpp
@@ -52,7 +52,6 @@ IGL_INLINE igl::SolverStatus igl::active_set(
 #  warning "ACTIVE_SET_CPP_DEBUG"
 #endif
   using namespace Eigen;
-  using namespace std;
   SolverStatus ret = SOLVER_STATUS_ERROR;
   const int n = A.rows();
   assert(n == A.cols() && "A must be square");
@@ -75,7 +74,7 @@ IGL_INLINE igl::SolverStatus igl::active_set(
   if(p_lx.size() == 0)
   {
     lx = Derivedlx::Constant(
-      n,1,-numeric_limits<typename Derivedlx::Scalar>::max());
+      n,1,-std::numeric_limits<typename Derivedlx::Scalar>::max());
   }else
   {
     lx = p_lx;
@@ -83,7 +82,7 @@ IGL_INLINE igl::SolverStatus igl::active_set(
   if(p_ux.size() == 0)
   {
     ux = Derivedux::Constant(
-      n,1,numeric_limits<typename Derivedux::Scalar>::max());
+      n,1,std::numeric_limits<typename Derivedux::Scalar>::max());
   }else
   {
     ux = p_ux;

--- a/include/igl/adjacency_matrix.cpp
+++ b/include/igl/adjacency_matrix.cpp
@@ -16,10 +16,9 @@ IGL_INLINE void igl::adjacency_matrix(
   const Eigen::MatrixBase<DerivedF> & F,
   Eigen::SparseMatrix<T>& A)
 {
-  using namespace Eigen;
   typedef typename DerivedF::Scalar Index;
 
-  typedef Triplet<T> IJV;
+  typedef Eigen::Triplet<T> IJV;
   std::vector<IJV > ijv;
   ijv.reserve(F.size()*2);
   // Loop over **simplex** (i.e., **not quad**)
@@ -70,9 +69,7 @@ IGL_INLINE void igl::adjacency_matrix(
   const Eigen::MatrixBase<DerivedC> & C,
   Eigen::SparseMatrix<T>& A)
 {
-  using namespace Eigen;
-
-  typedef Triplet<T> IJV;
+  typedef Eigen::Triplet<T> IJV;
   std::vector<IJV > ijv;
   ijv.reserve(C(C.size()-1)*2);
   typedef typename DerivedI::Scalar Index;

--- a/include/igl/adjacency_matrix.cpp
+++ b/include/igl/adjacency_matrix.cpp
@@ -16,12 +16,11 @@ IGL_INLINE void igl::adjacency_matrix(
   const Eigen::MatrixBase<DerivedF> & F,
   Eigen::SparseMatrix<T>& A)
 {
-  using namespace std;
   using namespace Eigen;
   typedef typename DerivedF::Scalar Index;
 
   typedef Triplet<T> IJV;
-  vector<IJV > ijv;
+  std::vector<IJV > ijv;
   ijv.reserve(F.size()*2);
   // Loop over **simplex** (i.e., **not quad**)
   for(int i = 0;i<F.rows();i++)
@@ -71,11 +70,10 @@ IGL_INLINE void igl::adjacency_matrix(
   const Eigen::MatrixBase<DerivedC> & C,
   Eigen::SparseMatrix<T>& A)
 {
-  using namespace std;
   using namespace Eigen;
 
   typedef Triplet<T> IJV;
-  vector<IJV > ijv;
+  std::vector<IJV > ijv;
   ijv.reserve(C(C.size()-1)*2);
   typedef typename DerivedI::Scalar Index;
   const Index n = I.maxCoeff()+1;

--- a/include/igl/adjacency_matrix.h
+++ b/include/igl/adjacency_matrix.h
@@ -30,10 +30,10 @@ namespace igl
   ///   SparseVector<double> Asum;
   ///   sum(A,1,Asum);
   ///   // Convert row sums into diagonal of sparse matrix
-  ///   SparseMatrix<double> Adiag;
+  ///   Eigen::SparseMatrix<double> Adiag;
   ///   diag(Asum,Adiag);
   ///   // Build uniform laplacian
-  ///   SparseMatrix<double> U;
+  ///   Eigen::SparseMatrix<double> U;
   ///   U = A-Adiag;
   /// \endcode
   ///

--- a/include/igl/all_pairs_distances.h
+++ b/include/igl/all_pairs_distances.h
@@ -15,7 +15,7 @@ namespace igl
   /// 
   ///     D = all_pairs_distances(V,U)
   /// 
-  /// @tparam matrix class like MatrixXd
+  /// @tparam matrix class like Eigen::MatrixXd
   /// @param[in] V  #V by dim list of points
   /// @param[in] U  #U by dim list of points
   /// @param[in] squared  whether to return squared distances

--- a/include/igl/ambient_occlusion.cpp
+++ b/include/igl/ambient_occlusion.cpp
@@ -30,7 +30,6 @@ IGL_INLINE void igl::ambient_occlusion(
   const int num_samples,
   Eigen::PlainObjectBase<DerivedS> & S)
 {
-  using namespace Eigen;
   const int n = P.rows();
   // Resize output
   S.resize(n,1);
@@ -38,7 +37,7 @@ IGL_INLINE void igl::ambient_occlusion(
   typedef typename DerivedP::Scalar Scalar;
   typedef Eigen::Matrix<Scalar,3,1> Vector3N;
 
-  const Matrix<Scalar,Eigen::Dynamic,3> D = random_dir_stratified(num_samples).cast<Scalar>();
+  const Eigen::Matrix<Scalar,Eigen::Dynamic,3> D = random_dir_stratified(num_samples).cast<Scalar>();
 
   const auto & inner = [&P,&N,&num_samples,&D,&S,&shoot_ray](const int p)
   {

--- a/include/igl/arap.cpp
+++ b/include/igl/arap.cpp
@@ -35,7 +35,6 @@ IGL_INLINE bool igl::arap_precomputation(
   const Eigen::MatrixBase<Derivedb> & b,
   ARAPData & data)
 {
-  using namespace std;
   using namespace Eigen;
   typedef typename DerivedV::Scalar Scalar;
   typedef typename DerivedF::Scalar Integer;
@@ -175,7 +174,6 @@ IGL_INLINE bool igl::arap_solve(
   Eigen::MatrixBase<DerivedU> & U)
 {
   using namespace Eigen;
-  using namespace std;
   assert(data.b.size() == bc.rows());
   assert(U.size() != 0 && "U cannot be empty");
   assert(U.cols() == data.dim && "U.cols() match data.dim");

--- a/include/igl/arap_dof.cpp
+++ b/include/igl/arap_dof.cpp
@@ -213,7 +213,7 @@ IGL_INLINE bool igl::arap_dof_precomputation(
       M_i = M((span_n.array()+i*n).eval(),span_mlbs_cols);
     }
 #else
-    constexpr bool LbsMatrixTypeIsSparse = std::is_base_of<SparseMatrixBase<LbsMatrixType>, LbsMatrixType>::value;
+    constexpr bool LbsMatrixTypeIsSparse = std::is_base_of<Eigen::SparseMatrixBase<LbsMatrixType>, LbsMatrixType>::value;
     arap_dof_slice_helper<LbsMatrixType,LbsMatrixTypeIsSparse>::slice(M,(span_n.array()+i*n).matrix().eval(),span_mlbs_cols,M_i);
 #endif
     LbsMatrixType M_i_dim;

--- a/include/igl/arap_dof.cpp
+++ b/include/igl/arap_dof.cpp
@@ -66,8 +66,7 @@ IGL_INLINE bool igl::arap_dof_precomputation(
   const Eigen::Matrix<int,Eigen::Dynamic,1> & G,
   ArapDOFData<LbsMatrixType, SSCALAR> & data)
 {
-  using namespace Eigen;
-  typedef Matrix<SSCALAR, Dynamic, Dynamic> MatrixXS;
+  typedef Eigen::Matrix<SSCALAR, Eigen::Dynamic, Eigen::Dynamic> MatrixXS;
   // number of mesh (domain) vertices
   int n = V.rows();
   // cache problem size
@@ -95,11 +94,11 @@ IGL_INLINE bool igl::arap_dof_precomputation(
   //printf("n=%d; dim=%d; m=%d;\n",n,data.dim,data.m);
 
   // Build cotangent laplacian
-  SparseMatrix<double> Lcot;
+  Eigen::SparseMatrix<double> Lcot;
   //printf("cotmatrix()\n");
   cotmatrix(V,F,Lcot);
   // Discrete laplacian (should be minus matlab version)
-  SparseMatrix<double> Lapl = -2.0*Lcot;
+  Eigen::SparseMatrix<double> Lapl = -2.0*Lcot;
 #ifdef EXTREME_VERBOSE
   cout<<"LaplIJV=["<<endl;print_ijv(Lapl,1);cout<<endl<<"];"<<
     endl<<"Lapl=sparse(LaplIJV(:,1),LaplIJV(:,2),LaplIJV(:,3),"<<
@@ -108,7 +107,7 @@ IGL_INLINE bool igl::arap_dof_precomputation(
 
   // Get group sum scatter matrix, when applied sums all entries of the same
   // group according to G
-  SparseMatrix<double> G_sum;
+  Eigen::SparseMatrix<double> G_sum;
   if(G.size() == 0)
   {
     speye(n,G_sum);
@@ -118,7 +117,7 @@ IGL_INLINE bool igl::arap_dof_precomputation(
     Eigen::Matrix<int,Eigen::Dynamic,1> GG;
     if(data.energy == ARAP_ENERGY_TYPE_ELEMENTS)
     {
-      MatrixXi GF(F.rows(),F.cols());
+      Eigen::MatrixXi GF(F.rows(),F.cols());
       for(int j = 0;j<F.cols();j++)
       {
         GF.col(j) = G(F.col(j));
@@ -140,7 +139,7 @@ IGL_INLINE bool igl::arap_dof_precomputation(
 
   // Get covariance scatter matrix, when applied collects the covariance matrices
   // used to fit rotations to during optimization
-  SparseMatrix<double> CSM;
+  Eigen::SparseMatrix<double> CSM;
   //printf("covariance_scatter_matrix()\n");
   covariance_scatter_matrix(V,F,data.energy,CSM);
 #ifdef EXTREME_VERBOSE
@@ -167,7 +166,7 @@ IGL_INLINE bool igl::arap_dof_precomputation(
   // S((k-1)*dim + 1:dim,:)
 
   // Apply group sum to each dimension's block of covariance scatter matrix
-  SparseMatrix<double> G_sum_dim;
+  Eigen::SparseMatrix<double> G_sum_dim;
   repdiag(G_sum,data.dim,G_sum_dim);
   CSM = (G_sum_dim * CSM).eval();
 #ifdef EXTREME_VERBOSE
@@ -205,7 +204,7 @@ IGL_INLINE bool igl::arap_dof_precomputation(
     //printf("CSM_M(): slice\n");
 #if __cplusplus >= 201703L
     // Check if LbsMatrixType is a sparse matrix
-    if constexpr (std::is_base_of<SparseMatrixBase<LbsMatrixType>, LbsMatrixType>::value)
+    if constexpr (std::is_base_of<Eigen::SparseMatrixBase<LbsMatrixType>, LbsMatrixType>::value)
     {
       slice(M,(span_n.array()+i*n).matrix().eval(),span_mlbs_cols,M_i);
     }
@@ -222,7 +221,7 @@ IGL_INLINE bool igl::arap_dof_precomputation(
     assert(data.CSM_M[i].cols() == M.cols());
     for(int j = 0;j<data.dim;j++)
     {
-      SparseMatrix<double> CSMj;
+      Eigen::SparseMatrix<double> CSMj;
       //printf("CSM_M(): slice\n");
       slice(
         CSM,
@@ -236,7 +235,7 @@ IGL_INLINE bool igl::arap_dof_precomputation(
       {
         // Convert to full
         //printf("CSM_M(): full\n");
-        MatrixXd CSMjM_ifull(CSMjM_i);
+        Eigen::MatrixXd CSMjM_ifull(CSMjM_i);
 //        printf("CSM_M[%d]: %d %d\n",i,data.CSM_M[i].rows(),data.CSM_M[i].cols());
 //        printf("CSM_M[%d].block(%d*%d=%d,0,%d,%d): %d %d\n",i,j,k,CSMjM_i.rows(),CSMjM_i.cols(),
 //            data.CSM_M[i].block(j*k,0,CSMjM_i.rows(),CSMjM_i.cols()).rows(),
@@ -256,7 +255,7 @@ IGL_INLINE bool igl::arap_dof_precomputation(
 
   // precompute arap_rhs matrix
   //printf("arap_rhs()\n");
-  SparseMatrix<double> K;
+  Eigen::SparseMatrix<double> K;
   arap_rhs(V,F,V.cols(),data.energy,K);
 //#ifdef EXTREME_VERBOSE
 //  cout<<"KIJV=["<<endl;print_ijv(K,1);cout<<endl<<"];"<<
@@ -264,8 +263,8 @@ IGL_INLINE bool igl::arap_dof_precomputation(
 //    K.rows()<<","<<K.cols()<<");"<<endl;
 //#endif
   // Precompute left muliplication by M and right multiplication by G_sum
-  SparseMatrix<double> G_sumT = G_sum.transpose();
-  SparseMatrix<double> G_sumT_dim_dim;
+  Eigen::SparseMatrix<double> G_sumT = G_sum.transpose();
+  Eigen::SparseMatrix<double> G_sumT_dim_dim;
   repdiag(G_sumT,data.dim*data.dim,G_sumT_dim_dim);
   LbsMatrixType MT = M.transpose();
   // If this is a bottle neck then consider reordering matrix multiplication
@@ -278,7 +277,7 @@ IGL_INLINE bool igl::arap_dof_precomputation(
 
   // Precompute system matrix
   //printf("A()\n");
-  SparseMatrix<double> A;
+  Eigen::SparseMatrix<double> A;
   repdiag(Lapl,data.dim,A);
   data.Q = MT * (A * M);
 //#ifdef EXTREME_VERBOSE
@@ -291,19 +290,19 @@ IGL_INLINE bool igl::arap_dof_precomputation(
   //if(data.with_dynamics)
   //{
     // Build cotangent laplacian
-    SparseMatrix<double> Mass;
+    Eigen::SparseMatrix<double> Mass;
     //printf("massmatrix()\n");
     massmatrix(V,F,(F.cols()>3?MASSMATRIX_TYPE_BARYCENTRIC:MASSMATRIX_TYPE_VORONOI),Mass);
     //cout<<"MIJV=["<<endl;print_ijv(Mass,1);cout<<endl<<"];"<<
     //  endl<<"M=sparse(MIJV(:,1),MIJV(:,2),MIJV(:,3),"<<
     //  Mass.rows()<<","<<Mass.cols()<<");"<<endl;
     //speye(data.n,Mass);
-    SparseMatrix<double> Mass_rep;
+    Eigen::SparseMatrix<double> Mass_rep;
     repdiag(Mass,data.dim,Mass_rep);
 
     // Multiply either side by weights matrix (should be dense)
     data.Mass_tilde = MT * Mass_rep * M;
-    MatrixXd ones(data.dim*data.n,data.dim);
+    Eigen::MatrixXd ones(data.dim*data.n,data.dim);
     for(int i = 0;i<data.n;i++)
     {
       for(int d = 0;d<data.dim;d++)
@@ -531,8 +530,7 @@ IGL_INLINE bool igl::arap_dof_recomputation(
   const Eigen::SparseMatrix<double> & A_eq,
   ArapDOFData<LbsMatrixType, SSCALAR> & data)
 {
-  using namespace Eigen;
-  typedef Matrix<SSCALAR, Dynamic, Dynamic> MatrixXS;
+  typedef Eigen::Matrix<SSCALAR, Eigen::Dynamic, Eigen::Dynamic> MatrixXS;
 
   LbsMatrixType * Q;
   LbsMatrixType Qdyn;
@@ -577,9 +575,9 @@ IGL_INLINE bool igl::arap_dof_recomputation(
 
   // Compute dense solve matrix (alternative of matrix factorization)
   //printf("kkt_inverse()\n");
-  MatrixXd Qfull(*Q);
-  MatrixXd A_eqfull(A_eq);
-  MatrixXd M_Solve;
+  Eigen::MatrixXd Qfull(*Q);
+  Eigen::MatrixXd A_eqfull(A_eq);
+  Eigen::MatrixXd M_Solve;
 
   double timer0_start = get_seconds();
   bool use_lu = data.effective_dim != 2;
@@ -646,8 +644,7 @@ IGL_INLINE bool igl::arap_dof_update(
   Eigen::MatrixXd & L
   )
 {
-  using namespace Eigen;
-  typedef Matrix<SSCALAR, Dynamic, Dynamic> MatrixXS;
+  typedef Eigen::Matrix<SSCALAR, Eigen::Dynamic, Eigen::Dynamic> MatrixXS;
 #ifdef ARAP_GLOBAL_TIMING
   double timer_start = get_seconds();
 #endif
@@ -700,9 +697,9 @@ IGL_INLINE bool igl::arap_dof_update(
   MatrixXS S(k*data.dim,data.dim);
   MatrixXS R(data.dim,data.dim*k);
   Eigen::Matrix<SSCALAR,Eigen::Dynamic,1> Rcol(data.dim * data.dim * k);
-  Matrix<SSCALAR,Dynamic,1> B_eq_SSCALAR = B_eq.cast<SSCALAR>();
-  Matrix<SSCALAR,Dynamic,1> L0SSCALAR = L0.cast<SSCALAR>();
-  Matrix<SSCALAR,Dynamic,1> B_eq_fix_SSCALAR = L0SSCALAR(data.fixed_dim);
+  Eigen::Matrix<SSCALAR ,Eigen::Dynamic,1> B_eq_SSCALAR = B_eq.cast<SSCALAR>();
+  Eigen::Matrix<SSCALAR ,Eigen::Dynamic,1> L0SSCALAR = L0.cast<SSCALAR>();
+  Eigen::Matrix<SSCALAR ,Eigen::Dynamic,1> B_eq_fix_SSCALAR = L0SSCALAR(data.fixed_dim);
   //MatrixXS rhsFull(Rcol.rows() + B_eq.rows() + B_eq_fix_SSCALAR.rows(), 1); 
 
   MatrixXS Lsep(data.m*(data.dim + 1), 3);  
@@ -831,13 +828,13 @@ IGL_INLINE bool igl::arap_dof_update(
           ( (-1.0/(data.h*data.h)) * data.L0.array() + 
             (1.0/(data.h)) * data.Lvel0.array()
             ).matrix();
-      MatrixXd temp_d = temp.template cast<double>();
+      Eigen::MatrixXd temp_d = temp.template cast<double>();
 
-      MatrixXd temp_g = data.fgrav*(data.grav_mag*data.grav_dir);
+      Eigen::MatrixXd temp_g = data.fgrav*(data.grav_mag*data.grav_dir);
 
       assert(data.fext.rows() == temp_g.rows());
       assert(data.fext.cols() == temp_g.cols());
-      MatrixXd temp2 = data.Mass_tilde * temp_d + temp_g + data.fext.template cast<double>();
+      Eigen::MatrixXd temp2 = data.Mass_tilde * temp_d + temp_g + data.fext.template cast<double>();
       MatrixXS temp2_f = temp2.template cast<SSCALAR>();
       L_part1_dyn = data.Pi_1 * temp2_f;
       L_part1.array() = L_part1.array() + L_part1_dyn.array();

--- a/include/igl/arap_linear_block.cpp
+++ b/include/igl/arap_linear_block.cpp
@@ -45,15 +45,14 @@ IGL_INLINE void igl::arap_linear_block_spokes(
 {
   typedef typename MatK::Scalar Scalar;
 
-  using namespace Eigen;
   // simplex size (3: triangles, 4: tetrahedra)
   int simplex_size = F.cols();
   // Number of elements
   int m = F.rows();
   // Temporary output
-  Matrix<int,Dynamic,2> edges;
+  Eigen::Matrix<int ,Eigen::Dynamic,2> edges;
   Kd.resize(V.rows(), V.rows());
-  std::vector<Triplet<Scalar> > Kd_IJV;
+  std::vector<Eigen::Triplet<Scalar> > Kd_IJV;
   if(simplex_size == 3)
   {
     // triangles
@@ -79,7 +78,7 @@ IGL_INLINE void igl::arap_linear_block_spokes(
       3,2;
   }
   // gather cotangent weights
-  Matrix<Scalar,Dynamic,Dynamic> C;
+  Eigen::Matrix<Scalar ,Eigen::Dynamic ,Eigen::Dynamic> C;
   cotmatrix_entries(V,F,C);
   // should have weights for each edge
   assert(C.cols() == edges.rows());
@@ -92,10 +91,10 @@ IGL_INLINE void igl::arap_linear_block_spokes(
       int source = F(i,edges(e,0));
       int dest = F(i,edges(e,1));
       double v = 0.5*C(i,e)*(V(source,d)-V(dest,d));
-      Kd_IJV.push_back(Triplet<Scalar>(source,dest,v));
-      Kd_IJV.push_back(Triplet<Scalar>(dest,source,-v));
-      Kd_IJV.push_back(Triplet<Scalar>(source,source,v));
-      Kd_IJV.push_back(Triplet<Scalar>(dest,dest,-v));
+      Kd_IJV.push_back(Eigen::Triplet<Scalar>(source,dest,v));
+      Kd_IJV.push_back(Eigen::Triplet<Scalar>(dest,source,-v));
+      Kd_IJV.push_back(Eigen::Triplet<Scalar>(source,source,v));
+      Kd_IJV.push_back(Eigen::Triplet<Scalar>(dest,dest,-v));
     }
   }
   Kd.setFromTriplets(Kd_IJV.begin(),Kd_IJV.end());
@@ -111,15 +110,14 @@ IGL_INLINE void igl::arap_linear_block_spokes_and_rims(
 {
   typedef typename MatK::Scalar Scalar;
 
-  using namespace Eigen;
   // simplex size (3: triangles, 4: tetrahedra)
   int simplex_size = F.cols();
   // Number of elements
   int m = F.rows();
   // Temporary output
   Kd.resize(V.rows(), V.rows());
-  std::vector<Triplet<Scalar> > Kd_IJV;
-  Matrix<int,Dynamic,2> edges;
+  std::vector<Eigen::Triplet<Scalar> > Kd_IJV;
+  Eigen::Matrix<int ,Eigen::Dynamic,2> edges;
   if(simplex_size == 3)
   {
     // triangles
@@ -147,7 +145,7 @@ IGL_INLINE void igl::arap_linear_block_spokes_and_rims(
     assert(false);
   }
   // gather cotangent weights
-  Matrix<Scalar,Dynamic,Dynamic> C;
+  Eigen::Matrix<Scalar ,Eigen::Dynamic ,Eigen::Dynamic> C;
   cotmatrix_entries(V,F,C);
   // should have weights for each edge
   assert(C.cols() == edges.rows());
@@ -167,18 +165,18 @@ IGL_INLINE void igl::arap_linear_block_spokes_and_rims(
         int Rd = F(i,edges(f,1));
         if(Rs == source && Rd == dest)
         {
-          Kd_IJV.push_back(Triplet<Scalar>(Rs,Rd,v));
-          Kd_IJV.push_back(Triplet<Scalar>(Rd,Rs,-v));
+          Kd_IJV.push_back(Eigen::Triplet<Scalar>(Rs,Rd,v));
+          Kd_IJV.push_back(Eigen::Triplet<Scalar>(Rd,Rs,-v));
         }else if(Rd == source)
         {
-          Kd_IJV.push_back(Triplet<Scalar>(Rd,Rs,v));
+          Kd_IJV.push_back(Eigen::Triplet<Scalar>(Rd,Rs,v));
         }else if(Rs == dest)
         {
-          Kd_IJV.push_back(Triplet<Scalar>(Rs,Rd,-v));
+          Kd_IJV.push_back(Eigen::Triplet<Scalar>(Rs,Rd,-v));
         }
       }
-      Kd_IJV.push_back(Triplet<Scalar>(source,source,v));
-      Kd_IJV.push_back(Triplet<Scalar>(dest,dest,-v));
+      Kd_IJV.push_back(Eigen::Triplet<Scalar>(source,source,v));
+      Kd_IJV.push_back(Eigen::Triplet<Scalar>(dest,dest,-v));
     }
   }
   Kd.setFromTriplets(Kd_IJV.begin(),Kd_IJV.end());
@@ -193,15 +191,14 @@ IGL_INLINE void igl::arap_linear_block_elements(
   MatK & Kd)
 {
   typedef typename MatK::Scalar Scalar;
-  using namespace Eigen;
   // simplex size (3: triangles, 4: tetrahedra)
   int simplex_size = F.cols();
   // Number of elements
   int m = F.rows();
   // Temporary output
   Kd.resize(V.rows(), F.rows());
-  std::vector<Triplet<Scalar> > Kd_IJV;
-  Matrix<int,Dynamic,2> edges;
+  std::vector<Eigen::Triplet<Scalar> > Kd_IJV;
+  Eigen::Matrix<int ,Eigen::Dynamic,2> edges;
   if(simplex_size == 3)
   {
     // triangles
@@ -227,7 +224,7 @@ IGL_INLINE void igl::arap_linear_block_elements(
       3,2;
   }
   // gather cotangent weights
-  Matrix<Scalar,Dynamic,Dynamic> C;
+  Eigen::Matrix<Scalar ,Eigen::Dynamic ,Eigen::Dynamic> C;
   cotmatrix_entries(V,F,C);
   // should have weights for each edge
   assert(C.cols() == edges.rows());
@@ -240,8 +237,8 @@ IGL_INLINE void igl::arap_linear_block_elements(
       int source = F(i,edges(e,0));
       int dest = F(i,edges(e,1));
       double v = C(i,e)*(V(source,d)-V(dest,d));
-      Kd_IJV.push_back(Triplet<Scalar>(source,i,v));
-      Kd_IJV.push_back(Triplet<Scalar>(dest,i,-v));
+      Kd_IJV.push_back(Eigen::Triplet<Scalar>(source,i,v));
+      Kd_IJV.push_back(Eigen::Triplet<Scalar>(dest,i,-v));
     }
   }
   Kd.setFromTriplets(Kd_IJV.begin(),Kd_IJV.end());

--- a/include/igl/arap_linear_block.cpp
+++ b/include/igl/arap_linear_block.cpp
@@ -45,7 +45,6 @@ IGL_INLINE void igl::arap_linear_block_spokes(
 {
   typedef typename MatK::Scalar Scalar;
 
-  using namespace std;
   using namespace Eigen;
   // simplex size (3: triangles, 4: tetrahedra)
   int simplex_size = F.cols();
@@ -54,7 +53,7 @@ IGL_INLINE void igl::arap_linear_block_spokes(
   // Temporary output
   Matrix<int,Dynamic,2> edges;
   Kd.resize(V.rows(), V.rows());
-  vector<Triplet<Scalar> > Kd_IJV;
+  std::vector<Triplet<Scalar> > Kd_IJV;
   if(simplex_size == 3)
   {
     // triangles
@@ -112,7 +111,6 @@ IGL_INLINE void igl::arap_linear_block_spokes_and_rims(
 {
   typedef typename MatK::Scalar Scalar;
 
-  using namespace std;
   using namespace Eigen;
   // simplex size (3: triangles, 4: tetrahedra)
   int simplex_size = F.cols();
@@ -120,7 +118,7 @@ IGL_INLINE void igl::arap_linear_block_spokes_and_rims(
   int m = F.rows();
   // Temporary output
   Kd.resize(V.rows(), V.rows());
-  vector<Triplet<Scalar> > Kd_IJV;
+  std::vector<Triplet<Scalar> > Kd_IJV;
   Matrix<int,Dynamic,2> edges;
   if(simplex_size == 3)
   {
@@ -195,7 +193,6 @@ IGL_INLINE void igl::arap_linear_block_elements(
   MatK & Kd)
 {
   typedef typename MatK::Scalar Scalar;
-  using namespace std;
   using namespace Eigen;
   // simplex size (3: triangles, 4: tetrahedra)
   int simplex_size = F.cols();
@@ -203,7 +200,7 @@ IGL_INLINE void igl::arap_linear_block_elements(
   int m = F.rows();
   // Temporary output
   Kd.resize(V.rows(), F.rows());
-  vector<Triplet<Scalar> > Kd_IJV;
+  std::vector<Triplet<Scalar> > Kd_IJV;
   Matrix<int,Dynamic,2> edges;
   if(simplex_size == 3)
   {

--- a/include/igl/arap_rhs.cpp
+++ b/include/igl/arap_rhs.cpp
@@ -20,7 +20,6 @@ IGL_INLINE void igl::arap_rhs(
     const igl::ARAPEnergyType energy,
     Eigen::SparseCompressedBase<DerivedK>& K)
 {
-  using namespace std;
   using namespace Eigen;
   // Number of dimensions
   int Vdim = V.cols();

--- a/include/igl/arap_rhs.cpp
+++ b/include/igl/arap_rhs.cpp
@@ -20,7 +20,6 @@ IGL_INLINE void igl::arap_rhs(
     const igl::ARAPEnergyType energy,
     Eigen::SparseCompressedBase<DerivedK>& K)
 {
-  using namespace Eigen;
   // Number of dimensions
   int Vdim = V.cols();
   //// Number of mesh vertices

--- a/include/igl/avg_edge_length.h
+++ b/include/igl/avg_edge_length.h
@@ -17,9 +17,9 @@ namespace igl
 {
   /// Compute the average edge length for the given triangle mesh
   ///
-  /// @tparam DerivedV derived from vertex positions matrix type: i.e. MatrixXd
-  /// @tparam DerivedF derived from face indices matrix type: i.e. MatrixXi
-  /// @tparam DerivedL derived from edge lengths matrix type: i.e. MatrixXd
+  /// @tparam DerivedV derived from vertex positions matrix type: i.e. Eigen::MatrixXd
+  /// @tparam DerivedF derived from face indices matrix type: i.e. Eigen::MatrixXi
+  /// @tparam DerivedL derived from edge lengths matrix type: i.e. Eigen::MatrixXd
   /// @param[in] V  #V by dim list of mesh vertex positions
   /// @param[in] F  #F by simplex-size list of mesh faces (must be simplex)
   /// @return average edge length

--- a/include/igl/barycentric_coordinates.cpp
+++ b/include/igl/barycentric_coordinates.cpp
@@ -23,7 +23,6 @@ IGL_INLINE void igl::barycentric_coordinates(
   const Eigen::MatrixBase<DerivedD> & D,
   Eigen::PlainObjectBase<DerivedL> & L)
 {
-  using namespace Eigen;
   assert(P.cols() == 3 && "query must be in 3d");
   assert(A.cols() == 3 && "corners must be in 3d");
   assert(B.cols() == 3 && "corners must be in 3d");
@@ -33,7 +32,7 @@ IGL_INLINE void igl::barycentric_coordinates(
   assert(A.rows() == B.rows() && "Corners must be same size");
   assert(A.rows() == C.rows() && "Corners must be same size");
   assert(A.rows() == D.rows() && "Corners must be same size");
-  typedef Matrix<typename DerivedL::Scalar,DerivedL::RowsAtCompileTime,1> 
+  typedef Eigen::Matrix<typename DerivedL::Scalar,DerivedL::RowsAtCompileTime,1>
     VectorXS;
   // Total volume
   VectorXS vol,LA,LB,LC,LD;
@@ -60,7 +59,6 @@ IGL_INLINE void igl::barycentric_coordinates(
   const Eigen::MatrixBase<DerivedC> & C,
   Eigen::PlainObjectBase<DerivedL> & L)
 {
-  using namespace Eigen;
 #ifndef NDEBUG
   const int DIM = P.cols();
   assert(A.cols() == DIM && "corners must be in same dimension as query");

--- a/include/igl/bbw.cpp
+++ b/include/igl/bbw.cpp
@@ -26,9 +26,8 @@ igl::BBWData::BBWData():
 
 void igl::BBWData::print()
 {
-  using namespace std;
-  cout<<"partition_unity: "<<partition_unity<<endl;
-  cout<<"W0=["<<endl<<W0<<endl<<"];"<<endl;
+  std::cout<<"partition_unity: "<<partition_unity<<std::endl;
+  std::cout<<"W0=["<<std::endl<<W0<<std::endl<<"];"<<std::endl;
 }
 
 
@@ -47,7 +46,6 @@ IGL_INLINE bool igl::bbw(
   Eigen::PlainObjectBase<DerivedW> & W
   )
 {
-  using namespace std;
   using namespace Eigen;
   assert(!data.partition_unity && "partition_unity not implemented yet");
   // number of domain vertices
@@ -69,13 +67,13 @@ IGL_INLINE bool igl::bbw(
   active_set_params eff_params = data.active_set_params;
   if(data.verbosity >= 1)
   {
-    cout<<"BBW: max_iter: "<<data.active_set_params.max_iter<<endl;
-    cout<<"BBW: eff_max_iter: "<<eff_params.max_iter<<endl;
+    std::cout<<"BBW: max_iter: "<<data.active_set_params.max_iter<<std::endl;
+    std::cout<<"BBW: eff_max_iter: "<<eff_params.max_iter<<std::endl;
   }
   if(data.verbosity >= 1)
   {
-    cout<<"BBW: Computing initial weights for "<<m<<" handle"<<
-      (m!=1?"s":"")<<"."<<endl;
+    std::cout<<"BBW: Computing initial weights for "<<m<<" handle"<<
+      (m!=1?"s":"")<<"."<<std::endl;
   }
   min_quad_with_fixed_data<typename DerivedW::Scalar > mqwf;
   min_quad_with_fixed_precompute(Q,b,Aeq,true,mqwf);
@@ -95,8 +93,8 @@ IGL_INLINE bool igl::bbw(
     if(data.verbosity >= 1)
     {
       std::lock_guard<std::mutex> lock(critical);
-      cout<<"BBW: Computing weight for handle "<<i+1<<" out of "<<m<<
-        "."<<endl;
+      std::cout<<"BBW: Computing weight for handle "<<i+1<<" out of "<<m<<
+        "."<<std::endl;
     }
     VectorXd bci = bc.col(i);
     VectorXd Wi;
@@ -133,8 +131,8 @@ IGL_INLINE bool igl::bbw(
   const double min_rowsum = W.rowwise().sum().array().abs().minCoeff();
   if(min_rowsum < 0.1)
   {
-    cerr<<"bbw.cpp: Warning, minimum row sum is very low. Consider more "
-      "active set iterations or enforcing partition of unity."<<endl;
+    std::cerr<<"bbw.cpp: Warning, minimum row sum is very low. Consider more "
+      "active set iterations or enforcing partition of unity."<<std::endl;
   }
 #endif
 

--- a/include/igl/bbw.cpp
+++ b/include/igl/bbw.cpp
@@ -46,7 +46,6 @@ IGL_INLINE bool igl::bbw(
   Eigen::PlainObjectBase<DerivedW> & W
   )
 {
-  using namespace Eigen;
   assert(!data.partition_unity && "partition_unity not implemented yet");
   // number of domain vertices
   int n = V.rows();
@@ -57,13 +56,13 @@ IGL_INLINE bool igl::bbw(
   harmonic(V,Ele,2,Q);
   W.derived().resize(n,m);
   // No linear terms
-  VectorXd c = VectorXd::Zero(n);
+  Eigen::VectorXd c = Eigen::VectorXd::Zero(n);
   // No linear constraints
-  SparseMatrix<typename DerivedW::Scalar> A(0,n),Aeq(0,n),Aieq(0,n);
-  VectorXd Beq(0,1),Bieq(0,1);
+  Eigen::SparseMatrix<typename DerivedW::Scalar> A(0,n),Aeq(0,n),Aieq(0,n);
+  Eigen::VectorXd Beq(0,1),Bieq(0,1);
   // Upper and lower box constraints (Constant bounds)
-  VectorXd ux = VectorXd::Ones(n);
-  VectorXd lx = VectorXd::Zero(n);
+  Eigen::VectorXd ux = Eigen::VectorXd::Ones(n);
+  Eigen::VectorXd lx = Eigen::VectorXd::Zero(n);
   active_set_params eff_params = data.active_set_params;
   if(data.verbosity >= 1)
   {
@@ -96,8 +95,8 @@ IGL_INLINE bool igl::bbw(
       std::cout<<"BBW: Computing weight for handle "<<i+1<<" out of "<<m<<
         "."<<std::endl;
     }
-    VectorXd bci = bc.col(i);
-    VectorXd Wi;
+    Eigen::VectorXd bci = bc.col(i);
+    Eigen::VectorXd Wi;
     // use initial guess
     Wi = W.col(i);
     SolverStatus ret = active_set(

--- a/include/igl/bbw.h
+++ b/include/igl/bbw.h
@@ -40,11 +40,11 @@ namespace igl
   /// Compute Bounded Biharmonic Weights on a given domain (V,Ele) with a given
   /// set of boundary conditions
   ///
-  /// @tparam DerivedV  derived type of eigen matrix for V (e.g. MatrixXd)
-  /// @tparam DerivedF  derived type of eigen matrix for F (e.g. MatrixXi)
-  /// @tparam Derivedb  derived type of eigen matrix for b (e.g. VectorXi)
-  /// @tparam Derivedbc  derived type of eigen matrix for bc (e.g. MatrixXd)
-  /// @tparam DerivedW  derived type of eigen matrix for W (e.g. MatrixXd)
+  /// @tparam DerivedV  derived type of eigen matrix for V (e.g. Eigen::MatrixXd)
+  /// @tparam DerivedF  derived type of eigen matrix for F (e.g. Eigen::MatrixXi)
+  /// @tparam Derivedb  derived type of eigen matrix for b (e.g. Eigen::VectorXi)
+  /// @tparam Derivedbc  derived type of eigen matrix for bc (e.g. Eigen::MatrixXd)
+  /// @tparam DerivedW  derived type of eigen matrix for W (e.g. Eigen::MatrixXd)
   /// @param[in] V  #V by dim vertex positions
   /// @param[in] Ele  #Elements by simplex-size list of element indices
   /// @param[in] b  #b boundary indices into V

--- a/include/igl/bfs_orient.cpp
+++ b/include/igl/bfs_orient.cpp
@@ -18,7 +18,6 @@ IGL_INLINE void igl::bfs_orient(
   Eigen::PlainObjectBase<DerivedC> & C)
 {
   using namespace Eigen;
-  using namespace std;
   SparseMatrix<typename DerivedF::Scalar> A;
   orientable_patches(F,C,A);
 
@@ -38,7 +37,7 @@ IGL_INLINE void igl::bfs_orient(
   // loop over patches
   parallel_for(num_cc,[&](const int c)
   {
-    queue<typename DerivedF::Scalar> Q;
+    std::queue<typename DerivedF::Scalar> Q;
     // find first member of patch c
     for(int f = 0;f<FF.rows();f++)
     {

--- a/include/igl/bfs_orient.cpp
+++ b/include/igl/bfs_orient.cpp
@@ -17,15 +17,14 @@ IGL_INLINE void igl::bfs_orient(
   Eigen::PlainObjectBase<DerivedFF> & FF,
   Eigen::PlainObjectBase<DerivedC> & C)
 {
-  using namespace Eigen;
-  SparseMatrix<typename DerivedF::Scalar> A;
+  Eigen::SparseMatrix<typename DerivedF::Scalar> A;
   orientable_patches(F,C,A);
 
   // number of faces
   const int m = F.rows();
   // number of patches
   const int num_cc = C.maxCoeff()+1;
-  VectorXi seen = VectorXi::Zero(m);
+  Eigen::VectorXi seen = Eigen::VectorXi::Zero(m);
 
   // Edge sets
   const int ES[3][2] = {{1,2},{2,0},{0,1}};
@@ -58,7 +57,7 @@ IGL_INLINE void igl::bfs_orient(
       }
       seen(f)++;
       // loop over neighbors of f
-      for(typename SparseMatrix<typename DerivedF::Scalar>::InnerIterator it (A,f); it; ++it)
+      for(typename Eigen::SparseMatrix<typename DerivedF::Scalar>::InnerIterator it (A,f); it; ++it)
       {
         // might be some lingering zeros, and skip self-adjacency
         if(it.value() != 0 && it.row() != f)
@@ -69,12 +68,12 @@ IGL_INLINE void igl::bfs_orient(
           for(int efi = 0;efi<3;efi++)
           {
             // efi'th edge of face f
-            Vector2i ef(FF(f,ES[efi][0]),FF(f,ES[efi][1]));
+            Eigen::Vector2i ef(FF(f,ES[efi][0]),FF(f,ES[efi][1]));
             // loop over edges of n
             for(int eni = 0;eni<3;eni++)
             {
               // eni'th edge of face n
-              Vector2i en(FF(n,ES[eni][0]),FF(n,ES[eni][1]));
+              Eigen::Vector2i en(FF(n,ES[eni][0]),FF(n,ES[eni][1]));
               // Match (half-edges go same direction)
               if(ef(0) == en(0) && ef(1) == en(1))
               {

--- a/include/igl/biharmonic_coordinates.cpp
+++ b/include/igl/biharmonic_coordinates.cpp
@@ -43,7 +43,6 @@ IGL_INLINE bool igl::biharmonic_coordinates(
   Eigen::PlainObjectBase<DerivedW> & W)
 {
   using namespace Eigen;
-  using namespace std;
 
   typedef typename DerivedV::Scalar Scalar;
   typedef typename DerivedT::Scalar Integer;
@@ -149,7 +148,7 @@ IGL_INLINE bool igl::biharmonic_coordinates(
   }
   // Vertices in point handles
   const size_t mp =
-    count_if(S.begin(),S.end(),[](const vector<SType> & h){return h.size()==1;});
+    count_if(S.begin(),S.end(),[](const std::vector<SType> & h){return h.size()==1;});
   // number of region handles
   const size_t r = S.size()-mp;
   // Vertices in region handles

--- a/include/igl/biharmonic_coordinates.cpp
+++ b/include/igl/biharmonic_coordinates.cpp
@@ -42,29 +42,27 @@ IGL_INLINE bool igl::biharmonic_coordinates(
   const int k,
   Eigen::PlainObjectBase<DerivedW> & W)
 {
-  using namespace Eigen;
-
   typedef typename DerivedV::Scalar Scalar;
   typedef typename DerivedT::Scalar Integer;
 
   // This is not the most efficient way to build A, but follows "Linear
   // Subspace Design for Real-Time Shape Deformation" [Wang et al. 2015].
-  SparseMatrix<Scalar> A;
+  Eigen::SparseMatrix<Scalar> A;
   {
-    DiagonalMatrix<Scalar, Dynamic> Minv;
-    SparseMatrix<Scalar> L, K;
-    Array<bool,Dynamic,Dynamic> C;
+    Eigen::DiagonalMatrix<Scalar, Eigen::Dynamic> Minv;
+    Eigen::SparseMatrix<Scalar> L, K;
+    Eigen::Array<bool ,Eigen::Dynamic ,Eigen::Dynamic> C;
     {
-      Array<bool,Dynamic,1> I;
+      Eigen::Array<bool ,Eigen::Dynamic,1> I;
       on_boundary(T,I,C);
     }
 #ifdef false
     // Version described in paper is "wrong"
     // http://www.cs.toronto.edu/~jacobson/images/error-in-linear-subspace-design-for-real-time-shape-deformation-2017-wang-et-al.pdf
-    SparseMatrix<Scalar> N, Z, M;
+    Eigen::SparseMatrix<Scalar> N, Z, M;
     normal_derivative(V,T,N);
     {
-      std::vector<Triplet<Scalar>> ZIJV;
+      std::vector<Eigen::Triplet<Scalar>> ZIJV;
       for(int t =0;t<T.rows();t++)
       {
         for(int f =0;f<T.cols();f++)
@@ -87,13 +85,13 @@ IGL_INLINE bool igl::biharmonic_coordinates(
     K = N+L;
     massmatrix(V,T,MASSMATRIX_TYPE_DEFAULT,M);
     // normalize
-    M /= ((Matrix<Scalar, Dynamic, 1>)M.diagonal()).array().abs().maxCoeff();
+    M /= ((Matrix<Scalar, Eigen::Dynamic, 1>)M.diagonal()).array().abs().maxCoeff();
     Minv =
-      ((Matrix<Scalar, Dynamic, 1>)M.diagonal().array().inverse()).asDiagonal();
+      ((Matrix<Scalar, Eigen::Dynamic, 1>)M.diagonal().array().inverse()).asDiagonal();
 #else
     Eigen::SparseMatrix<Scalar> M;
-    Eigen::Matrix<Integer, Dynamic, Dynamic> E;
-    Eigen::Matrix<Integer, Dynamic, 1> EMAP;
+    Eigen::Matrix<Integer, Eigen::Dynamic, Eigen::Dynamic> E;
+    Eigen::Matrix<Integer, Eigen::Dynamic, 1> EMAP;
     crouzeix_raviart_massmatrix(V,T,M,E,EMAP);
     crouzeix_raviart_cotmatrix(V,T,E,EMAP,L);
     // Ad  #E by #V facet-vertex incidence matrix
@@ -110,14 +108,14 @@ IGL_INLINE bool igl::biharmonic_coordinates(
       Ad.setFromTriplets(AIJV.begin(),AIJV.end());
     }
     // Degrees
-    Eigen::Matrix<Scalar, Dynamic, 1> De;
+    Eigen::Matrix<Scalar, Eigen::Dynamic, 1> De;
     sum(Ad,2,De);
     Eigen::DiagonalMatrix<Scalar,Eigen::Dynamic> De_diag =
       De.array().inverse().matrix().asDiagonal();
     K = L*(De_diag*Ad);
     // normalize
-    M /= ((Matrix<Scalar, Dynamic, 1>)M.diagonal()).array().abs().maxCoeff();
-    Minv = ((Matrix<Scalar, Dynamic, 1>)M.diagonal().array().inverse()).asDiagonal();
+    M /= ((Eigen::Matrix<Scalar, Eigen::Dynamic, 1>)M.diagonal()).array().abs().maxCoeff();
+    Minv = ((Eigen::Matrix<Scalar, Eigen::Dynamic, 1>)M.diagonal().array().inverse()).asDiagonal();
     // kill boundary edges
     for(int f = 0;f<T.rows();f++)
     {
@@ -162,9 +160,9 @@ IGL_INLINE bool igl::biharmonic_coordinates(
   }
   const size_t dim = T.cols()-1;
   // Might as well be dense... I think...
-  Matrix<Scalar, Dynamic, Dynamic> J = Matrix<Scalar, Dynamic, Dynamic>::Zero(mp+mr,mp+r*(dim+1));
-  Matrix<Integer, Dynamic, 1> b(mp+mr);
-  Matrix<Scalar, Dynamic, Dynamic> H(mp+r*(dim+1),dim);
+  Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> J = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>::Zero(mp+mr,mp+r*(dim+1));
+  Eigen::Matrix<Integer, Eigen::Dynamic, 1> b(mp+mr);
+  Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> H(mp+r*(dim+1),dim);
   {
     int v = 0;
     int c = 0;
@@ -197,7 +195,7 @@ IGL_INLINE bool igl::biharmonic_coordinates(
   // minimize    ½ W' A W'
   // subject to  W(b,:) = J
   return min_quad_with_fixed(
-    A,Matrix<Scalar, Dynamic, 1>::Zero(A.rows()).eval(),b,J,SparseMatrix<Scalar>(),Matrix<Scalar, Dynamic, 1>(),true,W);
+    A,Eigen::Matrix<Scalar, Eigen::Dynamic, 1>::Zero(A.rows()).eval(),b,J,Eigen::SparseMatrix<Scalar>(),Eigen::Matrix<Scalar, Eigen::Dynamic, 1>(),true,W);
 }
 
 #ifdef IGL_STATIC_LIBRARY

--- a/include/igl/biharmonic_coordinates.h
+++ b/include/igl/biharmonic_coordinates.h
@@ -39,10 +39,10 @@ namespace igl
   /// #### Example:
   ///
   /// \code{cpp}
-  ///     MatrixXd W;
+  ///     Eigen::MatrixXd W;
   ///     igl::biharmonic_coordinates(V,F,S,W);
   ///     const size_t dim = T.cols()-1;
-  ///     MatrixXd H(W.cols(),dim);
+  ///     Eigen::MatrixXd H(W.cols(),dim);
   ///     {
   ///       int c = 0;
   ///       for(int h = 0;h<S.size();h++)

--- a/include/igl/boundary_conditions.cpp
+++ b/include/igl/boundary_conditions.cpp
@@ -36,8 +36,6 @@ IGL_INLINE bool igl::boundary_conditions(
   Eigen::PlainObjectBase<Derivedb> & b,
   Eigen::PlainObjectBase<Derivedbc> & bc)
 {
-  using namespace Eigen;
-
   if(P.size()+BE.rows() == 0)
   {
     verbose("^%s: Error: no handles found\n",__FUNCTION__);
@@ -51,7 +49,7 @@ IGL_INLINE bool igl::boundary_conditions(
   // loop over points
   for(int p = 0;p<P.size();p++)
   {
-    VectorXd pos = C.row(P(p));
+    Eigen::VectorXd pos = C.row(P(p));
     // loop over domain vertices
     for(int i = 0;i<V.rows();i++)
     {
@@ -60,7 +58,7 @@ IGL_INLINE bool igl::boundary_conditions(
       // EIGEN GOTCHA:
       // double sqrd = (V.row(i)-pos).array().pow(2).sum();
       // Must first store in temporary
-      VectorXd vi = V.row(i);
+      Eigen::VectorXd vi = V.row(i);
       double sqrd = (vi-pos).squaredNorm();
       if(sqrd <= FLOAT_EPS)
       {
@@ -85,8 +83,8 @@ IGL_INLINE bool igl::boundary_conditions(
     for(int i = 0;i<V.rows();i++)
     {
       // Find samples from tip up to tail
-      VectorXd tip = C.row(BE(e,0));
-      VectorXd tail = C.row(BE(e,1));
+      Eigen::VectorXd tip = C.row(BE(e,0));
+      Eigen::VectorXd tail = C.row(BE(e,1));
       // Compute parameter along bone and squared distance
       double t,sqrd;
       project_to_line(
@@ -110,8 +108,8 @@ IGL_INLINE bool igl::boundary_conditions(
     for(int i = 0;i<V.rows();i++)
     {
       // Find samples from tip up to tail
-      VectorXd tip = C.row(P(CE(e,0)));
-      VectorXd tail = C.row(P(CE(e,1)));
+      Eigen::VectorXd tip = C.row(P(CE(e,0)));
+      Eigen::VectorXd tail = C.row(P(CE(e,1)));
       // Compute parameter along bone and squared distance
       double t,sqrd;
       project_to_line(
@@ -135,10 +133,10 @@ IGL_INLINE bool igl::boundary_conditions(
   // loop over cage faces
   for(int f = 0;f<CF.rows();f++)
   {
-    Vector3d v_0 = C.row(P(CF(f, 0)));
-    Vector3d v_1 = C.row(P(CF(f, 1)));
-    Vector3d v_2 = C.row(P(CF(f, 2)));
-    Vector3d n = (v_1 - v_0).cross(v_2 - v_1);
+    Eigen::Vector3d v_0 = C.row(P(CF(f, 0)));
+    Eigen::Vector3d v_1 = C.row(P(CF(f, 1)));
+    Eigen::Vector3d v_2 = C.row(P(CF(f, 2)));
+    Eigen::Vector3d n = (v_1 - v_0).cross(v_2 - v_1);
     n.normalize();
     // loop over domain vertices
     for (int i = 0;i<V.rows();i++)
@@ -148,13 +146,13 @@ IGL_INLINE bool igl::boundary_conditions(
       {
           continue;
       }
-      Vector3d point = V.row(i);
-      Vector3d v = point - v_0;
+      Eigen::Vector3d point = V.row(i);
+      Eigen::Vector3d v = point - v_0;
       double dist = abs(v.dot(n));
       if (dist <= 1.e-1f)
       {
         //barycentric coordinates
-        Vector3d vec_0 = v_1 - v_0, vec_1 = v_2 - v_0, vec_2 = point - v_0;
+        Eigen::Vector3d vec_0 = v_1 - v_0, vec_1 = v_2 - v_0, vec_2 = point - v_0;
         double d00 = vec_0.dot(vec_0);
         double d01 = vec_0.dot(vec_1);
         double d11 = vec_1.dot(vec_1);
@@ -188,7 +186,7 @@ IGL_INLINE bool igl::boundary_conditions(
   vb.erase(unique(vb.begin(), vb.end()), vb.end());
 
   b.resize(vb.size());
-  bc = MatrixXd::Zero(vb.size(),P.size()+BE.rows());
+  bc = Eigen::MatrixXd::Zero(vb.size(),P.size()+BE.rows());
   // Map from boundary index to index in boundary
   std::map<int,int> bim;
   int i = 0;

--- a/include/igl/boundary_conditions.cpp
+++ b/include/igl/boundary_conditions.cpp
@@ -37,7 +37,6 @@ IGL_INLINE bool igl::boundary_conditions(
   Eigen::PlainObjectBase<Derivedbc> & bc)
 {
   using namespace Eigen;
-  using namespace std;
 
   if(P.size()+BE.rows() == 0)
   {
@@ -45,9 +44,9 @@ IGL_INLINE bool igl::boundary_conditions(
     return false;
   }
 
-  vector<int> bci;
-  vector<int> bcj;
-  vector<double> bcv;
+  std::vector<int> bci;
+  std::vector<int> bcj;
+  std::vector<double> bcv;
 
   // loop over points
   for(int p = 0;p<P.size();p++)
@@ -184,17 +183,17 @@ IGL_INLINE bool igl::boundary_conditions(
   }
 
   // find unique boundary indices
-  vector<int> vb = bci;
-  sort(vb.begin(),vb.end());
+  std::vector<int> vb = bci;
+  std::sort(vb.begin(),vb.end());
   vb.erase(unique(vb.begin(), vb.end()), vb.end());
 
   b.resize(vb.size());
   bc = MatrixXd::Zero(vb.size(),P.size()+BE.rows());
   // Map from boundary index to index in boundary
-  map<int,int> bim;
+  std::map<int,int> bim;
   int i = 0;
   // Also fill in b
-  for(vector<int>::iterator bit = vb.begin();bit != vb.end();bit++)
+  for(std::vector<int>::iterator bit = vb.begin();bit != vb.end();bit++)
   {
     b(i) = *bit;
     bim[*bit] = i;

--- a/include/igl/boundary_loop.cpp
+++ b/include/igl/boundary_loop.cpp
@@ -16,7 +16,6 @@ IGL_INLINE void igl::boundary_loop(
     const Eigen::MatrixBase<DerivedF> & F,
     std::vector<std::vector<Index> >& L)
 {
-  using namespace std;
   using namespace Eigen;
 
   if(F.rows() == 0)
@@ -24,12 +23,12 @@ IGL_INLINE void igl::boundary_loop(
 
   VectorXd Vdummy(F.maxCoeff()+1,1);
   Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, Eigen::Dynamic> TT,TTi;
-  vector<std::vector<int> > VF, VFi;
+  std::vector<std::vector<int> > VF, VFi;
   triangle_triangle_adjacency(F,TT,TTi);
   vertex_triangle_adjacency(Vdummy,F,VF,VFi);
 
-  vector<bool> unvisited = is_border_vertex(F);
-  set<int> unseen;
+  std::vector<bool> unvisited = is_border_vertex(F);
+  std::set<int> unseen;
   for (size_t i = 0; i < unvisited.size(); ++i)
   {
     if (unvisited[i])
@@ -38,7 +37,7 @@ IGL_INLINE void igl::boundary_loop(
 
   while (!unseen.empty())
   {
-    vector<Index> l;
+    std::vector<Index> l;
 
     // Get first vertex of loop
     int start = *unseen.begin();
@@ -94,12 +93,11 @@ IGL_INLINE void igl::boundary_loop(
   std::vector<Index>& L)
 {
   using namespace Eigen;
-  using namespace std;
 
   if(F.rows() == 0)
     return;
 
-  vector<vector<int> > Lall;
+  std::vector<std::vector<int> > Lall;
   boundary_loop(F,Lall);
 
   int idxMax = -1;
@@ -133,12 +131,11 @@ IGL_INLINE void igl::boundary_loop(
   Eigen::PlainObjectBase<DerivedL>& L)
 {
   using namespace Eigen;
-  using namespace std;
 
   if(F.rows() == 0)
     return;
 
-  vector<int> Lvec;
+  std::vector<int> Lvec;
   boundary_loop(F,Lvec);
 
   L.resize(Lvec.size(), 1);

--- a/include/igl/boundary_loop.cpp
+++ b/include/igl/boundary_loop.cpp
@@ -16,12 +16,10 @@ IGL_INLINE void igl::boundary_loop(
     const Eigen::MatrixBase<DerivedF> & F,
     std::vector<std::vector<Index> >& L)
 {
-  using namespace Eigen;
-
   if(F.rows() == 0)
     return;
 
-  VectorXd Vdummy(F.maxCoeff()+1,1);
+  Eigen::VectorXd Vdummy(F.maxCoeff()+1,1);
   Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, Eigen::Dynamic> TT,TTi;
   std::vector<std::vector<int> > VF, VFi;
   triangle_triangle_adjacency(F,TT,TTi);
@@ -92,8 +90,6 @@ IGL_INLINE void igl::boundary_loop(
   const Eigen::MatrixBase<DerivedF>& F,
   std::vector<Index>& L)
 {
-  using namespace Eigen;
-
   if(F.rows() == 0)
     return;
 
@@ -130,8 +126,6 @@ IGL_INLINE void igl::boundary_loop(
   const Eigen::MatrixBase<DerivedF>& F,
   Eigen::PlainObjectBase<DerivedL>& L)
 {
-  using namespace Eigen;
-
   if(F.rows() == 0)
     return;
 

--- a/include/igl/bounding_box.cpp
+++ b/include/igl/bounding_box.cpp
@@ -24,7 +24,6 @@ IGL_INLINE void igl::bounding_box(
   Eigen::PlainObjectBase<DerivedBV>& BV,
   Eigen::PlainObjectBase<DerivedBF>& BF)
 {
-  using namespace std;
 
   const int dim = V.cols();
   const auto & minV = V.colwise().minCoeff().array()-pad;

--- a/include/igl/bounding_box_diagonal.cpp
+++ b/include/igl/bounding_box_diagonal.cpp
@@ -13,9 +13,8 @@
 IGL_INLINE double igl::bounding_box_diagonal(
   const Eigen::MatrixXd & V)
 {
-  using namespace Eigen;
-  VectorXd maxV,minV;
-  VectorXi maxVI,minVI;
+  Eigen::VectorXd maxV,minV;
+  Eigen::VectorXi maxVI,minVI;
   igl::max(V,1,maxV,maxVI);
   igl::min(V,1,minV,minVI);
   return sqrt((maxV-minV).array().square().sum());

--- a/include/igl/cat.cpp
+++ b/include/igl/cat.cpp
@@ -26,7 +26,6 @@ IGL_INLINE void igl::cat(
 {
 
   assert(dim == 1 || dim == 2);
-  using namespace Eigen;
   // Special case if B or A is empty
   if(A.size() == 0)
   {
@@ -40,7 +39,7 @@ IGL_INLINE void igl::cat(
   }
 
   // This is faster than using DynamicSparseMatrix or setFromTriplets
-  C = SparseMatrix<Scalar>(
+  C = Eigen::SparseMatrix<Scalar>(
       dim == 1 ? A.rows()+B.rows() : A.rows(),
       dim == 1 ? A.cols()          : A.cols()+B.cols());
   Eigen::VectorXi per_col = Eigen::VectorXi::Zero(C.cols());
@@ -49,11 +48,11 @@ IGL_INLINE void igl::cat(
     assert(A.outerSize() == B.outerSize());
     for(int k = 0;k<A.outerSize();++k)
     {
-      for(typename SparseMatrix<Scalar>::InnerIterator it (A,k); it; ++it)
+      for(typename Eigen::SparseMatrix<Scalar>::InnerIterator it (A,k); it; ++it)
       {
         per_col(k)++;
       }
-      for(typename SparseMatrix<Scalar>::InnerIterator it (B,k); it; ++it)
+      for(typename Eigen::SparseMatrix<Scalar>::InnerIterator it (B,k); it; ++it)
       {
         per_col(k)++;
       }
@@ -62,14 +61,14 @@ IGL_INLINE void igl::cat(
   {
     for(int k = 0;k<A.outerSize();++k)
     {
-      for(typename SparseMatrix<Scalar>::InnerIterator it (A,k); it; ++it)
+      for(typename Eigen::SparseMatrix<Scalar>::InnerIterator it (A,k); it; ++it)
       {
         per_col(k)++;
       }
     }
     for(int k = 0;k<B.outerSize();++k)
     {
-      for(typename SparseMatrix<Scalar>::InnerIterator it (B,k); it; ++it)
+      for(typename Eigen::SparseMatrix<Scalar>::InnerIterator it (B,k); it; ++it)
       {
         per_col(A.cols() + k)++;
       }
@@ -80,11 +79,11 @@ IGL_INLINE void igl::cat(
   {
     for(int k = 0;k<A.outerSize();++k)
     {
-      for(typename SparseMatrix<Scalar>::InnerIterator it (A,k); it; ++it)
+      for(typename Eigen::SparseMatrix<Scalar>::InnerIterator it (A,k); it; ++it)
       {
         C.insert(it.row(),k) = it.value();
       }
-      for(typename SparseMatrix<Scalar>::InnerIterator it (B,k); it; ++it)
+      for(typename Eigen::SparseMatrix<Scalar>::InnerIterator it (B,k); it; ++it)
       {
         C.insert(A.rows()+it.row(),k) = it.value();
       }
@@ -93,14 +92,14 @@ IGL_INLINE void igl::cat(
   {
     for(int k = 0;k<A.outerSize();++k)
     {
-      for(typename SparseMatrix<Scalar>::InnerIterator it (A,k); it; ++it)
+      for(typename Eigen::SparseMatrix<Scalar>::InnerIterator it (A,k); it; ++it)
       {
         C.insert(it.row(),k) = it.value();
       }
     }
     for(int k = 0;k<B.outerSize();++k)
     {
-      for(typename SparseMatrix<Scalar>::InnerIterator it (B,k); it; ++it)
+      for(typename Eigen::SparseMatrix<Scalar>::InnerIterator it (B,k); it; ++it)
       {
         C.insert(it.row(),A.cols()+k) = it.value();
       }
@@ -177,8 +176,6 @@ template <typename T, typename DerivedC>
 IGL_INLINE void igl::cat(const int dim, const std::vector<T> & A, Eigen::PlainObjectBase<DerivedC> & C)
 {
   assert(dim == 1 || dim == 2);
-  using namespace Eigen;
-
   const int num_mat = A.size();
   if(num_mat == 0)
   {

--- a/include/igl/cat.cpp
+++ b/include/igl/cat.cpp
@@ -157,7 +157,6 @@ IGL_INLINE Mat igl::cat(const int dim, const Mat & A, const Mat & B)
 template <class Mat>
 IGL_INLINE void igl::cat(const std::vector<std::vector< Mat > > & A, Mat & C)
 {
-  using namespace std;
   // Start with empty matrix
   C.resize(0,0);
   for(const auto & row_vec : A)

--- a/include/igl/cat.h
+++ b/include/igl/cat.h
@@ -21,8 +21,8 @@ namespace igl
   /// This is an attempt to act like matlab's cat function.
   /// 
   /// @tparam  Scalar  scalar data type for sparse matrices like double or int
-  /// @tparam  Mat  matrix type for all matrices (e.g. MatrixXd, SparseMatrix)
-  /// @tparam  MatC  matrix type for output matrix (e.g. MatrixXd) needs to support
+  /// @tparam  Mat  matrix type for all matrices (e.g. Eigen::MatrixXd, SparseMatrix)
+  /// @tparam  MatC  matrix type for output matrix (e.g. Eigen::MatrixXd) needs to support
   ///     resize
   /// @param[in]  dim  dimension along which to concatenate, 1 or 2
   /// @param[in]  A  first input matrix

--- a/include/igl/ceil.cpp
+++ b/include/igl/ceil.cpp
@@ -13,7 +13,6 @@ IGL_INLINE void igl::ceil(
   const Eigen::MatrixBase<DerivedX>& X,
   Eigen::PlainObjectBase<DerivedY>& Y)
 {
-  using namespace std;
   typedef typename DerivedX::Scalar Scalar;
   Y = X.unaryExpr([](const Scalar &x)->Scalar{return std::ceil(x);}).template cast<typename DerivedY::Scalar >();
 }

--- a/include/igl/centroid.cpp
+++ b/include/igl/centroid.cpp
@@ -19,7 +19,6 @@ IGL_INLINE void igl::centroid(
   Eigen::PlainObjectBase<Derivedc>& cen,
   Derivedvol & vol)
 {
-  using namespace Eigen;
   assert(F.cols() == 3 && "F should contain triangles.");
   assert(V.cols() == 3 && "V should contain 3d points.");
   const int m = F.rows();

--- a/include/igl/collapse_edge.cpp
+++ b/include/igl/collapse_edge.cpp
@@ -71,7 +71,6 @@ IGL_INLINE bool igl::collapse_edge(
   // draw as degenerate elements at vertex 0 (which should always exist and
   // never get collapsed to anything else since it is the smallest index)
   using namespace Eigen;
-  using namespace std;
   const int eflip = E(e,0)>E(e,1);
   // source and destination
   const int s = eflip?E(e,1):E(e,0);

--- a/include/igl/collapse_edge.cpp
+++ b/include/igl/collapse_edge.cpp
@@ -70,7 +70,6 @@ IGL_INLINE bool igl::collapse_edge(
   // Assign this to 0 rather than, say, -1 so that deleted elements will get
   // draw as degenerate elements at vertex 0 (which should always exist and
   // never get collapsed to anything else since it is the smallest index)
-  using namespace Eigen;
   const int eflip = E(e,0)>E(e,1);
   // source and destination
   const int s = eflip?E(e,1):E(e,0);

--- a/include/igl/collapse_least_cost_edge.cpp
+++ b/include/igl/collapse_least_cost_edge.cpp
@@ -28,7 +28,6 @@ IGL_INLINE bool igl::collapse_least_cost_edge(
   int & f1,
   int & f2)
 {
-  using namespace Eigen;
   using namespace igl;
   std::tuple<double,int,int> p;
   while(true)
@@ -127,7 +126,7 @@ IGL_INLINE bool igl::collapse_least_cost_edge(
     {
        // compute cost and potential placement
        double cost;
-       RowVectorXd place;
+       Eigen::RowVectorXd place;
        cost_and_placement(ei,V,F,E,EMAP,EF,EI,cost,place);
        // Increment timestamp
        EQ(ei)++;

--- a/include/igl/collapse_small_triangles.cpp
+++ b/include/igl/collapse_small_triangles.cpp
@@ -28,7 +28,6 @@ void igl::collapse_small_triangles(
   Eigen::PlainObjectBase<DerivedFF> & FF)
 {
   using namespace Eigen;
-  using namespace std;
 
   // Compute bounding box diagonal length
   double bbd = bounding_box_diagonal(V);

--- a/include/igl/collapse_small_triangles.cpp
+++ b/include/igl/collapse_small_triangles.cpp
@@ -27,13 +27,11 @@ void igl::collapse_small_triangles(
   const double eps,
   Eigen::PlainObjectBase<DerivedFF> & FF)
 {
-  using namespace Eigen;
-
   // Compute bounding box diagonal length
   double bbd = bounding_box_diagonal(V);
-  MatrixXd l;
+  Eigen::MatrixXd l;
   edge_lengths(V,F,l);
-  VectorXd dblA;
+  Eigen::VectorXd dblA;
   doublearea(l,0.,dblA);
 
   // Minimum area tolerance
@@ -84,7 +82,7 @@ void igl::collapse_small_triangles(
   }
 
   // Reindex faces
-  MatrixXi rF = F;
+  Eigen::MatrixXi rF = F;
   // Loop over triangles
   for(int f = 0;f<rF.rows();f++)
   {
@@ -141,7 +139,7 @@ void igl::collapse_small_triangles(
   //// force base case
   //return;
 
-  MatrixXi recFF = FF;
+  Eigen::MatrixXi recFF = FF;
   return collapse_small_triangles(V,recFF,eps,FF);
 }
 

--- a/include/igl/column_to_quats.cpp
+++ b/include/igl/column_to_quats.cpp
@@ -11,7 +11,6 @@ IGL_INLINE bool igl::column_to_quats(
   std::vector<
     Eigen::Quaterniond,Eigen::aligned_allocator<Eigen::Quaterniond> > & vQ)
 {
-  using namespace Eigen;
   if(Q.size() % 4 != 0)
   {
     return false;
@@ -21,7 +20,7 @@ IGL_INLINE bool igl::column_to_quats(
   for(int q=0;q<nQ;q++)
   {
     // Constructor uses wxyz
-    vQ[q] = Quaterniond( Q(q*4+3), Q(q*4+0), Q(q*4+1), Q(q*4+2));
+    vQ[q] = Eigen::Quaterniond( Q(q*4+3), Q(q*4+0), Q(q*4+1), Q(q*4+2));
   }
   return true;
 }

--- a/include/igl/copyleft/cgal/SelfIntersectMesh.h
+++ b/include/igl/copyleft/cgal/SelfIntersectMesh.h
@@ -331,8 +331,6 @@ inline igl::copyleft::cgal::SelfIntersectMesh<
   offending(),
   params(params)
 {
-  using namespace Eigen;
-
 #ifdef IGL_SELFINTERSECTMESH_TIMING
   const auto & tictoc = []() -> double
   {

--- a/include/igl/copyleft/cgal/SelfIntersectMesh.h
+++ b/include/igl/copyleft/cgal/SelfIntersectMesh.h
@@ -331,7 +331,6 @@ inline igl::copyleft::cgal::SelfIntersectMesh<
   offending(),
   params(params)
 {
-  using namespace std;
   using namespace Eigen;
 
 #ifdef IGL_SELFINTERSECTMESH_TIMING
@@ -453,7 +452,6 @@ inline void igl::copyleft::cgal::SelfIntersectMesh<
   DerivedJ,
   DerivedIM>::mark_offensive(const Index f)
 {
-  using namespace std;
   lIF.push_back(f);
   if(offending.count(f) == 0)
   {
@@ -594,7 +592,6 @@ inline bool igl::copyleft::cgal::SelfIntersectMesh<
   const Index va)
 {
   // This was not a good idea. It will not handle coplanar triangles well.
-  using namespace std;
   Segment_3 sa(
     A.vertex((va+1)%3),
     A.vertex((va+2)%3));
@@ -662,8 +659,6 @@ inline bool igl::copyleft::cgal::SelfIntersectMesh<
   const Index fb,
   const std::vector<std::pair<Index,Index> > shared)
 {
-  using namespace std;
-
   auto opposite_vertex = [](const Index a0, const Index a1) {
     // get opposite index of A
     int a2=-1;

--- a/include/igl/copyleft/cgal/complex_to_mesh.cpp
+++ b/include/igl/copyleft/cgal/complex_to_mesh.cpp
@@ -21,7 +21,6 @@ IGL_INLINE bool igl::copyleft::cgal::complex_to_mesh(
   Eigen::PlainObjectBase<DerivedV> & V, 
   Eigen::PlainObjectBase<DerivedF> & F)
 {
-  using namespace Eigen;
   // CGAL/IO/Complex_2_in_triangulation_3_file_writer.h
   using CGAL::Surface_mesher::number_of_facets_on_surface;
 
@@ -140,8 +139,8 @@ IGL_INLINE bool igl::copyleft::cgal::complex_to_mesh(
 
   // CGAL code somehow can end up with unreferenced vertices
   {
-    VectorXi _1;
-    remove_unreferenced( MatrixXd(V), MatrixXi(F), V,F,_1);
+    Eigen::VectorXi _1;
+    remove_unreferenced( Eigen::MatrixXd(V), Eigen::MatrixXi(F), V,F,_1);
   }
 
   return success;

--- a/include/igl/copyleft/cgal/extract_cells.cpp
+++ b/include/igl/copyleft/cgal/extract_cells.cpp
@@ -53,12 +53,12 @@ IGL_INLINE size_t igl::copyleft::cgal::extract_cells(
   using VectorXI = Eigen::Matrix<Index, Eigen::Dynamic, 1>;
   const size_t num_faces = F.rows();
   // Construct edge adjacency
-  MatrixXI E, uE;
-  VectorXI EMAP;
-  VectorXI uEC,uEE;
+  Eigen::MatrixXi E, uE;
+  Eigen::VectorXi EMAP;
+  Eigen::VectorXi uEC,uEE;
   igl::unique_edge_map(F, E, uE, EMAP, uEC, uEE);
   // Cluster into manifold patches
-  VectorXI P;
+  Eigen::VectorXi P;
   igl::extract_manifold_patches(F, EMAP, uEC, uEE, P);
   // Extract cells
   DerivedC per_patch_cells;
@@ -170,9 +170,9 @@ IGL_INLINE size_t igl::copyleft::cgal::extract_cells(
   std::vector<std::vector<bool> > in_Is(num_components);
 
   // Find outer facets, their orientations and cells for each component
-  VectorXI outer_facets(num_components);
-  VectorXI outer_facet_orientation(num_components);
-  VectorXI outer_cells(num_components);
+  Eigen::VectorXi outer_facets(num_components);
+  Eigen::VectorXi outer_facet_orientation(num_components);
+  Eigen::VectorXi outer_cells(num_components);
   igl::parallel_for(num_components,[&](size_t i)
   {
     Is[i].resize(components[i].size());
@@ -269,7 +269,7 @@ IGL_INLINE size_t igl::copyleft::cgal::extract_cells(
       const auto& in_I = in_Is[i];
       const auto& triangles = triangle_lists[i];
 
-      VectorXI closest_facets, closest_facet_orientations;
+      Eigen::VectorXi closest_facets, closest_facet_orientations;
       closest_facet(
         V,
         F,

--- a/include/igl/copyleft/cgal/intersect_other.cpp
+++ b/include/igl/copyleft/cgal/intersect_other.cpp
@@ -67,8 +67,6 @@ namespace igl
         Eigen::PlainObjectBase<DerivedIMAB> & IMAB)
       {
 
-        using namespace Eigen;
-
         typedef typename DerivedFA::Index Index;
         typedef CGAL::Triangle_3<Kernel> Triangle_3; 
         //// Axis-align boxes for all-pairs self-intersection detection

--- a/include/igl/copyleft/cgal/intersect_other.cpp
+++ b/include/igl/copyleft/cgal/intersect_other.cpp
@@ -67,7 +67,6 @@ namespace igl
         Eigen::PlainObjectBase<DerivedIMAB> & IMAB)
       {
 
-        using namespace std;
         using namespace Eigen;
 
         typedef typename DerivedFA::Index Index;
@@ -108,7 +107,6 @@ namespace igl
         std::list<int> lIF;
         const auto cb = [&](const Box &a, const Box &b) -> void
         {
-          using namespace std;
           // index in F and T
           int fa = a.handle()-TA.begin();
           int fb = b.handle()-TB.begin();
@@ -154,7 +152,7 @@ namespace igl
         {
           int i=0;
           for(
-            list<int>::const_iterator ifit = lIF.begin();
+            std::list<int>::const_iterator ifit = lIF.begin();
             ifit!=lIF.end();
             )
           {

--- a/include/igl/copyleft/cgal/minkowski_sum.cpp
+++ b/include/igl/copyleft/cgal/minkowski_sum.cpp
@@ -108,8 +108,8 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   }
   // Combine meshes
   int n=0,m=0;
-  for_each(vW.begin(),vW.end(),[&n](const DerivedW & w){n+=w.rows();});
-  for_each(vG.begin(),vG.end(),[&m](const DerivedG & g){m+=g.rows();});
+  std::for_each(vW.begin(),vW.end(),[&n](const DerivedW & w){n+=w.rows();});
+  std::for_each(vG.begin(),vG.end(),[&m](const DerivedG & g){m+=g.rows();});
   assert(n == offsets.back());
 
   W.resize(n,3);
@@ -194,7 +194,7 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   //// Mask whether positive dot product, or negative: because of exactly zero,
   //// these are not necessarily complementary
   // Nevermind, actually P = !N
-  Array<bool ,Eigen::Dynamic,1> P(m,1),N(m,1);
+  Eigen::Array<bool ,Eigen::Dynamic,1> P(m,1),N(m,1);
   // loop over faces
   int mp = 0,mn = 0;
   for(int f = 0;f<m;f++)
@@ -223,9 +223,9 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
     }
   }
 
-  typedef Eigen::Matrix<typename DerivedG::Scalar ,Eigen::Dynamic ,Eigen::Dynamic> Eigen::MatrixXi;
-  typedef Eigen::Matrix<typename DerivedG::Scalar ,Eigen::Dynamic,1> Eigen::VectorXi;
-  Eigen::MatrixXi GT(mp+mn,3);
+  typedef Eigen::Matrix<typename DerivedG::Scalar ,Eigen::Dynamic ,Eigen::Dynamic> MatrixXI;
+  typedef Eigen::Matrix<typename DerivedG::Scalar ,Eigen::Dynamic,1> VectorXI;
+  MatrixXI GT(mp+mn,3);
   GT<< 
     FA(igl::find(N),igl::placeholders::all), 
     (FA.array()+n).eval()(igl::find(P),igl::placeholders::all);
@@ -239,19 +239,19 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   JT.block(mp,0,mn,1).array()+=m;
 
   // Original non-co-planar faces with positively oriented reversed
-  Eigen::MatrixXi BA(mp+mn,3);
+  MatrixXI BA(mp+mn,3);
   BA << 
     FA(igl::find(P),igl::placeholders::all).rowwise().reverse(), 
     FA(igl::find(N),igl::placeholders::all);
   // Quads along **all** sides
-  Eigen::MatrixXi GQ((mp+mn)*3,4);
+  MatrixXI GQ((mp+mn)*3,4);
   GQ<< 
     BA.col(1), BA.col(0), BA.col(0).array()+n, BA.col(1).array()+n,
     BA.col(2), BA.col(1), BA.col(1).array()+n, BA.col(2).array()+n,
     BA.col(0), BA.col(2), BA.col(2).array()+n, BA.col(0).array()+n;
 
-  Eigen::MatrixXi uGQ;
-  Eigen::VectorXi S,sI,sJ;
+  MatrixXI uGQ;
+  VectorXI S,sI,sJ;
   // Inputs:
   //   F  #F by d list of polygons
   // Outputs:
@@ -260,15 +260,15 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   //   I  #uF index vector so that uF = sort(F,2)(I,:)
   //   J  #F index vector so that sort(F,2) = uF(J,:)
   [](
-      const Eigen::MatrixXi & F,
-      Eigen::VectorXi & S,
-      Eigen::MatrixXi & uF,
-      Eigen::VectorXi & I,
-      Eigen::VectorXi & J)
+      const MatrixXI & F,
+      VectorXI & S,
+      MatrixXI & uF,
+      VectorXI & I,
+      VectorXI & J)
   {
     const int m = F.rows();
     const int d = F.cols();
-    Eigen::MatrixXi sF = F;
+    MatrixXI sF = F;
     const auto MN = sF.rowwise().minCoeff().eval();
     // rotate until smallest index is first
     for(int p = 0;p<d;p++)
@@ -292,9 +292,9 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
         sF.block(f,1,1,d-1) = sF.block(f,1,1,d-1).reverse().eval();
       }
     }
-    Array<bool ,Eigen::Dynamic,1> M = Array<bool ,Eigen::Dynamic,1>::Zero(m,1);
+    Eigen::Array<bool ,Eigen::Dynamic,1> M = Eigen::Array<bool ,Eigen::Dynamic,1>::Zero(m,1);
     {
-      Eigen::VectorXi P = igl::LinSpaced<VectorXI >(d,0,d-1);
+      VectorXI P = igl::LinSpaced<VectorXI >(d,0,d-1);
       for(int p = 0;p<d;p++)
       {
         for(int f = 0;f<m;f++)
@@ -313,7 +313,7 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
       }
     }
     unique_rows(sF,uF,I,J);
-    S = Eigen::VectorXi::Zero(uF.rows(),1);
+    S = VectorXI::Zero(uF.rows(),1);
     assert(m == J.rows());
     for(int f = 0;f<m;f++)
     {

--- a/include/igl/copyleft/cgal/minkowski_sum.cpp
+++ b/include/igl/copyleft/cgal/minkowski_sum.cpp
@@ -38,7 +38,6 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   Eigen::PlainObjectBase<DerivedG> & G,
   Eigen::PlainObjectBase<DerivedJ> & J)
 {
-  using namespace Eigen;
   assert(FA.cols() == 3 && "FA must contain a closed triangle mesh");
   assert(FB.cols() <= FA.cols() && 
     "FB must contain lower diemnsional simplices than FA");
@@ -51,9 +50,9 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
     return interval;
   };
   tictoc();
-  Matrix<typename DerivedFB::Scalar,Dynamic,2> EB;
+  Eigen::Matrix<typename DerivedFB::Scalar ,Eigen::Dynamic,2> EB;
   edges(FB,EB);
-  Matrix<typename DerivedFA::Scalar,Dynamic,2> EA(0,2);
+  Eigen::Matrix<typename DerivedFA::Scalar ,Eigen::Dynamic,2> EA(0,2);
   if(FB.cols() == 3)
   {
     edges(FA,EA);
@@ -71,7 +70,7 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   // sweep A along edges of B
   for(int e = 0;e<n_ab;e++)
   {
-    Matrix<typename DerivedJ::Scalar,Dynamic,1> eJ;
+    Eigen::Matrix<typename DerivedJ::Scalar ,Eigen::Dynamic,1> eJ;
     minkowski_sum(
       VA,
       FA,
@@ -91,7 +90,7 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   // sweep B along edges of A
   for(int e = 0;e<n_ba;e++)
   {
-    Matrix<typename DerivedJ::Scalar,Dynamic,1> eJ;
+    Eigen::Matrix<typename DerivedJ::Scalar ,Eigen::Dynamic,1> eJ;
     const int ee = n_ab+e;
     minkowski_sum(
       VB,
@@ -135,8 +134,8 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
     mesh_boolean(
       DerivedW(W),
       DerivedG(G),
-      Matrix<typename DerivedW::Scalar,Dynamic,Dynamic>(),
-      Matrix<typename DerivedG::Scalar,Dynamic,Dynamic>(),
+      Eigen::Matrix<typename DerivedW::Scalar ,Eigen::Dynamic ,Eigen::Dynamic>(),
+      Eigen::Matrix<typename DerivedG::Scalar ,Eigen::Dynamic ,Eigen::Dynamic>(),
       MESH_BOOLEAN_TYPE_UNION,
       W,
       G,
@@ -163,7 +162,6 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   Eigen::PlainObjectBase<DerivedG> & G,
   Eigen::PlainObjectBase<DerivedJ> & J)
 {
-  using namespace Eigen;
   assert(s.cols() == 3 && "s should be a 3d point");
   assert(d.cols() == 3 && "d should be a 3d point");
   // silly base case
@@ -196,7 +194,7 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   //// Mask whether positive dot product, or negative: because of exactly zero,
   //// these are not necessarily complementary
   // Nevermind, actually P = !N
-  Array<bool,Dynamic,1> P(m,1),N(m,1);
+  Array<bool ,Eigen::Dynamic,1> P(m,1),N(m,1);
   // loop over faces
   int mp = 0,mn = 0;
   for(int f = 0;f<m;f++)
@@ -225,9 +223,9 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
     }
   }
 
-  typedef Matrix<typename DerivedG::Scalar,Dynamic,Dynamic> MatrixXI;
-  typedef Matrix<typename DerivedG::Scalar,Dynamic,1> VectorXI;
-  MatrixXI GT(mp+mn,3);
+  typedef Eigen::Matrix<typename DerivedG::Scalar ,Eigen::Dynamic ,Eigen::Dynamic> Eigen::MatrixXi;
+  typedef Eigen::Matrix<typename DerivedG::Scalar ,Eigen::Dynamic,1> Eigen::VectorXi;
+  Eigen::MatrixXi GT(mp+mn,3);
   GT<< 
     FA(igl::find(N),igl::placeholders::all), 
     (FA.array()+n).eval()(igl::find(P),igl::placeholders::all);
@@ -241,19 +239,19 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   JT.block(mp,0,mn,1).array()+=m;
 
   // Original non-co-planar faces with positively oriented reversed
-  MatrixXI BA(mp+mn,3);
+  Eigen::MatrixXi BA(mp+mn,3);
   BA << 
     FA(igl::find(P),igl::placeholders::all).rowwise().reverse(), 
     FA(igl::find(N),igl::placeholders::all);
   // Quads along **all** sides
-  MatrixXI GQ((mp+mn)*3,4);
+  Eigen::MatrixXi GQ((mp+mn)*3,4);
   GQ<< 
     BA.col(1), BA.col(0), BA.col(0).array()+n, BA.col(1).array()+n,
     BA.col(2), BA.col(1), BA.col(1).array()+n, BA.col(2).array()+n,
     BA.col(0), BA.col(2), BA.col(2).array()+n, BA.col(0).array()+n;
 
-  MatrixXI uGQ;
-  VectorXI S,sI,sJ;
+  Eigen::MatrixXi uGQ;
+  Eigen::VectorXi S,sI,sJ;
   // Inputs:
   //   F  #F by d list of polygons
   // Outputs:
@@ -262,15 +260,15 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   //   I  #uF index vector so that uF = sort(F,2)(I,:)
   //   J  #F index vector so that sort(F,2) = uF(J,:)
   [](
-      const MatrixXI & F,
-      VectorXI & S,
-      MatrixXI & uF,
-      VectorXI & I,
-      VectorXI & J)
+      const Eigen::MatrixXi & F,
+      Eigen::VectorXi & S,
+      Eigen::MatrixXi & uF,
+      Eigen::VectorXi & I,
+      Eigen::VectorXi & J)
   {
     const int m = F.rows();
     const int d = F.cols();
-    MatrixXI sF = F;
+    Eigen::MatrixXi sF = F;
     const auto MN = sF.rowwise().minCoeff().eval();
     // rotate until smallest index is first
     for(int p = 0;p<d;p++)
@@ -294,9 +292,9 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
         sF.block(f,1,1,d-1) = sF.block(f,1,1,d-1).reverse().eval();
       }
     }
-    Array<bool,Dynamic,1> M = Array<bool,Dynamic,1>::Zero(m,1);
+    Array<bool ,Eigen::Dynamic,1> M = Array<bool ,Eigen::Dynamic,1>::Zero(m,1);
     {
-      VectorXI P = igl::LinSpaced<VectorXI >(d,0,d-1);
+      Eigen::VectorXi P = igl::LinSpaced<VectorXI >(d,0,d-1);
       for(int p = 0;p<d;p++)
       {
         for(int f = 0;f<m;f++)
@@ -315,7 +313,7 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
       }
     }
     unique_rows(sF,uF,I,J);
-    S = VectorXI::Zero(uF.rows(),1);
+    S = Eigen::VectorXi::Zero(uF.rows(),1);
     assert(m == J.rows());
     for(int f = 0;f<m;f++)
     {
@@ -357,7 +355,7 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
     Eigen::Matrix<typename DerivedJ::Scalar, Eigen::Dynamic,1> SJ;
     mesh_boolean(
       DerivedW(W),DerivedG(G),
-      Matrix<typename DerivedVA::Scalar,Dynamic,Dynamic>(),MatrixXI(),
+      Eigen::Matrix<typename DerivedVA::Scalar ,Eigen::Dynamic ,Eigen::Dynamic>(),MatrixXI(),
       MESH_BOOLEAN_TYPE_UNION,
       W,G,SJ);
     J = J(SJ).eval();

--- a/include/igl/copyleft/cgal/minkowski_sum.cpp
+++ b/include/igl/copyleft/cgal/minkowski_sum.cpp
@@ -38,7 +38,6 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   Eigen::PlainObjectBase<DerivedG> & G,
   Eigen::PlainObjectBase<DerivedJ> & J)
 {
-  using namespace std;
   using namespace Eigen;
   assert(FA.cols() == 3 && "FA must contain a closed triangle mesh");
   assert(FB.cols() <= FA.cols() && 
@@ -64,10 +63,10 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   // number of copies of B along edges of A
   const int n_ba = EA.rows();
 
-  vector<DerivedW> vW(n_ab + n_ba);
-  vector<DerivedG> vG(n_ab + n_ba);
-  vector<DerivedJ> vJ(n_ab + n_ba);
-  vector<int> offsets(n_ab + n_ba + 1);
+  std::vector<DerivedW> vW(n_ab + n_ba);
+  std::vector<DerivedG> vG(n_ab + n_ba);
+  std::vector<DerivedJ> vJ(n_ab + n_ba);
+  std::vector<int> offsets(n_ab + n_ba + 1);
   offsets[0] = 0;
   // sweep A along edges of B
   for(int e = 0;e<n_ab;e++)
@@ -165,7 +164,6 @@ IGL_INLINE void igl::copyleft::cgal::minkowski_sum(
   Eigen::PlainObjectBase<DerivedJ> & J)
 {
   using namespace Eigen;
-  using namespace std;
   assert(s.cols() == 3 && "s should be a 3d point");
   assert(d.cols() == 3 && "d should be a 3d point");
   // silly base case

--- a/include/igl/copyleft/cgal/outer_hull_legacy.cpp
+++ b/include/igl/copyleft/cgal/outer_hull_legacy.cpp
@@ -54,13 +54,12 @@ IGL_INLINE void igl::copyleft::cgal::outer_hull_legacy(
 #ifdef IGL_OUTER_HULL_DEBUG
   std::cerr << "Extracting outer hull" << std::endl;
 #endif
-  using namespace Eigen;
   typedef typename DerivedF::Index Index;
-  Matrix<Index,DerivedF::RowsAtCompileTime,1> C;
-  typedef Matrix<typename DerivedV::Scalar,Dynamic,DerivedV::ColsAtCompileTime> MatrixXV;
-  //typedef Matrix<typename DerivedF::Scalar,Dynamic,DerivedF::ColsAtCompileTime> MatrixXF;
-  typedef Matrix<typename DerivedG::Scalar,Dynamic,DerivedG::ColsAtCompileTime> MatrixXG;
-  typedef Matrix<typename DerivedJ::Scalar,Dynamic,DerivedJ::ColsAtCompileTime> MatrixXJ;
+  Eigen::Matrix<Index,DerivedF::RowsAtCompileTime,1> C;
+  typedef Eigen::Matrix<typename DerivedV::Scalar ,Eigen::Dynamic,DerivedV::ColsAtCompileTime> MatrixXV;
+  //typedef Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,DerivedF::ColsAtCompileTime> MatrixXF;
+  typedef Eigen::Matrix<typename DerivedG::Scalar ,Eigen::Dynamic,DerivedG::ColsAtCompileTime> MatrixXG;
+  typedef Eigen::Matrix<typename DerivedJ::Scalar ,Eigen::Dynamic,DerivedJ::ColsAtCompileTime> MatrixXJ;
   const Index m = F.rows();
 
   // UNUSED:
@@ -82,11 +81,11 @@ IGL_INLINE void igl::copyleft::cgal::outer_hull_legacy(
 #ifdef IGL_OUTER_HULL_DEBUG
   cout<<"edge map..."<<endl;
 #endif
-  typedef Matrix<typename DerivedF::Scalar,Dynamic,2> MatrixX2I;
-  typedef Matrix<typename DerivedF::Index,Dynamic,1> VectorXI;
-  //typedef Matrix<typename DerivedV::Scalar, 3, 1> Vector3F;
+  typedef Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,2> MatrixX2I;
+  typedef Eigen::Matrix<typename DerivedF::Index ,Eigen::Dynamic,1> Eigen::VectorXi;
+  //typedef Eigen::Matrix<typename DerivedV::Scalar, 3, 1> Vector3F;
   MatrixX2I E,uE;
-  VectorXI EMAP;
+  Eigen::VectorXi EMAP;
   vector<vector<typename DerivedF::Index> > uE2E;
   unique_edge_map(F,E,uE,EMAP,uE2E);
 #ifdef IGL_OUTER_HULL_DEBUG
@@ -103,7 +102,7 @@ IGL_INLINE void igl::copyleft::cgal::outer_hull_legacy(
   std::vector<std::vector<bool> > uE2C;
   order_facets_around_edges(V, F, uE, uE2E, uE2oE, uE2C);
   uE2E = uE2oE;
-  VectorXI diIM(3*m);
+  Eigen::VectorXi diIM(3*m);
   for (auto ue : uE2E) {
       for (size_t i=0; i<ue.size(); i++) {
           auto fe = ue[i];
@@ -113,7 +112,7 @@ IGL_INLINE void igl::copyleft::cgal::outer_hull_legacy(
 
   vector<vector<vector<Index > > > TT,_1;
   triangle_triangle_adjacency(E,EMAP,uE2E,false,TT,_1);
-  VectorXI counts;
+  Eigen::VectorXi counts;
 #ifdef IGL_OUTER_HULL_DEBUG
   cout<<"facet components..."<<endl;
 #endif

--- a/include/igl/copyleft/cgal/outer_hull_legacy.cpp
+++ b/include/igl/copyleft/cgal/outer_hull_legacy.cpp
@@ -55,7 +55,6 @@ IGL_INLINE void igl::copyleft::cgal::outer_hull_legacy(
   std::cerr << "Extracting outer hull" << std::endl;
 #endif
   using namespace Eigen;
-  using namespace std;
   typedef typename DerivedF::Index Index;
   Matrix<Index,DerivedF::RowsAtCompileTime,1> C;
   typedef Matrix<typename DerivedV::Scalar,Dynamic,DerivedV::ColsAtCompileTime> MatrixXV;

--- a/include/igl/copyleft/cgal/outer_hull_legacy.cpp
+++ b/include/igl/copyleft/cgal/outer_hull_legacy.cpp
@@ -82,11 +82,11 @@ IGL_INLINE void igl::copyleft::cgal::outer_hull_legacy(
   cout<<"edge map..."<<endl;
 #endif
   typedef Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,2> MatrixX2I;
-  typedef Eigen::Matrix<typename DerivedF::Index ,Eigen::Dynamic,1> Eigen::VectorXi;
+  typedef Eigen::Matrix<typename DerivedF::Index ,Eigen::Dynamic,1> VectorXI;
   //typedef Eigen::Matrix<typename DerivedV::Scalar, 3, 1> Vector3F;
   MatrixX2I E,uE;
-  Eigen::VectorXi EMAP;
-  vector<vector<typename DerivedF::Index> > uE2E;
+  VectorXI EMAP;
+  std::vector<std::vector<typename DerivedF::Index> > uE2E;
   unique_edge_map(F,E,uE,EMAP,uE2E);
 #ifdef IGL_OUTER_HULL_DEBUG
   for (size_t ui=0; ui<uE.rows(); ui++) {
@@ -102,7 +102,7 @@ IGL_INLINE void igl::copyleft::cgal::outer_hull_legacy(
   std::vector<std::vector<bool> > uE2C;
   order_facets_around_edges(V, F, uE, uE2E, uE2oE, uE2C);
   uE2E = uE2oE;
-  Eigen::VectorXi diIM(3*m);
+  VectorXI diIM(3*m);
   for (auto ue : uE2E) {
       for (size_t i=0; i<ue.size(); i++) {
           auto fe = ue[i];
@@ -110,9 +110,9 @@ IGL_INLINE void igl::copyleft::cgal::outer_hull_legacy(
       }
   }
 
-  vector<vector<vector<Index > > > TT,_1;
+  std::vector<std::vector<std::vector<Index > > > TT,_1;
   triangle_triangle_adjacency(E,EMAP,uE2E,false,TT,_1);
-  Eigen::VectorXi counts;
+  VectorXI counts;
 #ifdef IGL_OUTER_HULL_DEBUG
   cout<<"facet components..."<<endl;
 #endif
@@ -127,18 +127,18 @@ IGL_INLINE void igl::copyleft::cgal::outer_hull_legacy(
   cout<<"reindex..."<<endl;
 #endif
   // H contains list of faces on outer hull;
-  vector<bool> FH(m,false);
-  vector<bool> EH(3*m,false);
-  vector<MatrixXG> vG(ncc);
-  vector<MatrixXJ> vJ(ncc);
-  vector<MatrixXJ> vIM(ncc);
+  std::vector<bool> FH(m,false);
+  std::vector<bool> EH(3*m,false);
+  std::vector<MatrixXG> vG(ncc);
+  std::vector<MatrixXJ> vJ(ncc);
+  std::vector<MatrixXJ> vIM(ncc);
   //size_t face_count = 0;
   for(size_t id = 0;id<ncc;id++)
   {
     vIM[id].resize(counts[id],1);
   }
   // current index into each IM
-  vector<size_t> g(ncc,0);
+  std::vector<size_t> g(ncc,0);
   // place order of each face in its respective component
   for(Index f = 0;f<m;f++)
   {
@@ -176,7 +176,7 @@ IGL_INLINE void igl::copyleft::cgal::outer_hull_legacy(
     int FHcount = 1;
     FH[f] = true;
     // Q contains list of face edges to continue traversing upong
-    queue<int> Q;
+    std::queue<int> Q;
     Q.push(f+0*m);
     Q.push(f+1*m);
     Q.push(f+2*m);
@@ -379,7 +379,7 @@ IGL_INLINE void igl::copyleft::cgal::outer_hull_legacy(
   };
 
   // Reject components which are completely inside other components
-  vector<bool> keep(ncc,true);
+  std::vector<bool> keep(ncc,true);
   size_t nG = 0;
   // This is O( ncc * ncc * m)
   for(size_t id = 0;id<ncc;id++)

--- a/include/igl/copyleft/cgal/peel_outer_hull_layers.cpp
+++ b/include/igl/copyleft/cgal/peel_outer_hull_layers.cpp
@@ -28,10 +28,9 @@ IGL_INLINE int igl::copyleft::cgal::peel_outer_hull_layers(
   Eigen::PlainObjectBase<DerivedI> & I,
   Eigen::PlainObjectBase<Derivedflip > & flip)
 {
-  using namespace Eigen;
-  typedef Matrix<typename DerivedF::Scalar,Dynamic,DerivedF::ColsAtCompileTime> MatrixXF;
-  typedef Matrix<int,Dynamic,1> MatrixXI;
-  typedef Matrix<typename Derivedflip::Scalar,Dynamic,Derivedflip::ColsAtCompileTime> MatrixXflip;
+  typedef Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,DerivedF::ColsAtCompileTime> MatrixXF;
+  typedef Eigen::Matrix<int ,Eigen::Dynamic,1> Eigen::MatrixXi;
+  typedef Eigen::Matrix<typename Derivedflip::Scalar ,Eigen::Dynamic,Derivedflip::ColsAtCompileTime> MatrixXflip;
   const int m = F.rows();
 #ifdef IGL_PEEL_OUTER_HULL_LAYERS_DEBUG
   cout<<"peel outer hull layers..."<<endl;
@@ -49,16 +48,16 @@ IGL_INLINE int igl::copyleft::cgal::peel_outer_hull_layers(
   I.resize(m,1);
   flip.resize(m,1);
   // Keep track of index map
-  MatrixXI IM = igl::LinSpaced<MatrixXI >(m,0,m-1);
+  Eigen::MatrixXi IM = igl::LinSpaced<MatrixXI >(m,0,m-1);
   // This is O(n * layers)
-  MatrixXI P(m,1);
+  Eigen::MatrixXi P(m,1);
   int iter = 0;
   while(Fr.size() > 0)
   {
     assert(Fr.rows() == IM.rows());
     // Compute outer hull of current Fr
     MatrixXF Fo;
-    MatrixXI Jo;
+    Eigen::MatrixXi Jo;
     MatrixXflip flipr;
 #ifdef IGL_PEEL_OUTER_HULL_LAYERS_DEBUG
   {
@@ -92,7 +91,7 @@ IGL_INLINE int igl::copyleft::cgal::peel_outer_hull_layers(
     // Fr = Fr - Fo
     // update IM
     MatrixXF prev_Fr = Fr;
-    MatrixXI prev_IM = IM;
+    Eigen::MatrixXi prev_IM = IM;
     Fr.resize(prev_Fr.rows() - Fo.rows(),F.cols());
     IM.resize(Fr.rows());
     {

--- a/include/igl/copyleft/cgal/peel_outer_hull_layers.cpp
+++ b/include/igl/copyleft/cgal/peel_outer_hull_layers.cpp
@@ -29,7 +29,6 @@ IGL_INLINE int igl::copyleft::cgal::peel_outer_hull_layers(
   Eigen::PlainObjectBase<Derivedflip > & flip)
 {
   using namespace Eigen;
-  using namespace std;
   typedef Matrix<typename DerivedF::Scalar,Dynamic,DerivedF::ColsAtCompileTime> MatrixXF;
   typedef Matrix<int,Dynamic,1> MatrixXI;
   typedef Matrix<typename Derivedflip::Scalar,Dynamic,Derivedflip::ColsAtCompileTime> MatrixXflip;
@@ -82,7 +81,7 @@ IGL_INLINE int igl::copyleft::cgal::peel_outer_hull_layers(
     assert(Fo.rows() != 0);
     assert(Fo.rows() == Jo.rows());
     // all faces in Fo of Fr
-    vector<bool> in_outer(Fr.rows(),false);
+    std::vector<bool> in_outer(Fr.rows(),false);
     for(int g = 0;g<Jo.rows();g++)
     {
       I(IM(Jo(g))) = iter;

--- a/include/igl/copyleft/cgal/peel_outer_hull_layers.cpp
+++ b/include/igl/copyleft/cgal/peel_outer_hull_layers.cpp
@@ -29,7 +29,7 @@ IGL_INLINE int igl::copyleft::cgal::peel_outer_hull_layers(
   Eigen::PlainObjectBase<Derivedflip > & flip)
 {
   typedef Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,DerivedF::ColsAtCompileTime> MatrixXF;
-  typedef Eigen::Matrix<int ,Eigen::Dynamic,1> Eigen::MatrixXi;
+  typedef Eigen::Matrix<int ,Eigen::Dynamic,1> MatrixXI;
   typedef Eigen::Matrix<typename Derivedflip::Scalar ,Eigen::Dynamic,Derivedflip::ColsAtCompileTime> MatrixXflip;
   const int m = F.rows();
 #ifdef IGL_PEEL_OUTER_HULL_LAYERS_DEBUG
@@ -48,16 +48,16 @@ IGL_INLINE int igl::copyleft::cgal::peel_outer_hull_layers(
   I.resize(m,1);
   flip.resize(m,1);
   // Keep track of index map
-  Eigen::MatrixXi IM = igl::LinSpaced<MatrixXI >(m,0,m-1);
+  MatrixXI IM = igl::LinSpaced<MatrixXI >(m,0,m-1);
   // This is O(n * layers)
-  Eigen::MatrixXi P(m,1);
+  MatrixXI P(m,1);
   int iter = 0;
   while(Fr.size() > 0)
   {
     assert(Fr.rows() == IM.rows());
     // Compute outer hull of current Fr
     MatrixXF Fo;
-    Eigen::MatrixXi Jo;
+    MatrixXI Jo;
     MatrixXflip flipr;
 #ifdef IGL_PEEL_OUTER_HULL_LAYERS_DEBUG
   {
@@ -91,7 +91,7 @@ IGL_INLINE int igl::copyleft::cgal::peel_outer_hull_layers(
     // Fr = Fr - Fo
     // update IM
     MatrixXF prev_Fr = Fr;
-    Eigen::MatrixXi prev_IM = IM;
+    MatrixXI prev_IM = IM;
     Fr.resize(prev_Fr.rows() - Fo.rows(),F.cols());
     IM.resize(Fr.rows());
     {

--- a/include/igl/copyleft/cgal/point_mesh_squared_distance.cpp
+++ b/include/igl/copyleft/cgal/point_mesh_squared_distance.cpp
@@ -26,14 +26,13 @@ IGL_INLINE void igl::copyleft::cgal::point_mesh_squared_distance(
         Eigen::PlainObjectBase<DerivedI> & I,
         Eigen::PlainObjectBase<DerivedC> & C)
 {
-  using namespace std;
-  typedef CGAL::Triangle_3<Kernel> Triangle_3; 
+  typedef CGAL::Triangle_3<Kernel> Triangle_3;
   typedef typename std::vector<Triangle_3>::iterator Iterator;
   typedef CGAL::AABB_triangle_primitive<Kernel, Iterator> Primitive;
   typedef CGAL::AABB_traits<Kernel, Primitive> AABB_triangle_traits;
   typedef CGAL::AABB_tree<AABB_triangle_traits> Tree;
   Tree tree;
-  vector<Triangle_3> T;
+  std::vector<Triangle_3> T;
   point_mesh_squared_distance_precompute(V,F,tree,T);
   return point_mesh_squared_distance(P,tree,T,sqrD,I,C);
 }
@@ -51,9 +50,7 @@ IGL_INLINE void igl::copyleft::cgal::point_mesh_squared_distance_precompute(
   > & tree,
   std::vector<CGAL::Triangle_3<Kernel> > & T)
 {
-  using namespace std;
-
-  typedef CGAL::Point_3<Kernel> Point_3; 
+  typedef CGAL::Point_3<Kernel> Point_3;
 
   // Must be 3D
   assert(V.cols() == 3);

--- a/include/igl/copyleft/cgal/points_inside_component.cpp
+++ b/include/igl/copyleft/cgal/points_inside_component.cpp
@@ -137,8 +137,8 @@ namespace igl {
                 igl::copyleft::cgal::assign_scalar(query.x(), pivot_point(0, 0));
                 igl::copyleft::cgal::assign_scalar(query.y(), pivot_point(0, 1));
                 igl::copyleft::cgal::assign_scalar(query.z(), pivot_point(0, 2));
-                using VectorXI = Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, 1>;
-                VectorXI order;
+                using Eigen::VectorXi = Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, 1>;
+                Eigen::VectorXi order;
                 order_facets_around_edge(V, F, s, d,
                         adj_faces, pivot_point, order);
                 assert((size_t)order.size() == num_adj_faces);
@@ -335,8 +335,8 @@ IGL_INLINE void igl::copyleft::cgal::points_inside_component(
         const Eigen::MatrixBase<DerivedF>& F,
         const Eigen::MatrixBase<DerivedP>& P,
         Eigen::PlainObjectBase<DerivedB>& inside) {
-    using VectorXI = Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, 1>;
-    VectorXI I = igl::LinSpaced<VectorXI>(F.rows(), 0, F.rows()-1);
+    using Eigen::VectorXi = Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, 1>;
+    Eigen::VectorXi I = igl::LinSpaced<VectorXI>(F.rows(), 0, F.rows()-1);
     igl::copyleft::cgal::points_inside_component(V, F, I, P, inside);
 }
 

--- a/include/igl/copyleft/cgal/points_inside_component.cpp
+++ b/include/igl/copyleft/cgal/points_inside_component.cpp
@@ -137,8 +137,8 @@ namespace igl {
                 igl::copyleft::cgal::assign_scalar(query.x(), pivot_point(0, 0));
                 igl::copyleft::cgal::assign_scalar(query.y(), pivot_point(0, 1));
                 igl::copyleft::cgal::assign_scalar(query.z(), pivot_point(0, 2));
-                using Eigen::VectorXi = Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, 1>;
-                Eigen::VectorXi order;
+                using VectorXI = Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, 1>;
+                VectorXI order;
                 order_facets_around_edge(V, F, s, d,
                         adj_faces, pivot_point, order);
                 assert((size_t)order.size() == num_adj_faces);
@@ -335,8 +335,8 @@ IGL_INLINE void igl::copyleft::cgal::points_inside_component(
         const Eigen::MatrixBase<DerivedF>& F,
         const Eigen::MatrixBase<DerivedP>& P,
         Eigen::PlainObjectBase<DerivedB>& inside) {
-    using Eigen::VectorXi = Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, 1>;
-    Eigen::VectorXi I = igl::LinSpaced<VectorXI>(F.rows(), 0, F.rows()-1);
+    using VectorXI = Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, 1>;
+    VectorXI I = igl::LinSpaced<VectorXI>(F.rows(), 0, F.rows()-1);
     igl::copyleft::cgal::points_inside_component(V, F, I, P, inside);
 }
 

--- a/include/igl/copyleft/cgal/polyhedron_to_mesh.cpp
+++ b/include/igl/copyleft/cgal/polyhedron_to_mesh.cpp
@@ -18,7 +18,6 @@ IGL_INLINE void igl::copyleft::cgal::polyhedron_to_mesh(
   Eigen::PlainObjectBase<DerivedV> & V,
   Eigen::PlainObjectBase<DerivedF> & F)
 {
-  using namespace std;
   V.resize(poly.size_of_vertices(),3);
   F.resize(poly.size_of_facets(),3);
   typedef typename Polyhedron::Vertex_const_iterator Vertex_iterator;

--- a/include/igl/copyleft/cgal/projected_delaunay.cpp
+++ b/include/igl/copyleft/cgal/projected_delaunay.cpp
@@ -25,7 +25,6 @@ IGL_INLINE void igl::copyleft::cgal::projected_delaunay(
         CGAL::Constrained_triangulation_face_base_2<Kernel> >,
       CGAL::Exact_intersections_tag> > & cdt)
 {
-  using namespace std;
   // 3D Primitives
   typedef CGAL::Point_3<Kernel>    Point_3;
   typedef CGAL::Segment_3<Kernel>  Segment_3; 

--- a/include/igl/copyleft/cgal/propagate_winding_numbers.cpp
+++ b/include/igl/copyleft/cgal/propagate_winding_numbers.cpp
@@ -41,8 +41,8 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
     Eigen::PlainObjectBase<DerivedW>& W) 
 {
   using Index = typename DerivedF::Scalar;
-  using Eigen::MatrixXi = Eigen::Matrix<Index, Eigen::Dynamic, Eigen::Dynamic>;
-  using Eigen::VectorXi = Eigen::Matrix<Index, Eigen::Dynamic, 1>;
+  using MatrixXI = Eigen::Matrix<Index, Eigen::Dynamic, Eigen::Dynamic>;
+  using VectorXI = Eigen::Matrix<Index, Eigen::Dynamic, 1>;
 
 #ifdef PROPAGATE_WINDING_NUMBER_TIMING
   const auto & tictoc = []() -> double
@@ -59,11 +59,11 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
   tictoc();
 #endif
 
-  Eigen::MatrixXi E, uE;
-  Eigen::VectorXi EMAP, uEC, uEE;
+  MatrixXI E, uE;
+  VectorXI EMAP, uEC, uEE;
   igl::unique_edge_map(F, E, uE, EMAP, uEC, uEE);
 
-  Eigen::VectorXi P;
+  VectorXI P;
   const size_t num_patches = igl::extract_manifold_patches(F,EMAP,uEC,uEE,P);
 
   DerivedW per_patch_cells;
@@ -105,8 +105,8 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
     Eigen::PlainObjectBase<DerivedW>& W)
 {
   using Index = typename DerivedF::Scalar;
-  using Eigen::MatrixXi = Eigen::Matrix<Index, Eigen::Dynamic, Eigen::Dynamic>;
-  using Eigen::VectorXi = Eigen::Matrix<Index, Eigen::Dynamic, 1>;
+  using MatrixXI = Eigen::Matrix<Index, Eigen::Dynamic, Eigen::Dynamic>;
+  using VectorXI = Eigen::Matrix<Index, Eigen::Dynamic, 1>;
 #ifdef PROPAGATE_WINDING_NUMBER_TIMING
   const auto & tictoc = []() -> double
   {
@@ -150,7 +150,7 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
         }
       }
     }
-    Eigen::MatrixXi cell_faces(faces.size(), 3);
+    MatrixXI cell_faces(faces.size(), 3);
     for (size_t i=0; i<faces.size(); i++) {
       cell_faces.row(i) = F.row(faces[i]);
     }
@@ -163,9 +163,9 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
 #ifdef IGL_COPYLEFT_CGAL_PROPAGATE_WINDING_NUMBERS_DEBUG
   {
     // Check for odd cycle.
-    Eigen::VectorXi cell_labels(num_cells);
+    VectorXI cell_labels(num_cells);
     cell_labels.setZero();
-    Eigen::VectorXi parents(num_cells);
+    VectorXI parents(num_cells);
     parents.setConstant(-1);
     auto trace_parents = [&](size_t idx) -> std::list<size_t> {
       std::list<size_t> path;
@@ -228,7 +228,7 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
 
   Eigen::Index outer_facet;
   bool flipped;
-  Eigen::VectorXi I = igl::LinSpaced<VectorXI>(num_faces, 0, num_faces-1);
+  VectorXI I = igl::LinSpaced<VectorXI>(num_faces, 0, num_faces-1);
   igl::copyleft::cgal::outer_facet(V, F, I, outer_facet, flipped);
 #ifdef PROPAGATE_WINDING_NUMBER_TIMING
   log_time("outer_facet");
@@ -237,7 +237,7 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
   const size_t outer_patch = P[outer_facet];
   const size_t infinity_cell = C(outer_patch, flipped?1:0);
 
-  Eigen::VectorXi patch_labels(num_patches);
+  VectorXI patch_labels(num_patches);
   const int INVALID = std::numeric_limits<int>::max();
   patch_labels.setConstant(INVALID);
   for (size_t i=0; i<num_faces; i++) {
@@ -250,7 +250,7 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
   assert((patch_labels.array() != INVALID).all());
   const size_t num_labels = patch_labels.maxCoeff()+1;
 
-  Eigen::MatrixXi per_cell_W(num_cells, num_labels);
+  MatrixXI per_cell_W(num_cells, num_labels);
   per_cell_W.setConstant(INVALID);
   per_cell_W.row(infinity_cell).setZero();
   std::queue<size_t> Q;

--- a/include/igl/copyleft/cgal/propagate_winding_numbers.cpp
+++ b/include/igl/copyleft/cgal/propagate_winding_numbers.cpp
@@ -41,8 +41,8 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
     Eigen::PlainObjectBase<DerivedW>& W) 
 {
   using Index = typename DerivedF::Scalar;
-  using MatrixXI = Eigen::Matrix<Index, Eigen::Dynamic, Eigen::Dynamic>;
-  using VectorXI = Eigen::Matrix<Index, Eigen::Dynamic, 1>;
+  using Eigen::MatrixXi = Eigen::Matrix<Index, Eigen::Dynamic, Eigen::Dynamic>;
+  using Eigen::VectorXi = Eigen::Matrix<Index, Eigen::Dynamic, 1>;
 
 #ifdef PROPAGATE_WINDING_NUMBER_TIMING
   const auto & tictoc = []() -> double
@@ -59,11 +59,11 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
   tictoc();
 #endif
 
-  MatrixXI E, uE;
-  VectorXI EMAP, uEC, uEE;
+  Eigen::MatrixXi E, uE;
+  Eigen::VectorXi EMAP, uEC, uEE;
   igl::unique_edge_map(F, E, uE, EMAP, uEC, uEE);
 
-  VectorXI P;
+  Eigen::VectorXi P;
   const size_t num_patches = igl::extract_manifold_patches(F,EMAP,uEC,uEE,P);
 
   DerivedW per_patch_cells;
@@ -105,8 +105,8 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
     Eigen::PlainObjectBase<DerivedW>& W)
 {
   using Index = typename DerivedF::Scalar;
-  using MatrixXI = Eigen::Matrix<Index, Eigen::Dynamic, Eigen::Dynamic>;
-  using VectorXI = Eigen::Matrix<Index, Eigen::Dynamic, 1>;
+  using Eigen::MatrixXi = Eigen::Matrix<Index, Eigen::Dynamic, Eigen::Dynamic>;
+  using Eigen::VectorXi = Eigen::Matrix<Index, Eigen::Dynamic, 1>;
 #ifdef PROPAGATE_WINDING_NUMBER_TIMING
   const auto & tictoc = []() -> double
   {
@@ -150,7 +150,7 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
         }
       }
     }
-    MatrixXI cell_faces(faces.size(), 3);
+    Eigen::MatrixXi cell_faces(faces.size(), 3);
     for (size_t i=0; i<faces.size(); i++) {
       cell_faces.row(i) = F.row(faces[i]);
     }
@@ -163,9 +163,9 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
 #ifdef IGL_COPYLEFT_CGAL_PROPAGATE_WINDING_NUMBERS_DEBUG
   {
     // Check for odd cycle.
-    VectorXI cell_labels(num_cells);
+    Eigen::VectorXi cell_labels(num_cells);
     cell_labels.setZero();
-    VectorXI parents(num_cells);
+    Eigen::VectorXi parents(num_cells);
     parents.setConstant(-1);
     auto trace_parents = [&](size_t idx) -> std::list<size_t> {
       std::list<size_t> path;
@@ -228,7 +228,7 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
 
   Eigen::Index outer_facet;
   bool flipped;
-  VectorXI I = igl::LinSpaced<VectorXI>(num_faces, 0, num_faces-1);
+  Eigen::VectorXi I = igl::LinSpaced<VectorXI>(num_faces, 0, num_faces-1);
   igl::copyleft::cgal::outer_facet(V, F, I, outer_facet, flipped);
 #ifdef PROPAGATE_WINDING_NUMBER_TIMING
   log_time("outer_facet");
@@ -237,7 +237,7 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
   const size_t outer_patch = P[outer_facet];
   const size_t infinity_cell = C(outer_patch, flipped?1:0);
 
-  VectorXI patch_labels(num_patches);
+  Eigen::VectorXi patch_labels(num_patches);
   const int INVALID = std::numeric_limits<int>::max();
   patch_labels.setConstant(INVALID);
   for (size_t i=0; i<num_faces; i++) {
@@ -250,7 +250,7 @@ IGL_INLINE bool igl::copyleft::cgal::propagate_winding_numbers(
   assert((patch_labels.array() != INVALID).all());
   const size_t num_labels = patch_labels.maxCoeff()+1;
 
-  MatrixXI per_cell_W(num_cells, num_labels);
+  Eigen::MatrixXi per_cell_W(num_cells, num_labels);
   per_cell_W.setConstant(INVALID);
   per_cell_W.row(infinity_cell).setZero();
   std::queue<size_t> Q;

--- a/include/igl/copyleft/cgal/remesh_self_intersections.cpp
+++ b/include/igl/copyleft/cgal/remesh_self_intersections.cpp
@@ -31,7 +31,6 @@ IGL_INLINE void igl::copyleft::cgal::remesh_self_intersections(
   Eigen::PlainObjectBase<DerivedJ> & J,
   Eigen::PlainObjectBase<DerivedIM> & IM)
 {
-  using namespace std;
   typedef typename DerivedV::Scalar VScalar;
   if(params.detect_only && ! std::is_same<VScalar,CGAL::Epeck::FT>::value)
   {

--- a/include/igl/copyleft/cgal/resolve_intersections.cpp
+++ b/include/igl/copyleft/cgal/resolve_intersections.cpp
@@ -31,14 +31,13 @@ IGL_INLINE void igl::copyleft::cgal::resolve_intersections(
   Eigen::PlainObjectBase<DerivedJ> & J,
   Eigen::PlainObjectBase<DerivedIM> & IM)
 {
-  using namespace Eigen;
   using namespace igl;
   // Exact scalar type
   typedef CGAL::Epeck K;
   typedef K::FT EScalar;
   typedef CGAL::Segment_2<K> Segment_2;
   typedef CGAL::Point_2<K> Point_2;
-  typedef Matrix<EScalar,Dynamic,Dynamic>  MatrixXE;
+  typedef Eigen::Matrix<EScalar ,Eigen::Dynamic ,Eigen::Dynamic>  MatrixXE;
 
   // Convert vertex positions to exact kernel
   MatrixXE VE(V.rows(),V.cols());

--- a/include/igl/copyleft/cgal/resolve_intersections.cpp
+++ b/include/igl/copyleft/cgal/resolve_intersections.cpp
@@ -33,7 +33,6 @@ IGL_INLINE void igl::copyleft::cgal::resolve_intersections(
 {
   using namespace Eigen;
   using namespace igl;
-  using namespace std;
   // Exact scalar type
   typedef CGAL::Epeck K;
   typedef K::FT EScalar;

--- a/include/igl/copyleft/cgal/signed_distance_isosurface.cpp
+++ b/include/igl/copyleft/cgal/signed_distance_isosurface.cpp
@@ -99,9 +99,9 @@ IGL_INLINE bool igl::copyleft::cgal::signed_distance_isosurface(
         [&tree,&IV,&IF,&level](const Point_3 & q) -> FT
         {
           int i;
-          RowVector3d c;
+          Eigen::RowVector3d c;
           const double sd = tree.squared_distance(
-            IV,IF,RowVector3d(q.x(),q.y(),q.z()),i,c);
+            IV,IF,Eigen::RowVector3d(q.x(),q.y(),q.z()),i,c);
           return sd-level;
         };
     case SIGNED_DISTANCE_TYPE_DEFAULT:
@@ -110,7 +110,7 @@ IGL_INLINE bool igl::copyleft::cgal::signed_distance_isosurface(
         [&tree,&IV,&IF,&hier,&level](const Point_3 & q) -> FT
         {
           const double sd = signed_distance_winding_number(
-            tree,IV,IF,hier,Vector3d(q.x(),q.y(),q.z()));
+            tree,IV,IF,hier,Eigen::Vector3d(q.x(),q.y(),q.z()));
           return sd-level;
         };
       break;
@@ -119,7 +119,7 @@ IGL_INLINE bool igl::copyleft::cgal::signed_distance_isosurface(
         {
           const double sd = 
             igl::signed_distance_pseudonormal(
-              tree,IV,IF,FN,VN,EN,EMAP,RowVector3d(q.x(),q.y(),q.z()));
+              tree,IV,IF,FN,VN,EN,EMAP,Eigen::RowVector3d(q.x(),q.y(),q.z()));
           return sd- level;
         };
       break;

--- a/include/igl/copyleft/cgal/signed_distance_isosurface.cpp
+++ b/include/igl/copyleft/cgal/signed_distance_isosurface.cpp
@@ -38,8 +38,6 @@ IGL_INLINE bool igl::copyleft::cgal::signed_distance_isosurface(
   Eigen::MatrixXd & V,
   Eigen::MatrixXi & F)
 {
-  using namespace Eigen;
-
   // default triangulation for Surface_mesher
   typedef CGAL::Surface_mesh_default_triangulation_3 Tr;
   // c2t3

--- a/include/igl/copyleft/cgal/signed_distance_isosurface.cpp
+++ b/include/igl/copyleft/cgal/signed_distance_isosurface.cpp
@@ -38,7 +38,6 @@ IGL_INLINE bool igl::copyleft::cgal::signed_distance_isosurface(
   Eigen::MatrixXd & V,
   Eigen::MatrixXi & F)
 {
-  using namespace std;
   using namespace Eigen;
 
   // default triangulation for Surface_mesher

--- a/include/igl/copyleft/cgal/snap_rounding.cpp
+++ b/include/igl/copyleft/cgal/snap_rounding.cpp
@@ -32,7 +32,6 @@ IGL_INLINE void igl::copyleft::cgal::snap_rounding(
   using namespace Eigen;
   using namespace igl;
   using namespace igl::copyleft::cgal;
-  using namespace std;
   // Exact scalar type
   typedef CGAL::Epeck Kernel;
   typedef Kernel::FT EScalar;
@@ -98,19 +97,19 @@ IGL_INLINE void igl::copyleft::cgal::snap_rounding(
     search(-1);
     return i;
   };
-  vector<Point_2> hot;
+  std::vector<Point_2> hot;
   for(int i = 0;i<VE.rows();i++)
   {
     hot.emplace_back(round(VE(i,0)),round(VE(i,1)));
   }
   {
     std::vector<size_t> _1,_2;
-    igl::unique(vector<Point_2>(hot),hot,_1,_2);
+    igl::unique(std::vector<Point_2>(hot),hot,_1,_2);
   }
 
   // find all segments intersecting hot pixels
   //   split edge at closest point to hot pixel center
-  vector<vector<Point_2>>  steiner(EI.rows());
+  std::vector<std::vector<Point_2>>  steiner(EI.rows());
   // initialize each segment with endpoints
   for(int i = 0;i<EI.rows();i++)
   {
@@ -143,7 +142,7 @@ IGL_INLINE void igl::copyleft::cgal::snap_rounding(
       }
       // otherwise check for intersections with walls consider all walls
       const Segment_2 si(s,d);
-      vector<Point_2> hits;
+      std::vector<Point_2> hits;
       for(int j = 0;j<4;j++)
       {
         const Segment_2 & sj = wall[j];

--- a/include/igl/copyleft/cgal/snap_rounding.cpp
+++ b/include/igl/copyleft/cgal/snap_rounding.cpp
@@ -29,7 +29,6 @@ IGL_INLINE void igl::copyleft::cgal::snap_rounding(
   Eigen::PlainObjectBase<DerivedEI> & EI,
   Eigen::PlainObjectBase<DerivedJ> & J)
 {
-  using namespace Eigen;
   using namespace igl;
   using namespace igl::copyleft::cgal;
   // Exact scalar type
@@ -38,18 +37,18 @@ IGL_INLINE void igl::copyleft::cgal::snap_rounding(
   typedef CGAL::Segment_2<Kernel> Segment_2;
   typedef CGAL::Point_2<Kernel> Point_2;
   typedef CGAL::Vector_2<Kernel> Vector_2;
-  typedef Matrix<EScalar,Dynamic,Dynamic>  MatrixXE;
+  typedef Eigen::Matrix<EScalar ,Eigen::Dynamic ,Eigen::Dynamic>  MatrixXE;
   // Convert vertex positions to exact kernel
 
   MatrixXE VE;
   {
-    VectorXi IM;
+    Eigen::VectorXi IM;
     resolve_intersections(V,E,VE,EI,J,IM);
     for_each(
       EI.data(),
       EI.data()+EI.size(),
       [&IM](typename DerivedEI::Scalar& i){i=IM(i);});
-    VectorXi _;
+    Eigen::VectorXi _;
     remove_unreferenced( MatrixXE(VE), DerivedEI(EI), VE,EI,_);
   }
 
@@ -182,14 +181,14 @@ IGL_INLINE void igl::copyleft::cgal::snap_rounding(
   }
   {
     DerivedJ prevJ = J;
-    VectorXi IM;
+    Eigen::VectorXi IM;
     subdivide_segments(MatrixXE(VE),MatrixXi(EI),steiner,VE,EI,J,IM);
     for_each(J.data(),J.data()+J.size(),[&prevJ](typename DerivedJ::Scalar & j){j=prevJ(j);});
     for_each(
       EI.data(),
       EI.data()+EI.size(),
       [&IM](typename DerivedEI::Scalar& i){i=IM(i);});
-    VectorXi _;
+    Eigen::VectorXi _;
     remove_unreferenced( MatrixXE(VE), DerivedEI(EI), VE,EI,_);
   }
 

--- a/include/igl/copyleft/cgal/snap_rounding.cpp
+++ b/include/igl/copyleft/cgal/snap_rounding.cpp
@@ -44,7 +44,7 @@ IGL_INLINE void igl::copyleft::cgal::snap_rounding(
   {
     Eigen::VectorXi IM;
     resolve_intersections(V,E,VE,EI,J,IM);
-    for_each(
+    std::for_each(
       EI.data(),
       EI.data()+EI.size(),
       [&IM](typename DerivedEI::Scalar& i){i=IM(i);});
@@ -182,9 +182,9 @@ IGL_INLINE void igl::copyleft::cgal::snap_rounding(
   {
     DerivedJ prevJ = J;
     Eigen::VectorXi IM;
-    subdivide_segments(MatrixXE(VE),MatrixXi(EI),steiner,VE,EI,J,IM);
-    for_each(J.data(),J.data()+J.size(),[&prevJ](typename DerivedJ::Scalar & j){j=prevJ(j);});
-    for_each(
+    subdivide_segments(MatrixXE(VE),Eigen::MatrixXi(EI),steiner,VE,EI,J,IM);
+    std::for_each(J.data(),J.data()+J.size(),[&prevJ](typename DerivedJ::Scalar & j){j=prevJ(j);});
+    std::for_each(
       EI.data(),
       EI.data()+EI.size(),
       [&IM](typename DerivedEI::Scalar& i){i=IM(i);});

--- a/include/igl/copyleft/cgal/string_to_mesh_boolean_type.cpp
+++ b/include/igl/copyleft/cgal/string_to_mesh_boolean_type.cpp
@@ -7,11 +7,10 @@ IGL_INLINE bool igl::copyleft::cgal::string_to_mesh_boolean_type(
   const std::string & s,
   MeshBooleanType & type)
 {
-  using namespace std;
-  string eff_s = s;
-  transform(eff_s.begin(), eff_s.end(), eff_s.begin(), ::tolower);
+  std::string eff_s = s;
+  std::transform(eff_s.begin(), eff_s.end(), eff_s.begin(), ::tolower);
   const auto & find_any = 
-    [](const vector<string> & haystack, const string & needle)->bool
+    [](const std::vector<std::string> & haystack, const std::string & needle)->bool
   {
     return find(haystack.begin(), haystack.end(), needle) != haystack.end();
   };

--- a/include/igl/copyleft/cgal/subdivide_segments.cpp
+++ b/include/igl/copyleft/cgal/subdivide_segments.cpp
@@ -122,7 +122,7 @@ IGL_INLINE void igl::copyleft::cgal::subdivide_segments(
     std::vector<size_t> vA,vIM;
     igl::unique(vVES,_1,vA,vIM);
     // Push indices back into vVES
-    for_each(vIM.data(),vIM.data()+vIM.size(),[&vA](size_t & i){i=vA[i];});
+    std::for_each(vIM.data(),vIM.data()+vIM.size(),[&vA](size_t & i){i=vA[i];});
     list_to_matrix(vIM,IM);
   }
 }

--- a/include/igl/copyleft/cgal/subdivide_segments.cpp
+++ b/include/igl/copyleft/cgal/subdivide_segments.cpp
@@ -33,13 +33,12 @@ IGL_INLINE void igl::copyleft::cgal::subdivide_segments(
   Eigen::PlainObjectBase<DerivedJ> & J,
   Eigen::PlainObjectBase<DerivedIM> & IM)
 {
-  using namespace Eigen;
   using namespace igl;
   // Exact scalar type
   typedef Kernel K;
   typedef typename Kernel::FT EScalar;
   typedef CGAL::Point_2<Kernel> Point_2;
-  typedef Matrix<EScalar,Dynamic,Dynamic>  MatrixXE;
+  typedef Eigen::Matrix<EScalar ,Eigen::Dynamic ,Eigen::Dynamic>  MatrixXE;
 
   // non-const copy
   std::vector<std::vector<CGAL::Point_2<Kernel> > > steiner = _steiner;

--- a/include/igl/copyleft/cgal/subdivide_segments.cpp
+++ b/include/igl/copyleft/cgal/subdivide_segments.cpp
@@ -35,8 +35,6 @@ IGL_INLINE void igl::copyleft::cgal::subdivide_segments(
 {
   using namespace Eigen;
   using namespace igl;
-  using namespace std;
-
   // Exact scalar type
   typedef Kernel K;
   typedef typename Kernel::FT EScalar;

--- a/include/igl/copyleft/opengl2/texture_from_tga.cpp
+++ b/include/igl/copyleft/opengl2/texture_from_tga.cpp
@@ -11,8 +11,6 @@
 
 IGL_INLINE bool igl::opengl::texture_from_tga(const std::string tga_file, GLuint & id)
 {
-  using namespace std;
-
   // read pixels to tga file
   FILE * imgFile;
   // "-" as input file name is code for read from stdin

--- a/include/igl/copyleft/progressive_hulls_cost_and_placement.cpp
+++ b/include/igl/copyleft/progressive_hulls_cost_and_placement.cpp
@@ -25,17 +25,16 @@ IGL_INLINE void igl::copyleft::progressive_hulls_cost_and_placement(
   Eigen::RowVectorXd & p)
 {
   using namespace Eigen;
-  using namespace std;
   // Controls the amount of quadratic energy to add (too small will introduce
   // instabilities and flaps)
   const double w = 0.1;
 
   assert(V.cols() == 3 && "V.cols() should be 3");
   // Gather list of unique face neighbors
-  vector<int> Nall =  circulation(e, true,EMAP,EF,EI);
-  vector<int> Nother= circulation(e,false,EMAP,EF,EI);
+  std::vector<int> Nall =  circulation(e, true,EMAP,EF,EI);
+  std::vector<int> Nother= circulation(e,false,EMAP,EF,EI);
   Nall.insert(Nall.end(),Nother.begin(),Nother.end());
-  vector<int> N;
+  std::vector<int> N;
   igl::unique(Nall,N);
   // Gather:
   //   A  #N by 3 normals scaled by area,

--- a/include/igl/copyleft/progressive_hulls_cost_and_placement.cpp
+++ b/include/igl/copyleft/progressive_hulls_cost_and_placement.cpp
@@ -24,7 +24,6 @@ IGL_INLINE void igl::copyleft::progressive_hulls_cost_and_placement(
   double & cost,
   Eigen::RowVectorXd & p)
 {
-  using namespace Eigen;
   // Controls the amount of quadratic energy to add (too small will introduce
   // instabilities and flaps)
   const double w = 0.1;
@@ -40,9 +39,9 @@ IGL_INLINE void igl::copyleft::progressive_hulls_cost_and_placement(
   //   A  #N by 3 normals scaled by area,
   //   D  #N determinants of matrix formed by points as columns
   //   B  #N point on plane dot normal
-  MatrixXd A(N.size(),3);
-  VectorXd D(N.size());
-  VectorXd B(N.size());
+  Eigen::MatrixXd A(N.size(),3);
+  Eigen::VectorXd D(N.size());
+  Eigen::VectorXd B(N.size());
   //cout<<"N=[";
   for(int i = 0;i<N.size();i++)
   {
@@ -59,7 +58,7 @@ IGL_INLINE void igl::copyleft::progressive_hulls_cost_and_placement(
   //cout<<"];"<<endl;
   // linear objective
   Vector3d f = A.colwise().sum().transpose();
-  VectorXd x;
+  Eigen::VectorXd x;
   //bool success = linprog(f,-A,-B,MatrixXd(0,A.cols()),VectorXd(0,1),x);
   //VectorXd _;
   //bool success = mosek_linprog(f,A.sparseView(),B,_,_,_,env,x);
@@ -70,12 +69,12 @@ IGL_INLINE void igl::copyleft::progressive_hulls_cost_and_placement(
   bool success = false;
   {
     RowVectorXd mid = 0.5*(V.row(E(e,0))+V.row(E(e,1)));
-    MatrixXd G =  w*Matrix3d::Identity(3,3);
-    VectorXd g0 = (1.-w)*f - w*mid.transpose();
+    Eigen::MatrixXd G =  w*Matrix3d::Identity(3,3);
+    Eigen::VectorXd g0 = (1.-w)*f - w*mid.transpose();
     const int n = A.cols();
     success = quadprog(
         G,g0,
-        MatrixXd(n,0),VectorXd(0,1),
+        Eigen::MatrixXd(n,0),VectorXd(0,1),
         A.transpose(),-B,x);
     cost  = (1.-w)*(1./6.)*(x.dot(f) - D.sum()) + 
       w*(x.transpose()-mid).squaredNorm() +

--- a/include/igl/copyleft/progressive_hulls_cost_and_placement.cpp
+++ b/include/igl/copyleft/progressive_hulls_cost_and_placement.cpp
@@ -47,17 +47,17 @@ IGL_INLINE void igl::copyleft::progressive_hulls_cost_and_placement(
   {
     const int f = N[i];
     //cout<<(f+1)<<" ";
-    const RowVector3d & v01 = V.row(F(f,1))-V.row(F(f,0));
-    const RowVector3d & v20 = V.row(F(f,2))-V.row(F(f,0));
+    const Eigen::RowVector3d & v01 = V.row(F(f,1))-V.row(F(f,0));
+    const Eigen::RowVector3d & v20 = V.row(F(f,2))-V.row(F(f,0));
     A.row(i) = v01.cross(v20);
     B(i) = V.row(F(f,0)).dot(A.row(i));
     D(i) = 
-      (Matrix3d()<< V.row(F(f,0)), V.row(F(f,1)), V.row(F(f,2)))
+      (Eigen::Matrix3d()<< V.row(F(f,0)), V.row(F(f,1)), V.row(F(f,2)))
       .finished().determinant();
   }
   //cout<<"];"<<endl;
   // linear objective
-  Vector3d f = A.colwise().sum().transpose();
+  Eigen::Vector3d f = A.colwise().sum().transpose();
   Eigen::VectorXd x;
   //bool success = linprog(f,-A,-B,MatrixXd(0,A.cols()),VectorXd(0,1),x);
   //VectorXd _;
@@ -68,13 +68,13 @@ IGL_INLINE void igl::copyleft::progressive_hulls_cost_and_placement(
   //}
   bool success = false;
   {
-    RowVectorXd mid = 0.5*(V.row(E(e,0))+V.row(E(e,1)));
-    Eigen::MatrixXd G =  w*Matrix3d::Identity(3,3);
+    Eigen::RowVectorXd mid = 0.5*(V.row(E(e,0))+V.row(E(e,1)));
+    Eigen::MatrixXd G =  w*Eigen::Matrix3d::Identity(3,3);
     Eigen::VectorXd g0 = (1.-w)*f - w*mid.transpose();
     const int n = A.cols();
     success = quadprog(
         G,g0,
-        Eigen::MatrixXd(n,0),VectorXd(0,1),
+        Eigen::MatrixXd(n,0),Eigen::VectorXd(0,1),
         A.transpose(),-B,x);
     cost  = (1.-w)*(1./6.)*(x.dot(f) - D.sum()) + 
       w*(x.transpose()-mid).squaredNorm() +
@@ -100,6 +100,6 @@ IGL_INLINE void igl::copyleft::progressive_hulls_cost_and_placement(
     //cout<<matlab_format(A,"A")<<endl;
     //cout<<matlab_format(B,"B")<<endl;
     //exit(-1);
-    p = RowVectorXd::Constant(1,3,std::nan("inf-cost"));
+    p = Eigen::RowVectorXd::Constant(1,3,std::nan("inf-cost"));
   }
 }

--- a/include/igl/copyleft/quadprog.cpp
+++ b/include/igl/copyleft/quadprog.cpp
@@ -130,13 +130,13 @@ IGL_INLINE bool igl::copyleft::quadprog(
   		}
   	return a1 * std::sqrt(2.0);
   };
-  const auto compute_d = [](VectorXd &d, const Eigen::MatrixXd& J, const Eigen::VectorXd& np)
+  const auto compute_d = [](Eigen::VectorXd &d, const Eigen::MatrixXd& J, const Eigen::VectorXd& np)
   {
     d = J.adjoint() * np;
   };
 
   const auto update_z = 
-    [](VectorXd& z, const Eigen::MatrixXd& J, const Eigen::VectorXd& d,  int iq)
+    [](Eigen::VectorXd& z, const Eigen::MatrixXd& J, const Eigen::VectorXd& d,  int iq)
   {
     z = J.rightCols(z.size()-iq) * d.tail(d.size()-iq);
   };
@@ -309,7 +309,7 @@ IGL_INLINE bool igl::copyleft::quadprog(
   int n=g0.size();  int p=ce0.size();  int m=ci0.size();  
   Eigen::MatrixXd R(G.rows(),G.cols()), J(G.rows(),G.cols());
   
-  LLT<MatrixXd,Lower> chol(G.cols());
+  Eigen::LLT<Eigen::MatrixXd,Eigen::Lower> chol(G.cols());
  
   Eigen::VectorXd s(m+p), z(n), r(m + p), d(n),  np(n), u(m + p);
   Eigen::VectorXd x_old(n), u_old(m + p);

--- a/include/igl/copyleft/quadprog.cpp
+++ b/include/igl/copyleft/quadprog.cpp
@@ -93,7 +93,6 @@ IGL_INLINE bool igl::copyleft::quadprog(
   const Eigen::VectorXd & ci0, 
   Eigen::VectorXd& x)
 {
-  using namespace Eigen;
   typedef double Scalar;
 
 
@@ -131,28 +130,28 @@ IGL_INLINE bool igl::copyleft::quadprog(
   		}
   	return a1 * std::sqrt(2.0);
   };
-  const auto compute_d = [](VectorXd &d, const MatrixXd& J, const VectorXd& np)
+  const auto compute_d = [](VectorXd &d, const Eigen::MatrixXd& J, const Eigen::VectorXd& np)
   {
     d = J.adjoint() * np;
   };
 
   const auto update_z = 
-    [](VectorXd& z, const MatrixXd& J, const VectorXd& d,  int iq)
+    [](VectorXd& z, const Eigen::MatrixXd& J, const Eigen::VectorXd& d,  int iq)
   {
     z = J.rightCols(z.size()-iq) * d.tail(d.size()-iq);
   };
 
   const auto update_r = 
-    [](const MatrixXd& R, VectorXd& r, const VectorXd& d, int iq) 
+    [](const Eigen::MatrixXd& R, Eigen::VectorXd& r, const Eigen::VectorXd& d, int iq)
   {
     r.head(iq) = 
-      R.topLeftCorner(iq,iq).triangularView<Upper>().solve(d.head(iq));
+      R.topLeftCorner(iq,iq).triangularView<Eigen::Upper>().solve(d.head(iq));
   };
 
   const auto add_constraint = [&distance](
-    MatrixXd& R, 
-    MatrixXd& J, 
-    VectorXd& d, 
+    Eigen::MatrixXd& R,
+    Eigen::MatrixXd& J,
+    Eigen::VectorXd& d,
     int& iq, 
     double& R_norm)->bool
   {
@@ -222,10 +221,10 @@ IGL_INLINE bool igl::copyleft::quadprog(
   };
 
   const auto delete_constraint = [&distance](
-      MatrixXd& R, 
-      MatrixXd& J, 
-      VectorXi& A, 
-      VectorXd& u, 
+      Eigen::MatrixXd& R,
+      Eigen::MatrixXd& J,
+      Eigen::VectorXi& A,
+      Eigen::VectorXd& u,
       int p, 
       int& iq, 
       int l)
@@ -308,12 +307,12 @@ IGL_INLINE bool igl::copyleft::quadprog(
   int i, k, l; /* indices */
   int ip, me, mi;
   int n=g0.size();  int p=ce0.size();  int m=ci0.size();  
-  MatrixXd R(G.rows(),G.cols()), J(G.rows(),G.cols());
+  Eigen::MatrixXd R(G.rows(),G.cols()), J(G.rows(),G.cols());
   
   LLT<MatrixXd,Lower> chol(G.cols());
  
-  VectorXd s(m+p), z(n), r(m + p), d(n),  np(n), u(m + p);
-  VectorXd x_old(n), u_old(m + p);
+  Eigen::VectorXd s(m+p), z(n), r(m + p), d(n),  np(n), u(m + p);
+  Eigen::VectorXd x_old(n), u_old(m + p);
 #ifdef TRACE_SOLVER
   double f_value;
 #endif
@@ -321,7 +320,7 @@ IGL_INLINE bool igl::copyleft::quadprog(
   const double inf = std::numeric_limits<double>::infinity();
   double t, t1, t2; /* t is the step length, which is the minimum of the partial step length t1 
     * and the full step length t2 */
-  VectorXi A(m + p), A_old(m + p), iai(m + p);
+  Eigen::VectorXi A(m + p), A_old(m + p), iai(m + p);
   int iq; 
   std::vector<bool> iaexcl(m + p);
  	

--- a/include/igl/copyleft/tetgen/cdt.cpp
+++ b/include/igl/copyleft/tetgen/cdt.cpp
@@ -24,7 +24,6 @@ IGL_INLINE bool igl::copyleft::tetgen::cdt(
   Eigen::PlainObjectBase<DerivedTT>& TT,
   Eigen::PlainObjectBase<DerivedTF>& TF)
 {
-  using namespace Eigen;
   // Effective input mesh
   PlainMatrix<DerivedV,Eigen::Dynamic> U;
   PlainMatrix<DerivedF,Eigen::Dynamic> G;
@@ -35,7 +34,7 @@ IGL_INLINE bool igl::copyleft::tetgen::cdt(
     PlainMatrix<DerivedF,Eigen::Dynamic> BF;
     bounding_box(V,BV,BF);
     // scale bounding box
-    const RowVector3d mid = 
+    const Eigen::RowVector3d mid =
      (BV.colwise().minCoeff() + BV.colwise().maxCoeff()).eval()*0.5;
     BV.rowwise() -= mid;
     assert(param.bounding_box_scale >= 1.);

--- a/include/igl/copyleft/tetgen/cdt.cpp
+++ b/include/igl/copyleft/tetgen/cdt.cpp
@@ -25,7 +25,6 @@ IGL_INLINE bool igl::copyleft::tetgen::cdt(
   Eigen::PlainObjectBase<DerivedTF>& TF)
 {
   using namespace Eigen;
-  using namespace std;
   // Effective input mesh
   PlainMatrix<DerivedV,Eigen::Dynamic> U;
   PlainMatrix<DerivedF,Eigen::Dynamic> G;

--- a/include/igl/copyleft/tetgen/cdt.cpp
+++ b/include/igl/copyleft/tetgen/cdt.cpp
@@ -53,7 +53,7 @@ IGL_INLINE bool igl::copyleft::tetgen::cdt(
     G = F;
   }
   // effective flags;
-  string flags = param.flags + (param.use_bounding_box ? "" : "c");
+  std::string flags = param.flags + (param.use_bounding_box ? "" : "c");
   return tetrahedralize(U,G,flags,TV,TT,TF);
 }
 

--- a/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
+++ b/include/igl/copyleft/tetgen/mesh_to_tetgenio.cpp
@@ -29,7 +29,6 @@ IGL_INLINE void igl::copyleft::tetgen::mesh_to_tetgenio(
   const Eigen::MatrixBase<DerivedR>& R,
   tetgenio & in)
 {
-  using namespace std;
   assert(V.cols() == 3 && "V should have 3 columns");
   assert((VM.size() == 0 || VM.size() == V.rows()) && "VM should be empty or #V by 1");
   assert((FM.size() == 0 || FM.size() == F.rows()) && "FM should be empty or #F by 1");

--- a/include/igl/copyleft/tetgen/mesh_with_skeleton.cpp
+++ b/include/igl/copyleft/tetgen/mesh_with_skeleton.cpp
@@ -30,8 +30,7 @@ IGL_INLINE bool igl::copyleft::tetgen::mesh_with_skeleton(
   Eigen::MatrixXi & FF)
 {
   using namespace Eigen;
-  using namespace std;
-  const string eff_tetgen_flags = 
+  const std::string eff_tetgen_flags =
     (tetgen_flags.length() == 0?DEFAULT_TETGEN_FLAGS:tetgen_flags);
   // Collect all edges that need samples:
   MatrixXi BECE = cat(1,BE,CE);
@@ -51,27 +50,27 @@ IGL_INLINE bool igl::copyleft::tetgen::mesh_with_skeleton(
   if(FF.rows() != F.rows())
   {
     // Issue a warning if the surface has changed
-    cerr<<"mesh_with_skeleton: Warning: boundary faces != input faces"<<endl;
+    std::cerr<<"mesh_with_skeleton: Warning: boundary faces != input faces"<<std::endl;
   }
   if(status != 0)
   {
-    cerr<<
-      "***************************************************************"<<endl<<
-      "***************************************************************"<<endl<<
-      "***************************************************************"<<endl<<
-      "***************************************************************"<<endl<<
-      "* mesh_with_skeleton: tetgen failed. Just meshing convex hull *"<<endl<<
-      "***************************************************************"<<endl<<
-      "***************************************************************"<<endl<<
-      "***************************************************************"<<endl<<
-      "***************************************************************"<<endl;
+    std::cerr<<
+      "***************************************************************"<<std::endl<<
+      "***************************************************************"<<std::endl<<
+      "***************************************************************"<<std::endl<<
+      "***************************************************************"<<std::endl<<
+      "* mesh_with_skeleton: tetgen failed. Just meshing convex hull *"<<std::endl<<
+      "***************************************************************"<<std::endl<<
+      "***************************************************************"<<std::endl<<
+      "***************************************************************"<<std::endl<<
+      "***************************************************************"<<std::endl;
     // If meshing convex hull then use more regular mesh
     status = tetrahedralize(VS,F,"q1.414",VV,TT,FF);
     // I suppose this will fail if the skeleton is outside the mesh
     assert(FF.maxCoeff() < VV.rows());
     if(status != 0)
     {
-      cerr<<"mesh_with_skeleton: tetgen failed again."<<endl;
+      std::cerr<<"mesh_with_skeleton: tetgen failed again."<<std::endl;
       return false;
     }
   }

--- a/include/igl/copyleft/tetgen/mesh_with_skeleton.cpp
+++ b/include/igl/copyleft/tetgen/mesh_with_skeleton.cpp
@@ -29,17 +29,16 @@ IGL_INLINE bool igl::copyleft::tetgen::mesh_with_skeleton(
   Eigen::MatrixXi & TT,
   Eigen::MatrixXi & FF)
 {
-  using namespace Eigen;
   const std::string eff_tetgen_flags =
     (tetgen_flags.length() == 0?DEFAULT_TETGEN_FLAGS:tetgen_flags);
   // Collect all edges that need samples:
-  MatrixXi BECE = cat(1,BE,CE);
-  MatrixXd S;
+  Eigen::MatrixXi BECE = cat(1,BE,CE);
+  Eigen::MatrixXd S;
   // Sample each edge with 10 samples. (Choice of 10 doesn't seem to matter so
   // much, but could under some circumstances)
   sample_edges(C,BECE,samples_per_bone,S);
   // Vertices we'll constrain tet mesh to meet
-  MatrixXd VS = cat(1,V,S);
+  Eigen::MatrixXd VS = cat(1,V,S);
   // Use tetgen to mesh the interior of surface, this assumes surface:
   //   * has no holes
   //   * has no non-manifold edges or vertices

--- a/include/igl/cotmatrix.cpp
+++ b/include/igl/cotmatrix.cpp
@@ -21,10 +21,8 @@ IGL_INLINE void igl::cotmatrix(
   const Eigen::MatrixBase<DerivedF> & F, 
   Eigen::SparseMatrix<Scalar>& L)
 {
-  using namespace Eigen;
-
   L.resize(V.rows(),V.rows());
-  Matrix<int,Dynamic,2> edges;
+  Eigen::Matrix<int ,Eigen::Dynamic,2> edges;
   int simplex_size = F.cols();
   // 3 for triangles, 4 for tets
   assert(simplex_size == 3 || simplex_size == 4);
@@ -55,10 +53,10 @@ IGL_INLINE void igl::cotmatrix(
     return;
   }
   // Gather cotangents
-  Matrix<Scalar,Dynamic,Dynamic> C;
+  Eigen::Matrix<Scalar ,Eigen::Dynamic ,Eigen::Dynamic> C;
   cotmatrix_entries(V,F,C);
   
-  std::vector<Triplet<Scalar> > IJV;
+  std::vector<Eigen::Triplet<Scalar> > IJV;
   IJV.reserve(F.rows()*edges.rows()*4);
   // Loop over triangles
   for(int i = 0; i < F.rows(); i++)
@@ -68,10 +66,10 @@ IGL_INLINE void igl::cotmatrix(
     {
       int source = F(i,edges(e,0));
       int dest = F(i,edges(e,1));
-      IJV.push_back(Triplet<Scalar>(source,dest,C(i,e)));
-      IJV.push_back(Triplet<Scalar>(dest,source,C(i,e)));
-      IJV.push_back(Triplet<Scalar>(source,source,-C(i,e)));
-      IJV.push_back(Triplet<Scalar>(dest,dest,-C(i,e)));
+      IJV.push_back(Eigen::Triplet<Scalar>(source,dest,C(i,e)));
+      IJV.push_back(Eigen::Triplet<Scalar>(dest,source,C(i,e)));
+      IJV.push_back(Eigen::Triplet<Scalar>(source,source,-C(i,e)));
+      IJV.push_back(Eigen::Triplet<Scalar>(dest,dest,-C(i,e)));
     }
   }
   L.setFromTriplets(IJV.begin(),IJV.end());

--- a/include/igl/cotmatrix.cpp
+++ b/include/igl/cotmatrix.cpp
@@ -22,7 +22,6 @@ IGL_INLINE void igl::cotmatrix(
   Eigen::SparseMatrix<Scalar>& L)
 {
   using namespace Eigen;
-  using namespace std;
 
   L.resize(V.rows(),V.rows());
   Matrix<int,Dynamic,2> edges;
@@ -59,7 +58,7 @@ IGL_INLINE void igl::cotmatrix(
   Matrix<Scalar,Dynamic,Dynamic> C;
   cotmatrix_entries(V,F,C);
   
-  vector<Triplet<Scalar> > IJV;
+  std::vector<Triplet<Scalar> > IJV;
   IJV.reserve(F.rows()*edges.rows()*4);
   // Loop over triangles
   for(int i = 0; i < F.rows(); i++)

--- a/include/igl/cotmatrix.h
+++ b/include/igl/cotmatrix.h
@@ -25,9 +25,9 @@ namespace igl
   /// mesh (V,F).
   ///
   ///   @tparam DerivedV  derived type of eigen matrix for V (e.g. derived from
-  ///     MatrixXd)
+  ///     Eigen::MatrixXd)
   ///   @tparam DerivedF  derived type of eigen matrix for F (e.g. derived from
-  ///     MatrixXi)
+  ///     Eigen::MatrixXi)
   ///   @tparam Scalar  scalar type for eigen sparse matrix (e.g. double)
   ///   @param[in] V  #V by dim list of mesh vertex positions
   ///   @param[in] F  #F by simplex_size list of mesh elements (triangles or tetrahedra)

--- a/include/igl/cotmatrix_entries.cpp
+++ b/include/igl/cotmatrix_entries.cpp
@@ -24,7 +24,6 @@ IGL_INLINE void igl::cotmatrix_entries(
   const Eigen::MatrixBase<DerivedF>& F,
   Eigen::PlainObjectBase<DerivedC>& C)
 {
-  using namespace std;
   using namespace Eigen;
   // simplex size (3: triangles, 4: tetrahedra)
   int simplex_size = F.cols();

--- a/include/igl/cotmatrix_entries.cpp
+++ b/include/igl/cotmatrix_entries.cpp
@@ -24,7 +24,6 @@ IGL_INLINE void igl::cotmatrix_entries(
   const Eigen::MatrixBase<DerivedF>& F,
   Eigen::PlainObjectBase<DerivedC>& C)
 {
-  using namespace Eigen;
   // simplex size (3: triangles, 4: tetrahedra)
   int simplex_size = F.cols();
   // Number of elements
@@ -37,14 +36,14 @@ IGL_INLINE void igl::cotmatrix_entries(
     {
       // Triangles
       //Compute Squared Edge lengths 
-      Matrix<typename DerivedC::Scalar,Dynamic,3> l2;
+      Eigen::Matrix<typename DerivedC::Scalar ,Eigen::Dynamic,3> l2;
       igl::squared_edge_lengths(V,F,l2);
       //Compute Edge lengths 
-      Matrix<typename DerivedC::Scalar,Dynamic,3> l;
+      Eigen::Matrix<typename DerivedC::Scalar ,Eigen::Dynamic,3> l;
       l = l2.array().sqrt();
       
       // double area
-      Matrix<typename DerivedC::Scalar,Dynamic,1> dblA;
+      Eigen::Matrix<typename DerivedC::Scalar ,Eigen::Dynamic,1> dblA;
       doublearea(l,0.,dblA);
       // cotangents and diagonal entries for element matrices
       // correctly divided by 4 (alec 2010)
@@ -62,21 +61,21 @@ IGL_INLINE void igl::cotmatrix_entries(
     {
 
       // edge lengths numbered same as opposite vertices
-      Matrix<typename DerivedC::Scalar,Dynamic,6> l;
+      Eigen::Matrix<typename DerivedC::Scalar ,Eigen::Dynamic,6> l;
       edge_lengths(V,F,l);
-      Matrix<typename DerivedC::Scalar,Dynamic,4> s;
+      Eigen::Matrix<typename DerivedC::Scalar ,Eigen::Dynamic,4> s;
       face_areas(l,s);
-      Matrix<typename DerivedC::Scalar,Dynamic,6> cos_theta,theta;
+      Eigen::Matrix<typename DerivedC::Scalar ,Eigen::Dynamic,6> cos_theta,theta;
       dihedral_angles_intrinsic(l,s,theta,cos_theta);
 
       // volume
-      Matrix<typename DerivedC::Scalar,Dynamic,1> vol;
+      Eigen::Matrix<typename DerivedC::Scalar ,Eigen::Dynamic,1> vol;
       volume(l,vol);
 
 
       // Law of sines
       // http://mathworld.wolfram.com/Tetrahedron.html
-      Matrix<typename DerivedC::Scalar,Dynamic,6> sin_theta(m,6);
+      Eigen::Matrix<typename DerivedC::Scalar ,Eigen::Dynamic,6> sin_theta(m,6);
       sin_theta.col(0) = vol.array() / ((2./(3.*l.col(0).array())).array() * s.col(1).array() * s.col(2).array());
       sin_theta.col(1) = vol.array() / ((2./(3.*l.col(1).array())).array() * s.col(2).array() * s.col(0).array());
       sin_theta.col(2) = vol.array() / ((2./(3.*l.col(2).array())).array() * s.col(0).array() * s.col(1).array());
@@ -104,11 +103,10 @@ IGL_INLINE void igl::cotmatrix_entries(
   const Eigen::MatrixBase<Derivedl>& l,
   Eigen::PlainObjectBase<DerivedC>& C)
 {
-  using namespace Eigen;
   const int m = l.rows();
   assert(l.cols() == 3 && "Only triangles accepted");
   //Compute squared Edge lengths 
-  Matrix<typename DerivedC::Scalar,Dynamic,3> l2;
+  Eigen::Matrix<typename DerivedC::Scalar ,Eigen::Dynamic,3> l2;
   l2 = l.array().square();
   // Alec: It's a little annoying that there's duplicate code here. The
   // "extrinic" version above is first computing squared edge lengths, taking
@@ -119,7 +117,7 @@ IGL_INLINE void igl::cotmatrix_entries(
   // edge_lengths and this cotmatrix_entries(l,C);
   //
   // double area
-  Matrix<typename DerivedC::Scalar,Dynamic,1> dblA;
+  Eigen::Matrix<typename DerivedC::Scalar ,Eigen::Dynamic,1> dblA;
   doublearea(l,0.,dblA);
   // cotangents and diagonal entries for element matrices
   // correctly divided by 4 (alec 2010)

--- a/include/igl/cotmatrix_intrinsic.cpp
+++ b/include/igl/cotmatrix_intrinsic.cpp
@@ -17,7 +17,6 @@ IGL_INLINE void igl::cotmatrix_intrinsic(
   Eigen::SparseMatrix<Scalar>& L)
 {
   using namespace Eigen;
-  using namespace std;
   // Cribbed from cotmatrix
 
   const int nverts = F.maxCoeff()+1;
@@ -39,7 +38,7 @@ IGL_INLINE void igl::cotmatrix_intrinsic(
   Matrix<Scalar,Dynamic,Dynamic> C;
   cotmatrix_entries(l,C);
   
-  vector<Triplet<Scalar> > IJV;
+  std::vector<Triplet<Scalar> > IJV;
   IJV.reserve(F.rows()*edges.rows()*4);
   // Loop over triangles
   for(int i = 0; i < F.rows(); i++)

--- a/include/igl/cotmatrix_intrinsic.cpp
+++ b/include/igl/cotmatrix_intrinsic.cpp
@@ -16,12 +16,11 @@ IGL_INLINE void igl::cotmatrix_intrinsic(
   const Eigen::MatrixBase<DerivedF> & F, 
   Eigen::SparseMatrix<Scalar>& L)
 {
-  using namespace Eigen;
   // Cribbed from cotmatrix
 
   const int nverts = F.maxCoeff()+1;
   L.resize(nverts,nverts);
-  Matrix<int,Dynamic,2> edges;
+  Eigen::Matrix<int ,Eigen::Dynamic,2> edges;
   int simplex_size = F.cols();
   // 3 for triangles, 4 for tets
   IGL_ASSERT(simplex_size == 3);
@@ -35,10 +34,10 @@ IGL_INLINE void igl::cotmatrix_intrinsic(
     2,0,
     0,1;
   // Gather cotangents
-  Matrix<Scalar,Dynamic,Dynamic> C;
+  Eigen::Matrix<Scalar ,Eigen::Dynamic ,Eigen::Dynamic> C;
   cotmatrix_entries(l,C);
   
-  std::vector<Triplet<Scalar> > IJV;
+  std::vector<Eigen::Triplet<Scalar> > IJV;
   IJV.reserve(F.rows()*edges.rows()*4);
   // Loop over triangles
   for(int i = 0; i < F.rows(); i++)
@@ -48,10 +47,10 @@ IGL_INLINE void igl::cotmatrix_intrinsic(
     {
       int source = F(i,edges(e,0));
       int dest = F(i,edges(e,1));
-      IJV.push_back(Triplet<Scalar>(source,dest,C(i,e)));
-      IJV.push_back(Triplet<Scalar>(dest,source,C(i,e)));
-      IJV.push_back(Triplet<Scalar>(source,source,-C(i,e)));
-      IJV.push_back(Triplet<Scalar>(dest,dest,-C(i,e)));
+      IJV.push_back(Eigen::Triplet<Scalar>(source,dest,C(i,e)));
+      IJV.push_back(Eigen::Triplet<Scalar>(dest,source,C(i,e)));
+      IJV.push_back(Eigen::Triplet<Scalar>(source,source,-C(i,e)));
+      IJV.push_back(Eigen::Triplet<Scalar>(dest,dest,-C(i,e)));
     }
   }
   L.setFromTriplets(IJV.begin(),IJV.end());

--- a/include/igl/covariance_scatter_matrix.cpp
+++ b/include/igl/covariance_scatter_matrix.cpp
@@ -24,7 +24,6 @@ IGL_INLINE void igl::covariance_scatter_matrix(
   const ARAPEnergyType energy,
   Eigen::SparseMatrix<CSM_type>& CSM)
 {
-  using namespace Eigen;
   // number of mesh vertices
   int n = V.rows();
   assert(n > F.maxCoeff());
@@ -54,17 +53,17 @@ IGL_INLINE void igl::covariance_scatter_matrix(
       return;
   }
 
-  SparseMatrix<double> KX,KY,KZ;
+  Eigen::SparseMatrix<double> KX,KY,KZ;
   arap_linear_block(V,F,0,energy,KX);
   arap_linear_block(V,F,1,energy,KY);
-  SparseMatrix<double> Z(n,nr);
+  Eigen::SparseMatrix<double> Z(n,nr);
   if(dim == 2)
   {
     CSM = cat(1,cat(2,KX,Z),cat(2,Z,KY)).transpose();
   }else if(dim == 3)
   {
     arap_linear_block(V,F,2,energy,KZ);
-    SparseMatrix<double>ZZ(n,nr*2);
+    Eigen::SparseMatrix<double>ZZ(n,nr*2);
     CSM = 
       cat(1,cat(1,cat(2,KX,ZZ),cat(2,cat(2,Z,KY),Z)),cat(2,ZZ,KZ)).transpose();
   }else

--- a/include/igl/crouzeix_raviart_massmatrix.cpp
+++ b/include/igl/crouzeix_raviart_massmatrix.cpp
@@ -40,14 +40,13 @@ void igl::crouzeix_raviart_massmatrix(
     const Eigen::MatrixBase<DerivedEMAP> & EMAP,
     Eigen::SparseMatrix<MT> & M)
 {
-  using namespace Eigen;
   // Mesh should be edge-manifold (TODO: replace `is_edge_manifold` with
   // `is_facet_manifold`)
   assert(F.cols() != 3 || is_edge_manifold(F));
   // number of elements (triangles)
   const int m = F.rows();
   // Get triangle areas/volumes
-  VectorXd TA;
+  Eigen::VectorXd TA;
   // Element simplex size
   const int ss = F.cols();
   switch(ss)
@@ -62,13 +61,13 @@ void igl::crouzeix_raviart_massmatrix(
       volume(V,F,TA);
       break;
   }
-  std::vector<Triplet<MT> > MIJV(ss*m);
+  std::vector<Eigen::Triplet<MT> > MIJV(ss*m);
   assert(EMAP.size() == m*ss);
   for(int f = 0;f<m;f++)
   {
     for(int c = 0;c<ss;c++)
     {
-      MIJV[f+m*c] = Triplet<MT>(EMAP(f+m*c, 0),EMAP(f+m*c, 0),TA(f)/(double)(ss));
+      MIJV[f+m*c] = Eigen::Triplet<MT>(EMAP(f+m*c, 0),EMAP(f+m*c, 0),TA(f)/(double)(ss));
     }
   }
   M.resize(E.rows(),E.rows());

--- a/include/igl/crouzeix_raviart_massmatrix.cpp
+++ b/include/igl/crouzeix_raviart_massmatrix.cpp
@@ -41,7 +41,6 @@ void igl::crouzeix_raviart_massmatrix(
     Eigen::SparseMatrix<MT> & M)
 {
   using namespace Eigen;
-  using namespace std;
   // Mesh should be edge-manifold (TODO: replace `is_edge_manifold` with
   // `is_facet_manifold`)
   assert(F.cols() != 3 || is_edge_manifold(F));
@@ -63,7 +62,7 @@ void igl::crouzeix_raviart_massmatrix(
       volume(V,F,TA);
       break;
   }
-  vector<Triplet<MT> > MIJV(ss*m);
+  std::vector<Triplet<MT> > MIJV(ss*m);
   assert(EMAP.size() == m*ss);
   for(int f = 0;f<m;f++)
   {

--- a/include/igl/cumprod.cpp
+++ b/include/igl/cumprod.cpp
@@ -16,7 +16,6 @@ IGL_INLINE void igl::cumprod(
   const int dim,
   Eigen::PlainObjectBase<DerivedY > & Y)
 {
-  using namespace Eigen;
   Y.resizeLike(X);
   // get number of columns (or rows)
   int num_outer = (dim == 1 ? X.cols() : X.rows() );

--- a/include/igl/cumprod.cpp
+++ b/include/igl/cumprod.cpp
@@ -17,7 +17,6 @@ IGL_INLINE void igl::cumprod(
   Eigen::PlainObjectBase<DerivedY > & Y)
 {
   using namespace Eigen;
-  using namespace std;
   Y.resizeLike(X);
   // get number of columns (or rows)
   int num_outer = (dim == 1 ? X.cols() : X.rows() );

--- a/include/igl/cumsum.cpp
+++ b/include/igl/cumsum.cpp
@@ -27,7 +27,6 @@ IGL_INLINE void igl::cumsum(
   Eigen::PlainObjectBase<DerivedY > & Y)
 {
   using namespace Eigen;
-  using namespace std;
   Y.resize(
     X.rows()+(zero_prefix&&dim==1?1:0),
     X.cols()+(zero_prefix&&dim==2?1:0));

--- a/include/igl/cumsum.cpp
+++ b/include/igl/cumsum.cpp
@@ -26,7 +26,6 @@ IGL_INLINE void igl::cumsum(
   const bool zero_prefix,
   Eigen::PlainObjectBase<DerivedY > & Y)
 {
-  using namespace Eigen;
   Y.resize(
     X.rows()+(zero_prefix&&dim==1?1:0),
     X.cols()+(zero_prefix&&dim==2?1:0));

--- a/include/igl/dated_copy.cpp
+++ b/include/igl/dated_copy.cpp
@@ -20,7 +20,6 @@
 
 IGL_INLINE bool igl::dated_copy(const std::string & src_path, const std::string & dir)
 {
-  using namespace std;
   // Get time and date as string
   char buffer[80];
   time_t rawtime;
@@ -29,33 +28,33 @@ IGL_INLINE bool igl::dated_copy(const std::string & src_path, const std::string 
   timeinfo = localtime (&rawtime);
   // ISO 8601 format with hyphens instead of colons and no timezone offset
   strftime (buffer,80,"%Y-%m-%dT%H-%M-%S",timeinfo);
-  string src_basename = basename(src_path);
-  string dst_basename = src_basename+"-"+buffer;
-  string dst_path = dir+"/"+dst_basename;
-  cerr<<"Saving binary to "<<dst_path;
+  std::string src_basename = basename(src_path);
+  std::string dst_basename = src_basename+"-"+buffer;
+  std::string dst_path = dir+"/"+dst_basename;
+  std::cerr<<"Saving binary to "<<dst_path;
   {
     // http://stackoverflow.com/a/10195497/148668
-    ifstream src(src_path,ios::binary);
+    std::ifstream src(src_path,std::ios::binary);
     if (!src.is_open()) 
     {
-      cerr<<" failed."<<endl;
+      std::cerr<<" failed."<<std::endl;
       return false;
     }
-    ofstream dst(dst_path,ios::binary);
+    std::ofstream dst(dst_path,std::ios::binary);
     if(!dst.is_open())
     {
-      cerr<<" failed."<<endl;
+      std::cerr<<" failed."<<std::endl;
       return false;
     }
     dst << src.rdbuf();
   }
-  cerr<<" succeeded."<<endl;
-  cerr<<"Setting permissions of "<<dst_path;
+  std::cerr<<" succeeded."<<std::endl;
+  std::cerr<<"Setting permissions of "<<dst_path;
   {
     int src_posix = fileno(fopen(src_path.c_str(),"r"));
     if(src_posix == -1)
     {
-      cerr<<" failed."<<endl;
+      std::cerr<<" failed."<<std::endl;
       return false;
     }
     struct stat fst;
@@ -63,22 +62,22 @@ IGL_INLINE bool igl::dated_copy(const std::string & src_path, const std::string 
     int dst_posix = fileno(fopen(dst_path.c_str(),"r"));
     if(dst_posix == -1)
     {
-      cerr<<" failed."<<endl;
+      std::cerr<<" failed."<<std::endl;
       return false;
     }
     //update to the same uid/gid
     if(fchown(dst_posix,fst.st_uid,fst.st_gid))
     {
-      cerr<<" failed."<<endl;
+      std::cerr<<" failed."<<std::endl;
       return false;
     }
     //update the permissions 
     if(fchmod(dst_posix,fst.st_mode) == -1)
     {
-      cerr<<" failed."<<endl;
+      std::cerr<<" failed."<<std::endl;
       return false;
     }
-    cerr<<" succeeded."<<endl;
+    std::cerr<<" succeeded."<<std::endl;
   }
   return true;
 }

--- a/include/igl/decimate.cpp
+++ b/include/igl/decimate.cpp
@@ -108,7 +108,6 @@ IGL_INLINE bool igl::decimate(
 {
   // Decimate 1
   using namespace Eigen;
-  using namespace std;
   // Working copies
   Eigen::MatrixXd V = OV;
   Eigen::MatrixXi F = OF;

--- a/include/igl/decimate.cpp
+++ b/include/igl/decimate.cpp
@@ -107,13 +107,12 @@ IGL_INLINE bool igl::decimate(
   )
 {
   // Decimate 1
-  using namespace Eigen;
   // Working copies
   Eigen::MatrixXd V = OV;
   Eigen::MatrixXi F = OF;
   // Why recompute this rather than copy input?
-  VectorXi EMAP;
-  MatrixXi E,EF,EI;
+  Eigen::VectorXi EMAP;
+  Eigen::MatrixXi E,EF,EI;
   edge_flaps(F,E,EMAP,EF,EI);
   {
     Eigen::Array<bool,Eigen::Dynamic,Eigen::Dynamic> BF;
@@ -128,7 +127,7 @@ IGL_INLINE bool igl::decimate(
   // Could reserve with https://stackoverflow.com/a/29236236/148668
   Eigen::VectorXi EQ = Eigen::VectorXi::Zero(E.rows());
   // If an edge were collapsed, we'd collapse it to these points:
-  MatrixXd C(E.rows(),V.cols());
+  Eigen::MatrixXd C(E.rows(),V.cols());
   // Pushing into a vector then using constructor was slower. Maybe using
   // std::move + make_heap would squeeze out something?
   
@@ -146,7 +145,7 @@ IGL_INLINE bool igl::decimate(
       // If we were using more modern C++ then cost_and_placement could return a
       // tuple and could be unpacked into auto [cost,p] =
       // cost_and_placement(...) without much issue.
-      RowVectorXd p(1,3);
+      Eigen::RowVectorXd p(1,3);
       cost_and_placement(e,V,F,E,EMAP,EF,EI,cost,p);
       C.row(e) = p;
       costs(e) = cost;
@@ -193,7 +192,7 @@ IGL_INLINE bool igl::decimate(
     prev_e = e;
   }
   // remove all IGL_COLLAPSE_EDGE_NULL faces
-  MatrixXi F2(F.rows(),3);
+  Eigen::MatrixXi F2(F.rows(),3);
   J.resize(F.rows());
   int m = 0;
   for(int f = 0;f<F.rows();f++)
@@ -210,7 +209,7 @@ IGL_INLINE bool igl::decimate(
   }
   F2.conservativeResize(m,F2.cols());
   J.conservativeResize(m);
-  VectorXi _1;
+  Eigen::VectorXi _1;
   igl::remove_unreferenced(V,F2,U,G,_1,I);
   return clean_finish;
 }

--- a/include/igl/deform_skeleton.cpp
+++ b/include/igl/deform_skeleton.cpp
@@ -14,7 +14,6 @@ void igl::deform_skeleton(
   Eigen::MatrixXd & CT,
   Eigen::MatrixXi & BET)
 {
-  using namespace Eigen;
   assert(BE.rows() == (int)vA.size());
   CT.resize(2*BE.rows(),C.cols());
   BET.resize(BE.rows(),2);
@@ -22,9 +21,9 @@ void igl::deform_skeleton(
   {
     BET(e,0) = 2*e;
     BET(e,1) = 2*e+1;
-    Affine3d a = vA[e];
-    Vector3d c0 = C.row(BE(e,0));
-    Vector3d c1 = C.row(BE(e,1));
+    Eigen::Affine3d a = vA[e];
+    Eigen::Vector3d c0 = C.row(BE(e,0));
+    Eigen::Vector3d c1 = C.row(BE(e,1));
     CT.row(2*e) =   a * c0;
     CT.row(2*e+1) = a * c1;
   }
@@ -38,7 +37,6 @@ IGL_INLINE void igl::deform_skeleton(
   Eigen::MatrixXd & CT,
   Eigen::MatrixXi & BET)
 {
-  using namespace Eigen;
   //assert(BE.rows() == (int)vA.size());
   CT.resize(2*BE.rows(),C.cols());
   BET.resize(BE.rows(),2);
@@ -46,12 +44,12 @@ IGL_INLINE void igl::deform_skeleton(
   {
     BET(e,0) = 2*e;
     BET(e,1) = 2*e+1;
-    Matrix4d t;
+    Eigen::Matrix4d t;
     t << T.block(e*4,0,4,3).transpose(), 0,0,0,0;
-    Affine3d a;
+    Eigen::Affine3d a;
     a.matrix() = t;
-    Vector3d c0 = C.row(BE(e,0));
-    Vector3d c1 = C.row(BE(e,1));
+    Eigen::Vector3d c0 = C.row(BE(e,0));
+    Eigen::Vector3d c1 = C.row(BE(e,1));
     CT.row(2*e) =   a * c0;
     CT.row(2*e+1) = a * c1;
   }

--- a/include/igl/dihedral_angles.cpp
+++ b/include/igl/dihedral_angles.cpp
@@ -23,11 +23,10 @@ IGL_INLINE void igl::dihedral_angles(
   Eigen::PlainObjectBase<Derivedtheta>& theta,
   Eigen::PlainObjectBase<Derivedcos_theta>& cos_theta)
 {
-  using namespace Eigen;
   assert(T.cols() == 4);
-  Matrix<typename Derivedtheta::Scalar,Dynamic,6> l;
+  Eigen::Matrix<typename Derivedtheta::Scalar ,Eigen::Dynamic,6> l;
   edge_lengths(V,T,l);
-  Matrix<typename Derivedtheta::Scalar,Dynamic,4> s;
+  Eigen::Matrix<typename Derivedtheta::Scalar ,Eigen::Dynamic,4> s;
   face_areas(l,s);
   return dihedral_angles_intrinsic(l,s,theta,cos_theta);
 }

--- a/include/igl/dihedral_angles_intrinsic.cpp
+++ b/include/igl/dihedral_angles_intrinsic.cpp
@@ -22,12 +22,11 @@ IGL_INLINE void igl::dihedral_angles_intrinsic(
   Eigen::PlainObjectBase<Derivedtheta>& theta,
   Eigen::PlainObjectBase<Derivedcos_theta>& cos_theta)
 {
-  using namespace Eigen;
   const int m = L.rows();
   assert(m == A.rows());
   // Law of cosines
   // http://math.stackexchange.com/a/49340/35376
-  Matrix<typename Derivedtheta::Scalar,Dynamic,6> H_sqr(m,6);
+  Eigen::Matrix<typename Derivedtheta::Scalar ,Eigen::Dynamic,6> H_sqr(m,6);
   H_sqr.col(0) = (1./16.) * (4. * L.col(3).array().square() * L.col(0).array().square() - 
                                 ((L.col(1).array().square() + L.col(4).array().square()) -
                                  (L.col(2).array().square() + L.col(5).array().square())).square());

--- a/include/igl/direct_delta_mush.cpp
+++ b/include/igl/direct_delta_mush.cpp
@@ -19,8 +19,6 @@ IGL_INLINE void igl::direct_delta_mush(
   const Eigen::MatrixBase<DerivedOmega> & Omega,
   Eigen::PlainObjectBase<DerivedU> & U)
 {
-  using namespace Eigen;
-
   // Shape checks
   assert(V.cols() == 3 && "V should contain 3D positions.");
   assert(Omega.rows() == V.rows() && "Omega contain the same number of rows as V.");
@@ -35,48 +33,48 @@ IGL_INLINE void igl::direct_delta_mush(
   // Note:
   // In the paper, the rest pose vertices are represented in U \in R^{4 x #V}
   // Thus the formulae involving U would differ from the paper by a transpose.
-  Matrix<Scalar, Dynamic, 4> V_homogeneous(n, 4);
-  V_homogeneous << V, Matrix<Scalar, Dynamic, 1>::Ones(n, 1);
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 4> V_homogeneous(n, 4);
+  V_homogeneous << V, Eigen::Matrix<Scalar, Eigen::Dynamic, 1>::Ones(n, 1);
   U.resize(n, 3);
 
   for (int i = 0; i < n; ++i)
   {
     // Construct Q matrix using Omega and Transformations
-    Matrix<Scalar, 4, 4> Q_mat(4, 4);
-    Q_mat = Matrix<Scalar, 4, 4>::Zero(4, 4);
+    Eigen::Matrix<Scalar, 4, 4> Q_mat(4, 4);
+    Q_mat = Eigen::Matrix<Scalar, 4, 4>::Zero(4, 4);
     for (int j = 0; j < m; ++j)
     {
-      Matrix<typename DerivedOmega::Scalar, 4, 4> Omega_curr(4, 4);
-      Matrix<typename DerivedOmega::Scalar, 10, 1> curr = Omega.block(i, j * 10, 1, 10).transpose();
+      Eigen::Matrix<typename DerivedOmega::Scalar, 4, 4> Omega_curr(4, 4);
+      Eigen::Matrix<typename DerivedOmega::Scalar, 10, 1> curr = Omega.block(i, j * 10, 1, 10).transpose();
       Omega_curr << curr(0), curr(1), curr(2), curr(3),
         curr(1), curr(4), curr(5), curr(6),
         curr(2), curr(5), curr(7), curr(8),
         curr(3), curr(6), curr(8), curr(9);
 
-      Affine3d M_curr = T[j];
+      Eigen::Affine3d M_curr = T[j];
       Q_mat += M_curr.matrix() * Omega_curr;
     }
     // Normalize so that the last element is 1
     Q_mat /= Q_mat(Q_mat.rows() - 1, Q_mat.cols() - 1);
 
-    Matrix<Scalar, 3, 3> Q_i = Q_mat.block(0, 0, 3, 3);
-    Matrix<Scalar, 3, 1> q_i = Q_mat.block(0, 3, 3, 1);
-    Matrix<Scalar, 3, 1> p_i = Q_mat.block(3, 0, 1, 3).transpose();
+    Eigen::Matrix<Scalar, 3, 3> Q_i = Q_mat.block(0, 0, 3, 3);
+    Eigen::Matrix<Scalar, 3, 1> q_i = Q_mat.block(0, 3, 3, 1);
+    Eigen::Matrix<Scalar, 3, 1> p_i = Q_mat.block(3, 0, 1, 3).transpose();
 
     // Get rotation and translation matrices using SVD
-    Matrix<Scalar, 3, 3> SVD_i = Q_i - q_i * p_i.transpose();
-    JacobiSVD<Matrix<Scalar, 3, 3>> svd;
-    svd.compute(SVD_i, ComputeFullU | ComputeFullV);
-    Matrix<Scalar, 3, 3> R_i = svd.matrixU() * svd.matrixV().transpose();
-    Matrix<Scalar, 3, 1> t_i = q_i - R_i * p_i;
+    Eigen::Matrix<Scalar, 3, 3> SVD_i = Q_i - q_i * p_i.transpose();
+    Eigen::JacobiSVD<Eigen::Matrix<Scalar, 3, 3>> svd;
+    svd.compute(SVD_i, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::Matrix<Scalar, 3, 3> R_i = svd.matrixU() * svd.matrixV().transpose();
+    Eigen::Matrix<Scalar, 3, 1> t_i = q_i - R_i * p_i;
 
     // Gamma final transformation matrix
-    Matrix<Scalar, 3, 4> Gamma_i(3, 4);
+    Eigen::Matrix<Scalar, 3, 4> Gamma_i(3, 4);
     Gamma_i.block(0, 0, 3, 3) = R_i;
     Gamma_i.block(0, 3, 3, 1) = t_i;
 
     // Final deformed position
-    Matrix<Scalar, 4, 1> v_i = V_homogeneous.row(i);
+    Eigen::Matrix<Scalar, 4, 1> v_i = V_homogeneous.row(i);
     U.row(i) = Gamma_i * v_i;
   }
 }
@@ -96,8 +94,6 @@ IGL_INLINE void igl::direct_delta_mush_precomputation(
   const typename DerivedV::Scalar alpha,
   Eigen::PlainObjectBase<DerivedOmega> & Omega)
 {
-  using namespace Eigen;
-
   // Shape checks
   assert(V.cols() == 3 && "V should contain 3D positions.");
   assert(F.cols() == 3 && "F should contain triangles.");
@@ -118,10 +114,10 @@ IGL_INLINE void igl::direct_delta_mush_precomputation(
   //      9  10 11 12      0  1  2  3  4  5  6   7   8   9
   //      13 14 15 16
   auto extract_upper_triangle = [](
-    const Matrix<Scalar, Dynamic, Dynamic> & full) -> Matrix<Scalar, Dynamic, 1>
+    const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> & full) -> Eigen::Matrix<Scalar, Eigen::Dynamic, 1>
   {
     int dims = full.rows();
-    Matrix<Scalar, Dynamic, 1> upper_triangle((dims * (dims + 1)) / 2);
+    Eigen::Matrix<Scalar, Eigen::Dynamic, 1> upper_triangle((dims * (dims + 1)) / 2);
     int vector_idx = 0;
     for (int i = 0; i < dims; ++i)
     {
@@ -141,20 +137,20 @@ IGL_INLINE void igl::direct_delta_mush_precomputation(
   // Note:
   // in the paper, the rest pose vertices are represented in U \in R^{4 \times #V}
   // Thus the formulae involving U would differ from the paper by a transpose.
-  Matrix<Scalar, Dynamic, 4> V_homogeneous(n, 4);
-  V_homogeneous << V, Matrix<Scalar, Dynamic, 1>::Ones(n);
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 4> V_homogeneous(n, 4);
+  V_homogeneous << V, Eigen::Matrix<Scalar, Eigen::Dynamic, 1>::Ones(n);
 
   // Identity matrix of #V by #V
-  SparseMatrix<Scalar> I(n, n);
+  Eigen::SparseMatrix<Scalar> I(n, n);
   I.setIdentity();
 
   // Laplacian matrix of #V by #V
   // L_bar = L \times D_L^{-1}
-  SparseMatrix<Scalar> L;
+  Eigen::SparseMatrix<Scalar> L;
   igl::cotmatrix(V, F, L);
   L = -L;
   // Inverse of diagonal matrix = reciprocal elements in diagonal
-  Matrix<Scalar, Dynamic, 1> D_L = L.diagonal();
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> D_L = L.diagonal();
   // D_L = D_L.array().pow(-1);  // Not using this since not sure if diagonal contains 0
   for (int i = 0; i < D_L.size(); ++i)
   {
@@ -163,17 +159,17 @@ IGL_INLINE void igl::direct_delta_mush_precomputation(
       D_L(i) = 1 / D_L(i);
     }
   }
-  SparseMatrix<Scalar> D_L_inv = D_L.asDiagonal().toDenseMatrix().sparseView();
-  SparseMatrix<Scalar> L_bar = L * D_L_inv;
+  Eigen::SparseMatrix<Scalar> D_L_inv = D_L.asDiagonal().toDenseMatrix().sparseView();
+  Eigen::SparseMatrix<Scalar> L_bar = L * D_L_inv;
 
   // Implicitly and iteratively solve for W'
   // w'_{ij} = \sum_{k=1}^{n}{C_{ki} w_{kj}}      where C = (I + kappa L_bar)^{-p}:
   // W' = C^T \times W  =>  c^T W_k = W_{k-1}     where c = (I + kappa L_bar)
   // C positive semi-definite => ldlt solver
-  SimplicialLDLT<SparseMatrix<Scalar>> ldlt_W_prime;
-  SparseMatrix<Scalar> c(I + kappa * L_bar);
+  Eigen::SimplicialLDLT<Eigen::SparseMatrix<Scalar>> ldlt_W_prime;
+  Eigen::SparseMatrix<Scalar> c(I + kappa * L_bar);
   // working copy
-  PlainMatrix<DerivedW,Dynamic,Dynamic> W_prime(W);
+  PlainMatrix<DerivedW ,Eigen::Dynamic ,Eigen::Dynamic> W_prime(W);
   ldlt_W_prime.compute(c.transpose());
   for (int iter = 0; iter < p; ++iter)
   {
@@ -182,23 +178,23 @@ IGL_INLINE void igl::direct_delta_mush_precomputation(
 
   // U_precomputed: #V by 10
   // Cache u_i^T \dot u_i \in R^{4 x 4} to reduce computation time.
-  Matrix<Scalar, Dynamic, 10> U_precomputed(n, 10);
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 10> U_precomputed(n, 10);
   for (int k = 0; k < n; ++k)
   {
-    Matrix<Scalar, 4, 4> u_full = V_homogeneous.row(k).transpose() * V_homogeneous.row(k);
+    Eigen::Matrix<Scalar, 4, 4> u_full = V_homogeneous.row(k).transpose() * V_homogeneous.row(k);
     U_precomputed.row(k) = extract_upper_triangle(u_full);
   }
 
   // U_prime: #V by #T*10 of u_{jx}
   // Each column of U_prime (u_{jx}) is the element-wise product of
   // W_j and U_precomputed_x where j \in {1...m}, x \in {1...10}
-  Matrix<Scalar, Dynamic, Dynamic> U_prime(n, m * 10);
+  Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> U_prime(n, m * 10);
   for (int j = 0; j < m; ++j)
   {
-    Matrix<Scalar, Dynamic, 1> w_j = W.col(j);
+    Eigen::Matrix<Scalar, Eigen::Dynamic, 1> w_j = W.col(j);
     for (int x = 0; x < 10; ++x)
     {
-      Matrix<Scalar, Dynamic, 1> u_x = U_precomputed.col(x);
+      Eigen::Matrix<Scalar, Eigen::Dynamic, 1> u_x = U_precomputed.col(x);
       U_prime.col(10 * j + x) = w_j.array() * u_x.array();
     }
   }
@@ -206,16 +202,16 @@ IGL_INLINE void igl::direct_delta_mush_precomputation(
   // Implicitly and iteratively solve for Psi: #V by #T*10 of \Psi_{ij}s.
   // Note: Using dense matrices to solve for Psi will cause the program to hang.
   // The following won't work
-  // Matrix<Scalar, Dynamic, Dynamic> Psi(U_prime);
-  // Matrix<Scalar, Dynamic, Dynamic> b((I + lambda * L_bar).transpose());
+  // Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Psi(U_prime);
+  // Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> b((I + lambda * L_bar).transpose());
   // for (int iter = 0; iter < p; ++iter)
   // {
   //   Psi = b.ldlt().solve(Psi);  // hangs here
   // }
   // Convert to sparse matrices and compute
-  Matrix<Scalar, Dynamic, Dynamic> Psi = U_prime.sparseView();
-  SparseMatrix<Scalar> b = (I + lambda * L_bar).transpose();
-  SimplicialLDLT<SparseMatrix<Scalar>> ldlt_Psi;
+  Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Psi = U_prime.sparseView();
+  Eigen::SparseMatrix<Scalar> b = (I + lambda * L_bar).transpose();
+  Eigen::SimplicialLDLT<Eigen::SparseMatrix<Scalar>> ldlt_Psi;
   ldlt_Psi.compute(b);
   for (int iter = 0; iter < p; ++iter)
   {
@@ -226,20 +222,20 @@ IGL_INLINE void igl::direct_delta_mush_precomputation(
   //    p_i p_i^T , p_i
   //    p_i^T     , 1
   // where p_i = (\sum_{j=1}^{n} Psi_{ij})'s top right 3 by 1 column
-  Matrix<Scalar, Dynamic, 10> P(n, 10);
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 10> P(n, 10);
   for (int i = 0; i < n; ++i)
   {
-    Matrix<Scalar, 3, 1> p_i = Matrix<Scalar, 3, 1>::Zero(3);
+    Eigen::Matrix<Scalar, 3, 1> p_i = Eigen::Matrix<Scalar, 3, 1>::Zero(3);
     Scalar last = 0;
     for (int j = 0; j < m; ++j)
     {
-      Matrix<Scalar, 3, 1> p_i_curr(3);
+      Eigen::Matrix<Scalar, 3, 1> p_i_curr(3);
       p_i_curr << Psi(i, j * 10 + 3), Psi(i, j * 10 + 6), Psi(i, j * 10 + 8);
       p_i += p_i_curr;
       last += Psi(i, j * 10 + 9);
     }
     p_i /= last;  // normalize
-    Matrix<Scalar, 4, 4> p_matrix(4, 4);
+    Eigen::Matrix<Scalar, 4, 4> p_matrix(4, 4);
     p_matrix.block(0, 0, 3, 3) = p_i * p_i.transpose();
     p_matrix.block(0, 3, 3, 1) = p_i;
     p_matrix.block(3, 0, 1, 3) = p_i.transpose();
@@ -251,11 +247,11 @@ IGL_INLINE void igl::direct_delta_mush_precomputation(
   Omega.resize(n, m * 10);
   for (int i = 0; i < n; ++i)
   {
-    Matrix<Scalar, 10, 1> p_vector = P.row(i);
+    Eigen::Matrix<Scalar, 10, 1> p_vector = P.row(i);
     for (int j = 0; j < m; ++j)
     {
-      Matrix<Scalar, 10, 1> Omega_curr(10);
-      Matrix<Scalar, 10, 1> Psi_curr = Psi.block(i, j * 10, 1, 10).transpose();
+      Eigen::Matrix<Scalar, 10, 1> Omega_curr(10);
+      Eigen::Matrix<Scalar, 10, 1> Psi_curr = Psi.block(i, j * 10, 1, 10).transpose();
       Omega_curr = (1. - alpha) * Psi_curr + alpha * W_prime(i, j) * p_vector;
       Omega.block(i, j * 10, 1, 10) = Omega_curr.transpose();
     }

--- a/include/igl/directed_edge_orientations.cpp
+++ b/include/igl/directed_edge_orientations.cpp
@@ -14,12 +14,11 @@ IGL_INLINE void igl::directed_edge_orientations(
   std::vector<
       Eigen::Quaterniond,Eigen::aligned_allocator<Eigen::Quaterniond> > & Q)
 {
-  using namespace Eigen;
   Q.resize(E.rows());
   for(int e = 0;e<E.rows();e++)
   {
     const auto & b = C.row(E(e,1)) - C.row(E(e,0));
-    Q[e].setFromTwoVectors( RowVector3d(1,0,0),b);
+    Q[e].setFromTwoVectors( Eigen::RowVector3d(1,0,0),b);
   }
 }
 

--- a/include/igl/directed_edge_parents.cpp
+++ b/include/igl/directed_edge_parents.cpp
@@ -15,7 +15,6 @@ IGL_INLINE void igl::directed_edge_parents(
   const Eigen::MatrixBase<DerivedE> & E,
   Eigen::PlainObjectBase<DerivedP> & P)
 {
-  using namespace Eigen;
   typedef Eigen::Matrix<typename DerivedE::Scalar, Eigen::Dynamic, 1> VectorT;
 
   VectorT I = VectorT::Constant(E.maxCoeff()+1,1,-1);

--- a/include/igl/directed_edge_parents.cpp
+++ b/include/igl/directed_edge_parents.cpp
@@ -16,7 +16,6 @@ IGL_INLINE void igl::directed_edge_parents(
   Eigen::PlainObjectBase<DerivedP> & P)
 {
   using namespace Eigen;
-  using namespace std;
   typedef Eigen::Matrix<typename DerivedE::Scalar, Eigen::Dynamic, 1> VectorT;
 
   VectorT I = VectorT::Constant(E.maxCoeff()+1,1,-1);

--- a/include/igl/doublearea.cpp
+++ b/include/igl/doublearea.cpp
@@ -148,7 +148,6 @@ IGL_INLINE void igl::doublearea(
   Eigen::PlainObjectBase<DeriveddblA> & dblA)
 {
   using namespace Eigen;
-  using namespace std;
   typedef typename Derivedl::Index Index;
   // Only support triangles
   assert(ul.cols() == 3);

--- a/include/igl/doublearea.cpp
+++ b/include/igl/doublearea.cpp
@@ -147,20 +147,19 @@ IGL_INLINE void igl::doublearea(
   const typename Derivedl::Scalar nan_replacement,
   Eigen::PlainObjectBase<DeriveddblA> & dblA)
 {
-  using namespace Eigen;
   typedef typename Derivedl::Index Index;
   // Only support triangles
   assert(ul.cols() == 3);
   // Number of triangles
   const Index m = ul.rows();
   Eigen::Matrix<typename Derivedl::Scalar, Eigen::Dynamic, 3> l;
-  MatrixXi _;
+  Eigen::MatrixXi _;
   //
   // "Miscalculating Area and Angles of a Needle-like Triangle"
   // https://people.eecs.berkeley.edu/~wkahan/Triangle.pdf
   igl::sort(ul,2,false,l,_);
   // semiperimeters
-  //Matrix<typename Derivedl::Scalar,Dynamic,1> s = l.rowwise().sum()*0.5;
+  //Matrix<typename Derivedl::Scalar ,Eigen::Dynamic,1> s = l.rowwise().sum()*0.5;
   //assert((Index)s.rows() == m);
   // resize output
   dblA.resize(l.rows(),1);

--- a/include/igl/doublearea.h
+++ b/include/igl/doublearea.h
@@ -14,11 +14,11 @@ namespace igl
   /// Computes twice the area for each input triangle or quad.
   ///
   /// @tparam  DerivedV  derived type of eigen matrix for V (e.g. derived from
-  ///     MatrixXd)
+  ///     Eigen::MatrixXd)
   /// @tparam  DerivedF  derived type of eigen matrix for F (e.g. derived from
-  ///     MatrixXi)
+  ///     Eigen::MatrixXi)
   /// @tparam  DeriveddblA  derived type of eigen matrix for dblA (e.g. derived from
-  ///     MatrixXd)
+  ///     Eigen::MatrixXd)
   /// @param[in] V  #V by dim list of mesh vertex positions
   /// @param[in] F  #F by (3|4) list of mesh faces (must be triangles or quads)
   /// @param[out] dblA  #F list of triangle[quad] double areas (SIGNED only for 2D input)

--- a/include/igl/dqs.cpp
+++ b/include/igl/dqs.cpp
@@ -22,7 +22,6 @@ IGL_INLINE void igl::dqs(
   const std::vector<T> & vT,
   Eigen::PlainObjectBase<DerivedU> & U)
 {
-  using namespace std;
   assert(V.rows() <= W.rows());
   assert(W.cols() == (int)vQ.size());
   assert(W.cols() == (int)vT.size());
@@ -30,7 +29,7 @@ IGL_INLINE void igl::dqs(
   U.resizeLike(V);
 
   // Convert quats + trans into dual parts
-  vector<Q> vD(vQ.size());
+  std::vector<Q> vD(vQ.size());
   for(int c = 0;c<W.cols();c++)
   {
     const Q & q = vQ[c];

--- a/include/igl/edge_collapse_is_valid.cpp
+++ b/include/igl/edge_collapse_is_valid.cpp
@@ -27,7 +27,6 @@ IGL_INLINE bool igl::edge_collapse_is_valid(
   const Eigen::MatrixBase<DerivedEF> & EF,
   const Eigen::MatrixBase<DerivedEI> & EI)
 {
-  using namespace Eigen;
   // For consistency with collapse_edge.cpp, let's determine edge flipness
   // (though not needed to check validity)
   const int eflip = E(e,0)>E(e,1);
@@ -58,22 +57,22 @@ IGL_INLINE bool igl::edge_collapse_is_valid(
       }
       std::vector<size_t> _1,_2;
       igl::unique(N,uN,_1,_2);
-      VectorXi uNm;
+      Eigen::VectorXi uNm;
       list_to_matrix(uN,uNm);
       return uNm;
     };
-    VectorXi Ns = neighbors(e, eflip);
-    VectorXi Nd = neighbors(e,!eflip);
-    VectorXi Nint = igl::intersect(Ns,Nd);
+    Eigen::VectorXi Ns = neighbors(e, eflip);
+    Eigen::VectorXi Nd = neighbors(e,!eflip);
+    Eigen::VectorXi Nint = igl::intersect(Ns,Nd);
     if(Nint.size() != 4)
     {
       return false;
     }
     if(Ns.size() == 4 && Nd.size() == 4)
     {
-      VectorXi NsNd(8);
+      Eigen::VectorXi NsNd(8);
       NsNd<<Ns,Nd;
-      VectorXi Nun,_1,_2;
+      Eigen::VectorXi Nun,_1,_2;
       igl::unique(NsNd,Nun,_1,_2);
       // single tet, don't collapse
       if(Nun.size() == 4)

--- a/include/igl/edge_collapse_is_valid.cpp
+++ b/include/igl/edge_collapse_is_valid.cpp
@@ -28,7 +28,6 @@ IGL_INLINE bool igl::edge_collapse_is_valid(
   const Eigen::MatrixBase<DerivedEI> & EI)
 {
   using namespace Eigen;
-  using namespace std;
   // For consistency with collapse_edge.cpp, let's determine edge flipness
   // (though not needed to check validity)
   const int eflip = E(e,0)>E(e,1);
@@ -49,15 +48,15 @@ IGL_INLINE bool igl::edge_collapse_is_valid(
       const int e,
       const bool ccw)
     {
-      vector<int> N,uN;
-      vector<int> V2Fe = circulation(e, ccw,EMAP,EF,EI);
+      std::vector<int> N,uN;
+      std::vector<int> V2Fe = circulation(e, ccw,EMAP,EF,EI);
       for(auto f : V2Fe)
       {
         N.push_back(F(f,0));
         N.push_back(F(f,1));
         N.push_back(F(f,2));
       }
-      vector<size_t> _1,_2;
+      std::vector<size_t> _1,_2;
       igl::unique(N,uN,_1,_2);
       VectorXi uNm;
       list_to_matrix(uN,uNm);

--- a/include/igl/edge_lengths.h
+++ b/include/igl/edge_lengths.h
@@ -16,9 +16,9 @@ namespace igl
   /// Constructs a list of lengths of edges opposite each index in a face
   /// (triangle/tet) list
   ///
-  /// @tparam DerivedV derived from vertex positions matrix type: i.e. MatrixXd
-  /// @tparam DerivedF derived from face indices matrix type: i.e. MatrixXi
-  /// @tparam DerivedL derived from edge lengths matrix type: i.e. MatrixXd
+  /// @tparam DerivedV derived from vertex positions matrix type: i.e. Eigen::MatrixXd
+  /// @tparam DerivedF derived from face indices matrix type: i.e. Eigen::MatrixXi
+  /// @tparam DerivedL derived from edge lengths matrix type: i.e. Eigen::MatrixXd
   /// @param[in] V  eigen matrix #V by 3
   /// @param[in] F  #F by (2|3|4) list of mesh simplex indices into rows of V
   /// @param[out] L  #F by {1|3|6} list of edge lengths 

--- a/include/igl/eigs.cpp
+++ b/include/igl/eigs.cpp
@@ -27,7 +27,6 @@ IGL_INLINE bool igl::eigs(
   Eigen::PlainObjectBase<DerivedS> & sS)
 {
   using namespace Eigen;
-  using namespace std;
   const size_t n = A.rows();
   assert(A.cols() == n && "A should be square.");
   assert(iB.rows() == n && "B should be match A's dims.");
@@ -134,7 +133,7 @@ IGL_INLINE bool igl::eigs(
     }
     if(iter == max_iter)
     {
-      cerr<<"Failed to converge."<<endl;
+      std::cerr<<"Failed to converge."<<std::endl;
       return false;
     }
     if(
@@ -158,7 +157,7 @@ IGL_INLINE bool igl::eigs(
       //std::cout<<"  "<<(S.head(i).array()-sigma).abs().maxCoeff()<<std::endl;
       //std::cout<<"  "<<(U.leftCols(i).transpose()*B*x).array().abs().transpose()<<std::endl;
       // restart with new random guess.
-      cout<<"igl::eigs RESTART"<<endl;
+      std::cout<<"igl::eigs RESTART"<<std::endl;
     }
   }
   // finally sort

--- a/include/igl/eigs.cpp
+++ b/include/igl/eigs.cpp
@@ -26,7 +26,6 @@ IGL_INLINE bool igl::eigs(
   Eigen::PlainObjectBase<DerivedU> & sU,
   Eigen::PlainObjectBase<DerivedS> & sS)
 {
-  using namespace Eigen;
   const size_t n = A.rows();
   assert(A.cols() == n && "A should be square.");
   assert(iB.rows() == n && "B should be match A's dims.");
@@ -98,8 +97,8 @@ IGL_INLINE bool igl::eigs(
           break;
         case EIGS_TYPE_SM:
         {
-          SimplicialLDLT<SparseMatrix<Scalar> > solver;
-          const SparseMatrix<Scalar> C = A-eff_sigma*B+tikhonov*B;
+          Eigen::SimplicialLDLT<Eigen::SparseMatrix<Scalar> > solver;
+          const Eigen::SparseMatrix<Scalar> C = A-eff_sigma*B+tikhonov*B;
           //mw.save(C,"C");
           //mw.save(eff_sigma,"eff_sigma");
           //mw.save(tikhonov,"tikhonov");
@@ -161,7 +160,7 @@ IGL_INLINE bool igl::eigs(
     }
   }
   // finally sort
-  VectorXi I;
+  Eigen::VectorXi I;
   igl::sort(S,1,false,sS,I);
   sU = U(igl::placeholders::all,I);
   sS /= rescale;

--- a/include/igl/embree/EmbreeIntersector.cpp
+++ b/include/igl/embree/EmbreeIntersector.cpp
@@ -59,7 +59,6 @@ IGL_INLINE void igl::embree::EmbreeIntersector::init(
   if(initialized)
     deinit();
 
-  using namespace std;
 
   if(V.size() == 0 || F.size() == 0)
   {
@@ -110,7 +109,7 @@ IGL_INLINE void igl::embree::EmbreeIntersector::init(
   rtcCommitScene(scene);
 
   if(rtcGetDeviceError (device) != RTC_ERROR_NONE)
-      std::cerr << "Embree: An error occurred while initializing the provided geometry!" << endl;
+      std::cerr << "Embree: An error occurred while initializing the provided geometry!" << std::endl;
 #ifdef IGL_VERBOSE
   else
     std::cerr << "Embree: geometry added." << endl;
@@ -245,7 +244,6 @@ igl::embree::EmbreeIntersector
   float tfar,
   int mask) const
 {
-  using namespace std;
   num_rays = 0;
   hits.clear();
   int last_id0 = -1;
@@ -315,9 +313,9 @@ igl::embree::EmbreeIntersector
 
     if(hits.size()>1000 && !large_hits_warned)
     {
-      std::cout<<"Warning: Large number of hits..."<<endl;
+      std::cout<<"Warning: Large number of hits..."<<std::endl;
       std::cout<<"[ ";
-      for(vector<Hit<float>>::iterator hit = hits.begin(); hit != hits.end();hit++)
+      for(std::vector<Hit<float>>::iterator hit = hits.begin(); hit != hits.end();hit++)
       {
         std::cout<<(hit->id+1)<<" ";
       }
@@ -325,12 +323,12 @@ igl::embree::EmbreeIntersector
       std::cout.precision(std::numeric_limits< double >::digits10);
       std::cout<<"[ ";
 
-      for(vector<Hit<float>>::iterator hit = hits.begin(); hit != hits.end(); hit++)
+      for(std::vector<Hit<float>>::iterator hit = hits.begin(); hit != hits.end(); hit++)
       {
-        std::cout<<(hit->t)<<endl;;
+        std::cout<<(hit->t)<<std::endl;
       }
 
-      std::cout<<"]"<<endl;
+      std::cout<<"]"<<std::endl;
       large_hits_warned = true;
 
       return hits.empty();

--- a/include/igl/embree/EmbreeIntersector.cpp
+++ b/include/igl/embree/EmbreeIntersector.cpp
@@ -112,7 +112,7 @@ IGL_INLINE void igl::embree::EmbreeIntersector::init(
       std::cerr << "Embree: An error occurred while initializing the provided geometry!" << std::endl;
 #ifdef IGL_VERBOSE
   else
-    std::cerr << "Embree: geometry added." << endl;
+    std::cerr << "Embree: geometry added." << std::endl;
 #endif
 
   initialized = true;
@@ -281,7 +281,7 @@ igl::embree::EmbreeIntersector
         //double t_push = pow(2.0,self_hits-4)*(hit.t<eps?eps:hit.t);
         double t_push = pow(2.0,self_hits)*eps;
         #ifdef IGL_VERBOSE
-        std::cerr<<"  t_push: "<<t_push<<endl;
+        std::cerr<<"  t_push: "<<t_push<<std::endl;
         #endif
         //o = o+t_push*d;
         min_t += t_push;
@@ -297,7 +297,7 @@ igl::embree::EmbreeIntersector
         hit.t = ray.ray.tfar;
         hits.push_back(hit);
 #ifdef IGL_VERBOSE
-        std::cerr<<"  t: "<<hit.t<<endl;
+        std::cerr<<"  t: "<<hit.t<<std::endl;
 #endif
         // Instead of moving origin, just change min_t. That way calculations
         // all use exactly same origin values

--- a/include/igl/embree/EmbreeRenderer.cpp
+++ b/include/igl/embree/EmbreeRenderer.cpp
@@ -91,7 +91,6 @@ IGL_INLINE void igl::embree::EmbreeRenderer::init(
   if(initialized)
     deinit();
 
-  using namespace std;
 
   if(V.size() == 0 || F.size() == 0)
   {

--- a/include/igl/embree/EmbreeRenderer.cpp
+++ b/include/igl/embree/EmbreeRenderer.cpp
@@ -135,10 +135,10 @@ IGL_INLINE void igl::embree::EmbreeRenderer::init(
   rtcCommitScene(scene);
 
   if(rtcGetDeviceError (device) != RTC_ERROR_NONE)
-      std::cerr << "Embree: An error occurred while initializing the provided geometry!" << endl;
+      std::cerr << "Embree: An error occurred while initializing the provided geometry!" << std::endl;
 #ifdef IGL_VERBOSE
   else
-    std::cerr << "Embree: geometry added." << endl;
+    std::cerr << "Embree: geometry added." << std::endl;
 #endif
 
   initialized = true;

--- a/include/igl/embree/ambient_occlusion.cpp
+++ b/include/igl/embree/ambient_occlusion.cpp
@@ -50,7 +50,6 @@ IGL_INLINE void igl::embree::ambient_occlusion(
   const int num_samples,
   Eigen::PlainObjectBase<DerivedS> & S)
 {
-  using namespace Eigen;
   EmbreeIntersector ei;
   ei.init(V.template cast<float>(),F.template cast<int>());
   ambient_occlusion(ei,P,N,num_samples,S);

--- a/include/igl/embree/bone_heat.cpp
+++ b/include/igl/embree/bone_heat.cpp
@@ -23,7 +23,6 @@ bool igl::embree::bone_heat(
   const Eigen::MatrixXi & CE,
   Eigen::MatrixXd & W)
 {
-  using namespace std;
   using namespace Eigen;
   assert(CE.rows() == 0 && "Cage edges not supported.");
   assert(C.cols() == V.cols() && "V and C should have same #cols");

--- a/include/igl/embree/bone_heat.cpp
+++ b/include/igl/embree/bone_heat.cpp
@@ -23,7 +23,6 @@ bool igl::embree::bone_heat(
   const Eigen::MatrixXi & CE,
   Eigen::MatrixXd & W)
 {
-  using namespace Eigen;
   assert(CE.rows() == 0 && "Cage edges not supported.");
   assert(C.cols() == V.cols() && "V and C should have same #cols");
   assert(BE.cols() == 2 && "BE should have #cols=2");
@@ -36,22 +35,22 @@ bool igl::embree::bone_heat(
   const int m = np + nb;
 
   // "double sided lighting"
-  MatrixXi FF;
+  Eigen::MatrixXi FF;
   FF.resize(F.rows()*2,F.cols());
   FF << F, F.rowwise().reverse();
   // Initialize intersector
   EmbreeIntersector ei;
   ei.init(V.cast<float>(),F.cast<int>());
 
-  typedef Matrix<bool,Dynamic,1> VectorXb;
-  typedef Matrix<bool,Dynamic,Dynamic> MatrixXb;
+  typedef Eigen::Matrix<bool ,Eigen::Dynamic,1> VectorXb;
+  typedef Eigen::Matrix<bool ,Eigen::Dynamic ,Eigen::Dynamic> MatrixXb;
   MatrixXb vis_mask(n,m);
   // Distances
-  MatrixXd D(n,m);
+  Eigen::MatrixXd D(n,m);
   // loop over points
   for(int j = 0;j<np;j++)
   {
-    const Vector3d p = C.row(P(j));
+    const Eigen::Vector3d p = C.row(P(j));
     D.col(j) = (V.rowwise()-p.transpose()).rowwise().norm();
     VectorXb vj;
     bone_visible(V,F,ei,p,p,vj);
@@ -61,9 +60,9 @@ bool igl::embree::bone_heat(
   // loop over bones
   for(int j = 0;j<nb;j++)
   {
-    const Vector3d s = C.row(BE(j,0));
-    const Vector3d d = C.row(BE(j,1));
-    VectorXd t,sqrD;
+    const Eigen::Vector3d s = C.row(BE(j,0));
+    const Eigen::Vector3d d = C.row(BE(j,1));
+    Eigen::VectorXd t,sqrD;
     project_to_line_segment(V,s,d,t,sqrD);
     D.col(np+j) = sqrD.array().sqrt();
     VectorXb vj;
@@ -73,10 +72,10 @@ bool igl::embree::bone_heat(
 
   assert(CE.rows() == 0 && "Cage edges not supported.");
 
-  MatrixXd PP = MatrixXd::Zero(n,m);
-  VectorXd min_D;
-  VectorXd Hdiag = VectorXd::Zero(n);
-  VectorXi J;
+  Eigen::MatrixXd PP = Eigen::MatrixXd::Zero(n,m);
+  Eigen::VectorXd min_D;
+  Eigen::VectorXd Hdiag = Eigen::VectorXd::Zero(n);
+  Eigen::VectorXi J;
   igl::min(D,2,min_D,J);
   for(int i = 0;i<n;i++)
   {
@@ -87,12 +86,12 @@ bool igl::embree::bone_heat(
       Hdiag(i) = (hii>1e10?1e10:hii);
     }
   }
-  SparseMatrix<double> Q,L,M;
+  Eigen::SparseMatrix<double> Q,L,M;
   cotmatrix(V,F,L);
   massmatrix(V,F,MASSMATRIX_TYPE_DEFAULT,M);
   const auto & H = Hdiag.asDiagonal();
   Q = (-L+M*H);
-  SimplicialLLT <SparseMatrix<double > > llt;
+  Eigen::SimplicialLLT <Eigen::SparseMatrix<double > > llt;
   llt.compute(Q);
   switch(llt.info())
   {

--- a/include/igl/embree/bone_visible.cpp
+++ b/include/igl/embree/bone_visible.cpp
@@ -48,18 +48,17 @@ IGL_INLINE void igl::embree::bone_visible(
   const Eigen::MatrixBase<DerivedSD> & d,
   Eigen::PlainObjectBase<Derivedflag>  & flag)
 {
-  using namespace Eigen;
   flag.resize(V.rows());
   const double sd_norm = (s-d).norm();
   // Embree seems to be parallel when constructing but not when tracing rays
   // loop over mesh vertices
   parallel_for(V.rows(),[&](const int v)
   {
-    const Vector3d Vv = V.row(v);
+    const Eigen::Vector3d Vv = V.row(v);
     // Project vertex v onto line segment sd
     //embree.intersectSegment
     double t,sqrd;
-    Vector3d projv;
+    Eigen::Vector3d projv;
     // degenerate bone, just snap to s
     if(sd_norm < DOUBLE_EPS)
     {
@@ -90,7 +89,7 @@ IGL_INLINE void igl::embree::bone_visible(
     igl::Hit<float> hit;
     // perhaps 1.0 should be 1.0-epsilon, or actually since we checking the
     // incident face, perhaps 1.0 should be 1.0+eps
-    const Vector3d dir = (Vv-projv)*1.0;
+    const Eigen::Vector3d dir = (Vv-projv)*1.0;
     if(ei.intersectSegment(
        projv.template cast<float>(),
        dir.template cast<float>(), 

--- a/include/igl/embree/bone_visible.cpp
+++ b/include/igl/embree/bone_visible.cpp
@@ -48,7 +48,6 @@ IGL_INLINE void igl::embree::bone_visible(
   const Eigen::MatrixBase<DerivedSD> & d,
   Eigen::PlainObjectBase<Derivedflag>  & flag)
 {
-  using namespace std;
   using namespace Eigen;
   flag.resize(V.rows());
   const double sd_norm = (s-d).norm();

--- a/include/igl/embree/reorient_facets_raycast.cpp
+++ b/include/igl/embree/reorient_facets_raycast.cpp
@@ -34,7 +34,6 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
   Eigen::PlainObjectBase<DerivedC> & C)
 {
   using namespace Eigen;
-  using namespace std;
   assert(F.cols() == 3);
   assert(V.cols() == 3);
 
@@ -49,10 +48,10 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
     for (int i = 0; i < m; ++i) C(i) = i;
 
   } else {
-    if (is_verbose) cout << "extracting patches... ";
+    if (is_verbose) std::cout << "extracting patches... ";
     bfs_orient(Fi,FF,C);
   }
-  if (is_verbose) cout << (C.maxCoeff() + 1)  << " components. ";
+  if (is_verbose) std::cout << (C.maxCoeff() + 1)  << " components. ";
 
   // number of patches
   const int num_cc = C.maxCoeff()+1;
@@ -80,18 +79,18 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
   VectorXi num_rays_per_component(num_cc);
   for (int c = 0; c < num_cc; ++c)
   {
-    num_rays_per_component(c) = max<int>(static_cast<int>(rays_total * area_per_component(c) / area_total), rays_minimum);
+    num_rays_per_component(c) = std::max<int>(static_cast<int>(rays_total * area_per_component(c) / area_total), rays_minimum);
   }
   rays_total = num_rays_per_component.sum();
 
   // generate all the rays
-  if (is_verbose) cout << "generating rays... ";
-  uniform_real_distribution<float> rdist;
-  mt19937 prng;
+  if (is_verbose) std::cout << "generating rays... ";
+  std::uniform_real_distribution<float> rdist;
+  std::mt19937 prng;
   prng.seed(time(nullptr));
-  vector<int     > ray_face;
-  vector<Vector3f> ray_ori;
-  vector<Vector3f> ray_dir;
+  std::vector<int     > ray_face;
+  std::vector<Vector3f> ray_ori;
+  std::vector<Vector3f> ray_dir;
   ray_face.reserve(rays_total);
   ray_ori .reserve(rays_total);
   ray_dir .reserve(rays_total);
@@ -101,8 +100,8 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
     {
       continue;
     }
-    vector<int> CF;     // set of faces per component
-    vector<double> CF_area;
+    std::vector<int> CF;     // set of faces per component
+    std::vector<double> CF_area;
     for (int f = 0; f < m; ++f)
     {
       if (C(f)==c)
@@ -112,7 +111,7 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
       }
     }
     // discrete distribution for random selection of faces with probability proportional to their areas
-    discrete_distribution<int> ddist(CF.size(), 0, CF.size(), [&](double i){ return CF_area[static_cast<int>(i)]; });       // simple ctor of (Iter, Iter) not provided by the stupid VC11/12
+    std::discrete_distribution<int> ddist(CF.size(), 0, CF.size(), [&](double i){ return CF_area[static_cast<int>(i)]; });       // simple ctor of (Iter, Iter) not provided by the stupid VC11/12
     for (int i = 0; i < num_rays_per_component[c]; ++i)
     {
       int f = CF[ddist(prng)];          // select face with probability proportional to face area
@@ -146,17 +145,17 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
       ray_ori .push_back(p);
       ray_dir .push_back(d);
 
-      if (is_verbose && ray_face.size() % (rays_total / 10) == 0) cout << ".";
+      if (is_verbose && ray_face.size() % (rays_total / 10) == 0) std::cout << ".";
     }
   }
-  if (is_verbose) cout << ray_face.size()  << " rays. ";
+  if (is_verbose) std::cout << ray_face.size()  << " rays. ";
 
   // per component voting: first=front, second=back
-  vector<pair<float, float>> C_vote_distance(num_cc, make_pair(0, 0));      // sum of distance between ray origin and intersection
-  vector<pair<int  , int  >> C_vote_infinity(num_cc, make_pair(0, 0));      // number of rays reaching infinity
-  vector<pair<int  , int  >> C_vote_parity(num_cc, make_pair(0, 0));        // sum of parity count for each ray
+  std::vector<std::pair<float, float>> C_vote_distance(num_cc, std::make_pair(0, 0));      // sum of distance between ray origin and intersection
+  std::vector<std::pair<int  , int  >> C_vote_infinity(num_cc, std::make_pair(0, 0));      // number of rays reaching infinity
+  std::vector<std::pair<int  , int  >> C_vote_parity(num_cc, std::make_pair(0, 0));        // sum of parity count for each ray
 
-  if (is_verbose) cout << "shooting rays... ";
+  if (is_verbose) std::cout << "shooting rays... ";
 // #pragma omp parallel for
   for (int i = 0; i < (int)ray_face.size(); ++i)
   {
@@ -166,8 +165,8 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
     int c = C(f);
 
     // shoot ray toward front & back
-    vector<Hit<float>> hits_front;
-    vector<Hit<float>> hits_back;
+    std::vector<Hit<float>> hits_front;
+    std::vector<Hit<float>> hits_back;
     int num_rays_front;
     int num_rays_back;
     ei.intersectRay(o,  d, hits_front, num_rays_front);
@@ -218,7 +217,7 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
     if (Fi.row(f) != FF.row(f))
       I(f) = 1 - I(f);
   }
-  if (is_verbose) cout << "done!" << endl;
+  if (is_verbose) std::cout << "done!" << std::endl;
 }
 
 template <

--- a/include/igl/embree/reorient_facets_raycast.cpp
+++ b/include/igl/embree/reorient_facets_raycast.cpp
@@ -33,7 +33,6 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
   Eigen::PlainObjectBase<DerivedI> & I,
   Eigen::PlainObjectBase<DerivedC> & C)
 {
-  using namespace Eigen;
   assert(F.cols() == 3);
   assert(V.cols() == 3);
 
@@ -61,22 +60,22 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
   ei.init(V.template cast<float>(),FF);
 
   // face normal
-  MatrixXd N;
+  Eigen::MatrixXd N;
   per_face_normals(V,FF,N);
 
   // face area
-  Matrix<typename DerivedV::Scalar,Dynamic,1> A;
+  Eigen::Matrix<typename DerivedV::Scalar ,Eigen::Dynamic,1> A;
   doublearea(V,FF,A);
   double area_total = A.sum();
 
   // determine number of rays per component according to its area
-  VectorXd area_per_component;
+  Eigen::VectorXd area_per_component;
   area_per_component.setZero(num_cc);
   for (int f = 0; f < m; ++f)
   {
     area_per_component(C(f)) += A(f);
   }
-  VectorXi num_rays_per_component(num_cc);
+  Eigen::VectorXi num_rays_per_component(num_cc);
   for (int c = 0; c < num_cc; ++c)
   {
     num_rays_per_component(c) = std::max<int>(static_cast<int>(rays_total * area_per_component(c) / area_total), rays_minimum);

--- a/include/igl/embree/reorient_facets_raycast.cpp
+++ b/include/igl/embree/reorient_facets_raycast.cpp
@@ -88,8 +88,8 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
   std::mt19937 prng;
   prng.seed(time(nullptr));
   std::vector<int     > ray_face;
-  std::vector<Vector3f> ray_ori;
-  std::vector<Vector3f> ray_dir;
+  std::vector<Eigen::Vector3f> ray_ori;
+  std::vector<Eigen::Vector3f> ray_dir;
   ray_face.reserve(rays_total);
   ray_ori .reserve(rays_total);
   ray_dir .reserve(rays_total);
@@ -120,13 +120,13 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
       float a = 1 - sqrt_t;
       float b = (1 - s) * sqrt_t;
       float c = s * sqrt_t;
-      Vector3f p = a * V.row(FF(f,0)).template cast<float>().eval()       // be careful with the index!!!
+      Eigen::Vector3f p = a * V.row(FF(f,0)).template cast<float>().eval()       // be careful with the index!!!
                  + b * V.row(FF(f,1)).template cast<float>().eval()
                  + c * V.row(FF(f,2)).template cast<float>().eval();
-      Vector3f n = N.row(f).cast<float>();
+      Eigen::Vector3f n = N.row(f).cast<float>();
       if (n.isZero()) continue;
       // random direction in hemisphere around n (avoid too grazing angle)
-      Vector3f d;
+      Eigen::Vector3f d;
       while (true) {
         d = random_dir().cast<float>();
         float ndotd = n.dot(d);
@@ -159,8 +159,8 @@ IGL_INLINE void igl::embree::reorient_facets_raycast(
   for (int i = 0; i < (int)ray_face.size(); ++i)
   {
     int      f = ray_face[i];
-    Vector3f o = ray_ori [i];
-    Vector3f d = ray_dir [i];
+    Eigen::Vector3f o = ray_ori [i];
+    Eigen::Vector3f d = ray_dir [i];
     int c = C(f);
 
     // shoot ray toward front & back

--- a/include/igl/embree/shape_diameter_function.cpp
+++ b/include/igl/embree/shape_diameter_function.cpp
@@ -56,7 +56,6 @@ IGL_INLINE void igl::embree::shape_diameter_function(
   const int num_samples,
   Eigen::PlainObjectBase<DerivedS> & S)
 {
-  using namespace Eigen;
   EmbreeIntersector ei;
   ei.init(V.template cast<float>(),F.template cast<int>());
   shape_diameter_function(ei,P,N,num_samples,S);

--- a/include/igl/embree/unproject_in_mesh.cpp
+++ b/include/igl/embree/unproject_in_mesh.cpp
@@ -21,7 +21,6 @@ IGL_INLINE int igl::embree::unproject_in_mesh(
   Eigen::PlainObjectBase<Derivedobj> & obj,
   std::vector<igl::Hit<float> > & hits)
 {
-  using namespace std;
   using namespace Eigen;
   const auto & shoot_ray = [&ei](
     const Eigen::Vector3f& s,

--- a/include/igl/embree/unproject_in_mesh.cpp
+++ b/include/igl/embree/unproject_in_mesh.cpp
@@ -21,7 +21,6 @@ IGL_INLINE int igl::embree::unproject_in_mesh(
   Eigen::PlainObjectBase<Derivedobj> & obj,
   std::vector<igl::Hit<float> > & hits)
 {
-  using namespace Eigen;
   const auto & shoot_ray = [&ei](
     const Eigen::Vector3f& s,
     const Eigen::Vector3f& dir,

--- a/include/igl/embree/unproject_onto_mesh.cpp
+++ b/include/igl/embree/unproject_onto_mesh.cpp
@@ -19,7 +19,6 @@ IGL_INLINE bool igl::embree::unproject_onto_mesh(
   int& fid,
   Eigen::Vector3f& bc)
 {
-  using namespace Eigen;
   const auto & shoot_ray = [&ei](
     const Eigen::Vector3f& s,
     const Eigen::Vector3f& dir,

--- a/include/igl/embree/unproject_onto_mesh.cpp
+++ b/include/igl/embree/unproject_onto_mesh.cpp
@@ -19,7 +19,6 @@ IGL_INLINE bool igl::embree::unproject_onto_mesh(
   int& fid,
   Eigen::Vector3f& bc)
 {
-  using namespace std;
   using namespace Eigen;
   const auto & shoot_ray = [&ei](
     const Eigen::Vector3f& s,

--- a/include/igl/example_fun.cpp
+++ b/include/igl/example_fun.cpp
@@ -11,8 +11,7 @@
 template <typename Printable>
 IGL_INLINE bool igl::example_fun(const Printable & input)
 {
-  using namespace std;
-  cout<<"example_fun: "<<input<<endl;
+  std::cout<<"example_fun: "<<input<<std::endl;
   return true;
 }
 

--- a/include/igl/exterior_edges.cpp
+++ b/include/igl/exterior_edges.cpp
@@ -47,21 +47,20 @@ IGL_INLINE void igl::exterior_edges(
   const Eigen::MatrixBase<DerivedF> & F,
   Eigen::PlainObjectBase<DerivedE> & E)
 {
-  using namespace Eigen;
   using Index = typename DerivedF::Scalar;
   using VectorXI = Eigen::Matrix<typename DerivedF::Scalar,Eigen::Dynamic,1>;
   using MatrixXI = Eigen::Matrix<typename DerivedF::Scalar,Eigen::Dynamic,Eigen::Dynamic>;
   assert(F.cols() == 3);
   const Index m = F.rows();
-  MatrixXI all_E,sall_E,sort_order;
+  Eigen::MatrixXi all_E,sall_E,sort_order;
   // Sort each edge by index
   oriented_facets(F,all_E);
   sort(all_E,2,true,sall_E,sort_order);
   // Find unique edges
   PlainMatrix<DerivedF,Eigen::Dynamic> uE;
-  VectorXI IA,EMAP;
+  Eigen::VectorXi IA,EMAP;
   unique_rows(sall_E,uE,IA,EMAP);
-  VectorXI counts = VectorXI::Zero(uE.rows());
+  Eigen::VectorXi counts = Eigen::VectorXi::Zero(uE.rows());
   for(Index a = 0;a<3*m;a++)
   {
     counts(EMAP(a)) += (sort_order(a)==0?1:-1);

--- a/include/igl/exterior_edges.cpp
+++ b/include/igl/exterior_edges.cpp
@@ -48,7 +48,6 @@ IGL_INLINE void igl::exterior_edges(
   Eigen::PlainObjectBase<DerivedE> & E)
 {
   using namespace Eigen;
-  using namespace std;
   using Index = typename DerivedF::Scalar;
   using VectorXI = Eigen::Matrix<typename DerivedF::Scalar,Eigen::Dynamic,1>;
   using MatrixXI = Eigen::Matrix<typename DerivedF::Scalar,Eigen::Dynamic,Eigen::Dynamic>;

--- a/include/igl/face_areas.cpp
+++ b/include/igl/face_areas.cpp
@@ -36,13 +36,12 @@ IGL_INLINE void igl::face_areas(
   const typename DerivedL::Scalar doublearea_nan_replacement,
   Eigen::PlainObjectBase<DerivedA>& A)
 {
-  using namespace Eigen;
   assert(L.cols() == 6);
   const int m = L.rows();
   // (unsigned) face Areas (opposite vertices: 1 2 3 4)
-  Matrix<typename DerivedA::Scalar,Dynamic,1> 
+  Eigen::Matrix<typename DerivedA::Scalar ,Eigen::Dynamic,1>
     A0(m,1), A1(m,1), A2(m,1), A3(m,1);
-  Matrix<typename DerivedA::Scalar,Dynamic,3> 
+  Eigen::Matrix<typename DerivedA::Scalar ,Eigen::Dynamic,3>
     L0(m,3), L1(m,3), L2(m,3), L3(m,3);
   L0<<L.col(1),L.col(2),L.col(3);
   L1<<L.col(0),L.col(2),L.col(4);

--- a/include/igl/face_occurrences.cpp
+++ b/include/igl/face_occurrences.cpp
@@ -18,16 +18,14 @@ IGL_INLINE void igl::face_occurrences(
   const std::vector<std::vector<IntegerF> > & F,
   std::vector<IntegerC> & C)
 {
-  using namespace std;
-
   // Get a list of sorted faces
-  vector<vector<IntegerF> > sortedF = F;
+  std::vector<std::vector<IntegerF> > sortedF = F;
   for(int i = 0; i < (int)F.size();i++)
   {
     sort(sortedF[i].begin(),sortedF[i].end());
   }
   // Count how many times each sorted face occurs
-  map<vector<IntegerF>,int> counts;
+  std::map<std::vector<IntegerF>,int> counts;
   for(int i = 0; i < (int)sortedF.size();i++)
   {
     if(counts.find(sortedF[i]) == counts.end())

--- a/include/igl/faces_first.cpp
+++ b/include/igl/faces_first.cpp
@@ -20,7 +20,6 @@ IGL_INLINE void igl::faces_first(
 {
   assert(&V != &RV);
   assert(&F != &RF);
-  using namespace Eigen;
   std::vector<bool> in_face(V.rows());
   for(int i = 0; i<F.rows(); i++)
   {
@@ -36,9 +35,9 @@ IGL_INLINE void igl::faces_first(
     num_in_F += (in_face[i]?1:0);
   }
   // list of unique vertices that occur in F
-  VectorXi U(num_in_F);
+  Eigen::VectorXi U(num_in_F);
   // list of unique vertices that do not occur in F
-  VectorXi NU(V.rows()-num_in_F);
+  Eigen::VectorXi NU(V.rows()-num_in_F);
   int Ui = 0;
   int NUi = 0;
   // loop over vertices

--- a/include/igl/faces_first.cpp
+++ b/include/igl/faces_first.cpp
@@ -20,9 +20,8 @@ IGL_INLINE void igl::faces_first(
 {
   assert(&V != &RV);
   assert(&F != &RF);
-  using namespace std;
   using namespace Eigen;
-  vector<bool> in_face(V.rows());
+  std::vector<bool> in_face(V.rows());
   for(int i = 0; i<F.rows(); i++)
   {
     for(int j = 0; j<F.cols(); j++)

--- a/include/igl/faces_first.h
+++ b/include/igl/faces_first.h
@@ -16,9 +16,9 @@ namespace igl
   /// listed before internal vertices
   ///
   ///
-  /// @tparam MatV  matrix for vertex positions, e.g. MatrixXd
-  /// @tparam MatF  matrix for face indices, e.g. MatrixXi
-  /// @tparam VecI  vector for index map, e.g. VectorXi
+  /// @tparam MatV  matrix for vertex positions, e.g. Eigen::MatrixXd
+  /// @tparam MatF  matrix for face indices, e.g. Eigen::MatrixXi
+  /// @tparam VecI  vector for index map, e.g. Eigen::VectorXi
   /// @param[in] V  # vertices by 3 vertex positions
   /// @param[in] F  # faces by 3 list of face indices
   /// @param[out] RV  # vertices by 3 vertex positions, order such that if the jth vertex is

--- a/include/igl/facet_adjacency_matrix.cpp
+++ b/include/igl/facet_adjacency_matrix.cpp
@@ -12,11 +12,10 @@ template <typename DerivedF, typename Atype>
 IGL_INLINE void igl::facet_adjacency_matrix(
   const Eigen::MatrixBase<DerivedF> & F, Eigen::SparseMatrix<Atype> & A)
 {
-  using namespace Eigen;
   typedef typename DerivedF::Scalar Index;
   const auto m = F.rows();
-  Eigen::Matrix<Index,Dynamic,1> EMAP,uEE,uEC;
-  Eigen::Matrix<Index,Dynamic,2> E,uE;
+  Eigen::Matrix<Index,Eigen::Dynamic,1> EMAP,uEE,uEC;
+  Eigen::Matrix<Index,Eigen::Dynamic,2> E,uE;
   igl::unique_edge_map(F,E,uE,EMAP,uEC,uEE);
   std::vector<Eigen::Triplet<Index> > AIJV;
   AIJV.reserve(2*uE.rows());

--- a/include/igl/facet_components.cpp
+++ b/include/igl/facet_components.cpp
@@ -35,13 +35,12 @@ IGL_INLINE void igl::facet_components(
   Eigen::PlainObjectBase<DerivedC> & C,
   Eigen::PlainObjectBase<Derivedcounts> & counts)
 {
-  using namespace std;
   typedef TTIndex Index;
   const Index m = TT.size();
   C.resize(m,1);
-  vector<bool> seen(m,false);
+  std::vector<bool> seen(m,false);
   Index id = 0;
-  vector<Index> vcounts;
+  std::vector<Index> vcounts;
   for(Index g = 0;g<m;g++)
   {
     if(seen[g])
@@ -49,7 +48,7 @@ IGL_INLINE void igl::facet_components(
       continue;
     }
     vcounts.push_back(0);
-    queue<Index> Q;
+    std::queue<Index> Q;
     Q.push(g);
     while(!Q.empty())
     {

--- a/include/igl/false_barycentric_subdivision.cpp
+++ b/include/igl/false_barycentric_subdivision.cpp
@@ -18,7 +18,6 @@ IGL_INLINE void igl::false_barycentric_subdivision(
     Eigen::PlainObjectBase<DerivedVD> & VD,
     Eigen::PlainObjectBase<DerivedFD> & FD)
 {
-  using namespace Eigen;
   // Compute face barycenter
   PlainMatrix<DerivedV> BC;
   igl::barycenter(V,F,BC);

--- a/include/igl/find_zero.cpp
+++ b/include/igl/find_zero.cpp
@@ -38,7 +38,7 @@ IGL_INLINE void igl::find_zero(
       }
     }
   };
-  for_each(A,func);
+  igl::for_each(A,func);
 }
 
 #ifdef IGL_STATIC_LIBRARY

--- a/include/igl/fit_rotations.cpp
+++ b/include/igl/fit_rotations.cpp
@@ -20,7 +20,6 @@ IGL_INLINE void igl::fit_rotations(
   const bool single_precision,
   Eigen::PlainObjectBase<DerivedD> & R)
 {
-  using namespace std;
   const int dim = S.cols();
   const int nr = S.rows()/dim;
   assert(nr * dim == S.rows());
@@ -67,7 +66,6 @@ IGL_INLINE void igl::fit_rotations_planar(
   const Eigen::MatrixBase<DerivedS> & S,
         Eigen::PlainObjectBase<DerivedD> & R)
 { 
-  using namespace std;
   const int dim = S.cols();
   const int nr = S.rows()/dim;
   //assert(dim == 2 && "_planar input should be 2D");

--- a/include/igl/flip_avoiding_line_search.cpp
+++ b/include/igl/flip_avoiding_line_search.cpp
@@ -24,7 +24,6 @@ namespace igl
     // http://math.ivanovo.ac.ru/dalgebra/Khashin/poly/index.html
     IGL_INLINE int SolveP3(std::vector<double>& x,double a,double b,double c)
     { // solve cubic equation x^3 + a*x^2 + b*x + c
-      using namespace std;
       double a2 = a*a;
         double q  = (a2 - 3*b)/9;
       double r  = (a*(2*a2-9*b) + 27*c)/54;
@@ -63,7 +62,6 @@ namespace igl
 
     IGL_INLINE double get_smallest_pos_quad_zero(double a,double b, double c)
     {
-      using namespace std;
       double t1, t2;
       if(std::abs(a) > 1.0e-10)
       {
@@ -114,7 +112,6 @@ namespace igl
                                           Eigen::MatrixXd& d,
                                           int f)
     {
-      using namespace std;
     /*
           Finding the smallest timestep t s.t a triangle get degenerated (<=> det = 0)
           The following code can be derived by a symbolic expression in matlab:
@@ -180,7 +177,6 @@ namespace igl
                                           Eigen::MatrixXd& direc,
                                           int f)
     {
-      using namespace std;
       /*
           Searching for the roots of:
             +-1/6 * |ax ay az 1|
@@ -275,7 +271,6 @@ namespace igl
                                                           const Eigen::MatrixXi& F,
                                                           Eigen::MatrixXd& d)
     {
-      using namespace std;
       double max_step = INFINITY;
 
       // The if statement is outside the for loops to avoid branching/ease parallelizing
@@ -307,7 +302,6 @@ IGL_INLINE double igl::flip_avoiding_line_search(
   std::function<double(Eigen::MatrixXd&)> & energy,
   double cur_energy)
 {
-  using namespace std;
   Eigen::MatrixXd d = dst_v - cur_v;
 
   double min_step_to_singularity = igl::flip_avoiding::compute_max_step_from_singularities(cur_v,F,d);

--- a/include/igl/flood_fill.cpp
+++ b/include/igl/flood_fill.cpp
@@ -13,7 +13,6 @@ IGL_INLINE void igl::flood_fill(
   const Eigen::MatrixBase<Derivedres>& res,
   Eigen::PlainObjectBase<DerivedS> & S)
 {
-  using namespace Eigen;
   typedef typename DerivedS::Scalar Scalar;
   const auto flood = [&res,&S] (
      const int xi,

--- a/include/igl/flood_fill.cpp
+++ b/include/igl/flood_fill.cpp
@@ -14,7 +14,6 @@ IGL_INLINE void igl::flood_fill(
   Eigen::PlainObjectBase<DerivedS> & S)
 {
   using namespace Eigen;
-  using namespace std;
   typedef typename DerivedS::Scalar Scalar;
   const auto flood = [&res,&S] (
      const int xi,
@@ -51,7 +50,7 @@ IGL_INLINE void igl::flood_fill(
       }
     };
   int signed_zi = -1;
-  Scalar s = numeric_limits<Scalar>::quiet_NaN();
+  Scalar s = std::numeric_limits<Scalar>::quiet_NaN();
   for(int zi = 0;zi<res(2);zi++)
   {
     int signed_yi = -1;

--- a/include/igl/floor.cpp
+++ b/include/igl/floor.cpp
@@ -14,7 +14,6 @@ IGL_INLINE void igl::floor(
   const Eigen::DenseBase<DerivedX>& X,
   Eigen::PlainObjectBase<DerivedY>& Y)
 {
-  using namespace std;
   typedef typename DerivedX::Scalar Scalar;
   Y = X.unaryExpr([](const Scalar &x)->Scalar{return std::floor(x);}).template cast<typename DerivedY::Scalar >();
 }

--- a/include/igl/forward_kinematics.cpp
+++ b/include/igl/forward_kinematics.cpp
@@ -20,8 +20,7 @@ IGL_INLINE void igl::forward_kinematics(
     Eigen::Quaterniond,Eigen::aligned_allocator<Eigen::Quaterniond> > & vQ,
   std::vector<Eigen::Vector3d> & vT)
 {
-  using namespace Eigen;
-  const int m = BE.rows(); 
+  const int m = BE.rows();
   assert(m == P.rows());
   assert(m == (int)dQ.size());
   assert(m == (int)dT.size());
@@ -37,7 +36,7 @@ IGL_INLINE void igl::forward_kinematics(
       {
         // base case for roots
         vQ[b] = dQ[b];
-        const Vector3d r = C.row(BE(b,0)).transpose();
+        const Eigen::Vector3d r = C.row(BE(b,0)).transpose();
         vT[b] = r-dQ[b]*r + dT[b];
       }else
       {
@@ -45,7 +44,7 @@ IGL_INLINE void igl::forward_kinematics(
         const int p = P(b);
         fk_helper(p);
         vQ[b] = vQ[p] * dQ[b];
-        const Vector3d r = C.row(BE(b,0)).transpose();
+        const Eigen::Vector3d r = C.row(BE(b,0)).transpose();
         vT[b] = vT[p] - vQ[b]*r + vQ[p]*(r + dT[b]);
       }
       computed[b] = true;
@@ -80,15 +79,14 @@ IGL_INLINE void igl::forward_kinematics(
   const std::vector<Eigen::Vector3d> & dT,
   Eigen::MatrixXd & T)
 {
-  using namespace Eigen;
-  std::vector< Quaterniond,aligned_allocator<Quaterniond> > vQ;
-  std::vector< Vector3d> vT;
+  std::vector< Eigen::Quaterniond,Eigen::aligned_allocator<Eigen::Quaterniond> > vQ;
+  std::vector< Eigen::Vector3d> vT;
   forward_kinematics(C,BE,P,dQ,dT,vQ,vT);
   const int dim = C.cols();
   T.resize(BE.rows()*(dim+1),dim);
   for(int e = 0;e<BE.rows();e++)
   {
-    Affine3d a = Affine3d::Identity();
+    Eigen::Affine3d a = Eigen::Affine3d::Identity();
     a.translate(vT[e]);
     a.rotate(vQ[e]);
     T.block(e*(dim+1),0,dim+1,dim) =

--- a/include/igl/forward_kinematics.cpp
+++ b/include/igl/forward_kinematics.cpp
@@ -20,17 +20,16 @@ IGL_INLINE void igl::forward_kinematics(
     Eigen::Quaterniond,Eigen::aligned_allocator<Eigen::Quaterniond> > & vQ,
   std::vector<Eigen::Vector3d> & vT)
 {
-  using namespace std;
   using namespace Eigen;
   const int m = BE.rows(); 
   assert(m == P.rows());
   assert(m == (int)dQ.size());
   assert(m == (int)dT.size());
-  vector<bool> computed(m,false);
+  std::vector<bool> computed(m,false);
   vQ.resize(m);
   vT.resize(m);
   // Dynamic programming
-  function<void (int) > fk_helper = [&] (int b)
+  std::function<void (int) > fk_helper = [&] (int b)
   {
     if(!computed[b])
     {
@@ -82,9 +81,8 @@ IGL_INLINE void igl::forward_kinematics(
   Eigen::MatrixXd & T)
 {
   using namespace Eigen;
-  using namespace std;
-  vector< Quaterniond,aligned_allocator<Quaterniond> > vQ;
-  vector< Vector3d> vT;
+  std::vector< Quaterniond,aligned_allocator<Quaterniond> > vQ;
+  std::vector< Vector3d> vT;
   forward_kinematics(C,BE,P,dQ,dT,vQ,vT);
   const int dim = C.cols();
   T.resize(BE.rows()*(dim+1),dim);

--- a/include/igl/frame_to_cross_field.cpp
+++ b/include/igl/frame_to_cross_field.cpp
@@ -15,15 +15,13 @@ IGL_INLINE void igl::frame_to_cross_field(
   const Eigen::MatrixXd& FF2,
   Eigen::MatrixXd& X)
 {
-  using namespace Eigen;
-
   // Generate local basis
-  MatrixXd B1, B2, B3;
+  Eigen::MatrixXd B1, B2, B3;
 
   igl::local_basis(V,F,B1,B2,B3);
 
   // Project the frame fields in the local basis
-  MatrixXd d1, d2;
+  Eigen::MatrixXd d1, d2;
   d1.resize(F.rows(),2);
   d2.resize(F.rows(),2);
 
@@ -37,19 +35,19 @@ IGL_INLINE void igl::frame_to_cross_field(
 
 	for (int i=0;i<F.rows();i++)
 	{
-		Vector2d v1 = d1.row(i);
-		Vector2d v2 = d2.row(i);
+		Eigen::Vector2d v1 = d1.row(i);
+		Eigen::Vector2d v2 = d2.row(i);
 
     // define inverse map that maps the canonical axis to the given frame directions
-		Matrix2d A;
+		Eigen::Matrix2d A;
 		A <<    v1[0], v2[0],
             v1[1], v2[1];
 
 		// find the closest rotation
-		Eigen::JacobiSVD<Matrix<double,2,2> > svd(A, Eigen::ComputeFullU | Eigen::ComputeFullV );
-    Matrix2d C = svd.matrixU() * svd.matrixV().transpose();
+		Eigen::JacobiSVD<Eigen::Matrix<double,2,2> > svd(A, Eigen::ComputeFullU | Eigen::ComputeFullV );
+    Eigen::Matrix2d C = svd.matrixU() * svd.matrixV().transpose();
 
-    Vector2d v = C.col(0);
+    Eigen::Vector2d v = C.col(0);
     X.row(i) = v(0) * B1.row(i) + v(1) * B2.row(i);
   }
 }

--- a/include/igl/gaussian_curvature.cpp
+++ b/include/igl/gaussian_curvature.cpp
@@ -15,9 +15,8 @@ IGL_INLINE void igl::gaussian_curvature(
   const Eigen::MatrixBase<DerivedF>& F,
   Eigen::PlainObjectBase<DerivedK> & K)
 {
-  using namespace Eigen;
   // internal corner angles
-  Matrix<
+  Eigen::Matrix<
     typename DerivedV::Scalar,
     DerivedF::RowsAtCompileTime,
     DerivedF::ColsAtCompileTime> A;

--- a/include/igl/gaussian_curvature.cpp
+++ b/include/igl/gaussian_curvature.cpp
@@ -16,7 +16,6 @@ IGL_INLINE void igl::gaussian_curvature(
   Eigen::PlainObjectBase<DerivedK> & K)
 {
   using namespace Eigen;
-  using namespace std;
   // internal corner angles
   Matrix<
     typename DerivedV::Scalar,

--- a/include/igl/grad.cpp
+++ b/include/igl/grad.cpp
@@ -25,7 +25,6 @@ IGL_INLINE void grad_tet(
   Eigen::SparseMatrix<typename DerivedV::Scalar> &G,
   bool uniform)
 {
-  using namespace Eigen;
   assert(T.cols() == 4);
   const int n = V.rows(); int m = T.rows();
 
@@ -35,7 +34,7 @@ IGL_INLINE void grad_tet(
       T(:,1) T(:,3) T(:,4); ...
       T(:,1) T(:,4) T(:,2); ...
       T(:,2) T(:,4) T(:,3)]; */
-  MatrixXi F(4*m,3);
+  Eigen::MatrixXi F(4*m,3);
   for (int i = 0; i < m; i++) {
     F.row(0*m + i) << T(i,0), T(i,1), T(i,2);
     F.row(1*m + i) << T(i,0), T(i,2), T(i,3);
@@ -92,7 +91,7 @@ IGL_INLINE void grad_tet(
       repmat([T(:,4);T(:,2);T(:,3);T(:,1)],3,1), ...
       repmat(A./(3*repmat(vol,4,1)),3,1).*N(:), ...
       3*m,n);*/
-  std::vector<Triplet<double> > G_t;
+  std::vector<Eigen::Triplet<double> > G_t;
   for (int i = 0; i < 4*m; i++) {
     int T_j; // j indexes : repmat([T(:,4);T(:,2);T(:,3);T(:,1)],3,1)
     switch (i/m) {
@@ -113,9 +112,9 @@ IGL_INLINE void grad_tet(
     int j_idx = T(i_idx,T_j);
 
     double val_before_n = A(i)/(3*vol(i_idx));
-    G_t.push_back(Triplet<double>(0*m+i_idx, j_idx, val_before_n * N(i,0)));
-    G_t.push_back(Triplet<double>(1*m+i_idx, j_idx, val_before_n * N(i,1)));
-    G_t.push_back(Triplet<double>(2*m+i_idx, j_idx, val_before_n * N(i,2)));
+    G_t.push_back(Eigen::Triplet<double>(0*m+i_idx, j_idx, val_before_n * N(i,0)));
+    G_t.push_back(Eigen::Triplet<double>(1*m+i_idx, j_idx, val_before_n * N(i,1)));
+    G_t.push_back(Eigen::Triplet<double>(2*m+i_idx, j_idx, val_before_n * N(i,2)));
   }
   G.resize(3*m,n);
   G.setFromTriplets(G_t.begin(), G_t.end());

--- a/include/igl/grid.cpp
+++ b/include/igl/grid.cpp
@@ -16,7 +16,6 @@ IGL_INLINE void igl::grid(
   const Eigen::MatrixBase<Derivedres> & res, 
   Eigen::PlainObjectBase<DerivedGV> & GV)
 {
-  using namespace Eigen;
   typedef typename DerivedGV::Scalar Scalar;
   GV.resize(res.array().prod(),res.size());
   const auto lerp = 

--- a/include/igl/harmonic.cpp
+++ b/include/igl/harmonic.cpp
@@ -30,9 +30,8 @@ IGL_INLINE bool igl::harmonic(
   const int k,
   Eigen::PlainObjectBase<DerivedW> & W)
 {
-  using namespace Eigen;
-  typedef typename DerivedV::Scalar Scalar;
-  SparseMatrix<Scalar> L,M;
+    typedef typename DerivedV::Scalar Scalar;
+  Eigen::SparseMatrix<Scalar> L,M;
   cotmatrix(V,F,L);
   if(k>1)
   {
@@ -53,9 +52,8 @@ IGL_INLINE bool igl::harmonic(
   const int k,
   Eigen::PlainObjectBase<DerivedW> & W)
 {
-  using namespace Eigen;
   typedef typename Derivedbc::Scalar Scalar;
-  SparseMatrix<Scalar> A;
+  Eigen::SparseMatrix<Scalar> A;
   adjacency_matrix(F,A);
   // sum each row
   Eigen::Matrix<Scalar,Eigen::Dynamic,1> Asum;
@@ -63,7 +61,7 @@ IGL_INLINE bool igl::harmonic(
   // Eigen 3.4 still struggles to do arithmetic with sparse and diagonal matrices
   Eigen::SparseMatrix<Scalar> L = A - Eigen::SparseMatrix<Scalar>(Asum.asDiagonal());
 
-  SparseMatrix<Scalar> M;
+  Eigen::SparseMatrix<Scalar> M;
   speye(L.rows(),M);
   return harmonic(L,M,b,bc,k,W);
 }

--- a/include/igl/hausdorff.cpp
+++ b/include/igl/hausdorff.cpp
@@ -21,14 +21,13 @@ IGL_INLINE void igl::hausdorff(
   const Eigen::MatrixBase<DerivedFB> & FB,
   Scalar & d)
 {
-  using namespace Eigen;
   assert(VA.cols() == 3 && "VA should contain 3d points");
   assert(FA.cols() == 3 && "FA should contain triangles");
   assert(VB.cols() == 3 && "VB should contain 3d points");
   assert(FB.cols() == 3 && "FB should contain triangles");
-  Matrix<typename DerivedVA::Scalar, Dynamic, 1> sqr_DBA, sqr_DAB;
-  Matrix<typename DerivedVA::Index,Dynamic,1> I;
-  Matrix<typename DerivedVA::Scalar,Dynamic,3> C;
+  Eigen::Matrix<typename DerivedVA::Scalar, Eigen::Dynamic, 1> sqr_DBA, sqr_DAB;
+  Eigen::Matrix<typename DerivedVA::Index ,Eigen::Dynamic,1> I;
+  Eigen::Matrix<typename DerivedVA::Scalar ,Eigen::Dynamic,3> C;
   point_mesh_squared_distance(VB,VA,FA,sqr_DBA,I,C);
   point_mesh_squared_distance(VA,VB,FB,sqr_DAB,I,C);
   const Scalar dba = sqr_DBA.maxCoeff();

--- a/include/igl/histc.cpp
+++ b/include/igl/histc.cpp
@@ -39,8 +39,7 @@ IGL_INLINE void igl::histc(
   Eigen::PlainObjectBase<DerivedB > & B)
 {
   const int m = X.size();
-  using namespace std;
-  assert( 
+  assert(
     (E.bottomRightCorner(E.size()-1,1) -
       E.topLeftCorner(E.size()-1,1)).maxCoeff() >= 0 && 
     "E should be monotonically increasing");

--- a/include/igl/in_element.cpp
+++ b/include/igl/in_element.cpp
@@ -21,7 +21,6 @@ IGL_INLINE void igl::in_element(
   const AABB<DerivedV,DIM> & aabb,
   Eigen::PlainObjectBase<DerivedI> & I)
 {
-  using namespace std;
   using namespace Eigen;
   const int Qr = Q.rows();
   I.setConstant(Qr,1,-1);
@@ -44,7 +43,6 @@ IGL_INLINE void igl::in_element(
   const AABB<DerivedV,DIM> & aabb,
   Eigen::SparseMatrix<Scalar> & I)
 {
-  using namespace std;
   using namespace Eigen;
   const int Qr = Q.rows();
   std::vector<Triplet<Scalar> > IJV;

--- a/include/igl/in_element.cpp
+++ b/include/igl/in_element.cpp
@@ -21,7 +21,6 @@ IGL_INLINE void igl::in_element(
   const AABB<DerivedV,DIM> & aabb,
   Eigen::PlainObjectBase<DerivedI> & I)
 {
-  using namespace Eigen;
   const int Qr = Q.rows();
   I.setConstant(Qr,1,-1);
   parallel_for(Qr,[&](const int e)
@@ -43,9 +42,8 @@ IGL_INLINE void igl::in_element(
   const AABB<DerivedV,DIM> & aabb,
   Eigen::SparseMatrix<Scalar> & I)
 {
-  using namespace Eigen;
   const int Qr = Q.rows();
-  std::vector<Triplet<Scalar> > IJV;
+  std::vector<Eigen::Triplet<Scalar> > IJV;
   IJV.reserve(Qr);
 // #pragma omp parallel for if (Qr>10000)
   for(int e = 0;e<Qr;e++)
@@ -55,7 +53,7 @@ IGL_INLINE void igl::in_element(
     for(const auto r : R)
     {
 // #pragma omp critical
-      IJV.push_back(Triplet<Scalar>(e,r,1));
+      IJV.push_back(Eigen::Triplet<Scalar>(e,r,1));
     }
   }
   I.resize(Qr,Ele.rows());

--- a/include/igl/is_boundary_edge.cpp
+++ b/include/igl/is_boundary_edge.cpp
@@ -19,7 +19,6 @@ void igl::is_boundary_edge(
   Eigen::PlainObjectBase<DerivedB> & B)
 {
   using namespace Eigen;
-  using namespace std;
   // Should be triangles
   assert(F.cols() == 3);
   // Should be edges
@@ -85,7 +84,6 @@ void igl::is_boundary_edge(
     (DerivedEMAP::RowsAtCompileTime == 1 || DerivedEMAP::ColsAtCompileTime == 1),
     "B and EMAP need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
   using namespace Eigen;
-  using namespace std;
   // Should be triangles
   assert(F.cols() == 3);
   // number of faces

--- a/include/igl/is_boundary_edge.cpp
+++ b/include/igl/is_boundary_edge.cpp
@@ -18,7 +18,6 @@ void igl::is_boundary_edge(
   const Eigen::MatrixBase<DerivedF> & F,
   Eigen::PlainObjectBase<DerivedB> & B)
 {
-  using namespace Eigen;
   // Should be triangles
   assert(F.cols() == 3);
   // Should be edges
@@ -26,7 +25,7 @@ void igl::is_boundary_edge(
   // number of faces
   const int m = F.rows();
   // Collect all directed edges after E
-  MatrixXi EallE(E.rows()+3*m,2);
+  Eigen::MatrixXi EallE(E.rows()+3*m,2);
   EallE.block(0,0,E.rows(),E.cols()) = E;
   for(int e = 0;e<3;e++)
   {
@@ -40,20 +39,20 @@ void igl::is_boundary_edge(
     }
   }
   // sort directed edges into undirected edges
-  MatrixXi sorted_EallE;
+  Eigen::MatrixXi sorted_EallE;
   {
-    MatrixXi _;
+    Eigen::MatrixXi _;
     sort(EallE,2,true,sorted_EallE,_);
   }
   // Determine unique undirected edges E and map to directed edges EMAP
-  MatrixXi uE;
-  VectorXi EMAP;
+  Eigen::MatrixXi uE;
+  Eigen::VectorXi EMAP;
   {
-    VectorXi _;
+    Eigen::VectorXi _;
     unique_rows(sorted_EallE,uE,_,EMAP);
   }
   // Counts of occurrences
-  VectorXi N = VectorXi::Zero(uE.rows());
+  Eigen::VectorXi N = Eigen::VectorXi::Zero(uE.rows());
   for(int e = 0;e<EMAP.rows();e++)
   {
     N(EMAP(e))++;
@@ -83,13 +82,12 @@ void igl::is_boundary_edge(
     (DerivedB::RowsAtCompileTime == 1 || DerivedB::ColsAtCompileTime == 1) &&
     (DerivedEMAP::RowsAtCompileTime == 1 || DerivedEMAP::ColsAtCompileTime == 1),
     "B and EMAP need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
-  using namespace Eigen;
   // Should be triangles
   assert(F.cols() == 3);
   // number of faces
   const int m = F.rows();
   // Collect all directed edges after E
-  MatrixXi allE(3*m,2);
+  Eigen::MatrixXi allE(3*m,2);
   for(int e = 0;e<3;e++)
   {
     for(int f = 0;f<m;f++)
@@ -102,7 +100,7 @@ void igl::is_boundary_edge(
     }
   }
   // sort directed edges into undirected edges
-  MatrixXi sorted_allE;
+  Eigen::MatrixXi sorted_allE;
   {
     Eigen::MatrixXi _;
     sort(allE,2,true,sorted_allE,_);
@@ -113,7 +111,7 @@ void igl::is_boundary_edge(
     unique_rows(sorted_allE,E,_,EMAP);
   }
   // Counts of occurrences
-  VectorXi N = VectorXi::Zero(E.rows());
+  Eigen::VectorXi N = Eigen::VectorXi::Zero(E.rows());
   for(int e = 0;e<EMAP.rows();e++)
   {
     N(EMAP(e))++;

--- a/include/igl/is_edge_manifold.cpp
+++ b/include/igl/is_edge_manifold.cpp
@@ -57,8 +57,7 @@ IGL_INLINE bool igl::is_edge_manifold(
   Eigen::PlainObjectBase<DerivedEMAP>& EMAP,
   Eigen::PlainObjectBase<DerivedBE>& BE)
 {
-  using namespace Eigen;
-  typedef Matrix<typename DerivedF::Scalar,Dynamic,2> MatrixXF2;
+  typedef Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,2> MatrixXF2;
   MatrixXF2 allE;
   unique_edge_map(F,allE,E,EMAP);
   return is_edge_manifold(F,E.rows(),EMAP,BF,BE);

--- a/include/igl/is_symmetric.cpp
+++ b/include/igl/is_symmetric.cpp
@@ -48,7 +48,6 @@ IGL_INLINE bool igl::is_symmetric(
   const epsilonT epsilon)
 {
   using namespace Eigen;
-  using namespace std;
   if(A.rows() != A.cols())
   {
     return false;

--- a/include/igl/is_symmetric.cpp
+++ b/include/igl/is_symmetric.cpp
@@ -47,7 +47,6 @@ IGL_INLINE bool igl::is_symmetric(
   const Eigen::SparseMatrix<AType>& A, 
   const epsilonT epsilon)
 {
-  using namespace Eigen;
   if(A.rows() != A.cols())
   {
     return false;
@@ -58,10 +57,10 @@ IGL_INLINE bool igl::is_symmetric(
     return true;
   }
   assert(A.size() != 0);
-  SparseMatrix<AType> AT = A.transpose();
-  SparseMatrix<AType> AmAT = A-AT;
-  VectorXi AmATI,AmATJ;
-  Matrix<AType,Dynamic,1> AmATV;
+  Eigen::SparseMatrix<AType> AT = A.transpose();
+  Eigen::SparseMatrix<AType> AmAT = A-AT;
+  Eigen::VectorXi AmATI,AmATJ;
+  Eigen::Matrix<AType ,Eigen::Dynamic,1> AmATV;
   find(AmAT,AmATI,AmATJ,AmATV);
   if(AmATI.size() == 0)
   {

--- a/include/igl/is_vertex_manifold.cpp
+++ b/include/igl/is_vertex_manifold.cpp
@@ -20,7 +20,6 @@ IGL_INLINE bool igl::is_vertex_manifold(
   const Eigen::MatrixBase<DerivedF>& F,
   Eigen::PlainObjectBase<DerivedB>& B)
 {
-  using namespace Eigen;
   assert(F.cols() == 3 && "F must contain triangles");
   typedef typename DerivedF::Scalar Index;
   typedef typename DerivedF::Index FIndex;

--- a/include/igl/is_vertex_manifold.cpp
+++ b/include/igl/is_vertex_manifold.cpp
@@ -20,24 +20,23 @@ IGL_INLINE bool igl::is_vertex_manifold(
   const Eigen::MatrixBase<DerivedF>& F,
   Eigen::PlainObjectBase<DerivedB>& B)
 {
-  using namespace std;
   using namespace Eigen;
   assert(F.cols() == 3 && "F must contain triangles");
   typedef typename DerivedF::Scalar Index;
   typedef typename DerivedF::Index FIndex;
   const Index n = F.maxCoeff()+1;
-  vector<vector<vector<FIndex > > > TT;
-  vector<vector<vector<FIndex > > > TTi;
+  std::vector<std::vector<std::vector<FIndex > > > TT;
+  std::vector<std::vector<std::vector<FIndex > > > TTi;
   triangle_triangle_adjacency(F,TT,TTi);
 
-  vector<vector<FIndex > > V2F,_1;
+  std::vector<std::vector<FIndex > > V2F,_1;
   vertex_triangle_adjacency(n,F,V2F,_1);
 
   const auto & check_vertex = [&](const Index v)->bool
   {
-    vector<FIndex> uV2Fv;
+    std::vector<FIndex> uV2Fv;
     {
-      vector<size_t> _1,_2;
+      std::vector<size_t> _1,_2;
       unique(V2F[v],uV2Fv,_1,_2);
     }
     const FIndex one_ring_size = uV2Fv.size();
@@ -46,9 +45,9 @@ IGL_INLINE bool igl::is_vertex_manifold(
       return false;
     }
     const FIndex g = uV2Fv[0];
-    queue<Index> Q;
+    std::queue<Index> Q;
     Q.push(g);
-    map<FIndex,bool> seen;
+    std::map<FIndex,bool> seen;
     while(!Q.empty())
     {
       const FIndex f = Q.front();

--- a/include/igl/ismember.cpp
+++ b/include/igl/ismember.cpp
@@ -25,7 +25,6 @@ IGL_INLINE void igl::ismember(
   Eigen::PlainObjectBase<DerivedIA> & IA,
   Eigen::PlainObjectBase<DerivedLOCB> & LOCB)
 {
-  using namespace Eigen;
   IA.resizeLike(A);
   IA.setConstant(false);
   LOCB.resizeLike(A);
@@ -41,19 +40,19 @@ IGL_INLINE void igl::ismember(
   }
 
   // Get rid of any duplicates
-  typedef Matrix<typename DerivedA::Scalar,Dynamic,1> VectorA;
-  typedef Matrix<typename DerivedB::Scalar,Dynamic,1> VectorB;
+  typedef Eigen::Matrix<typename DerivedA::Scalar ,Eigen::Dynamic,1> VectorA;
+  typedef Eigen::Matrix<typename DerivedB::Scalar ,Eigen::Dynamic,1> VectorB;
   const VectorA vA(Eigen::Map<const VectorA>(DerivedA(A).data(), A.cols()*A.rows(),1));
   const VectorB vB(Eigen::Map<const VectorB>(DerivedB(B).data(), B.cols()*B.rows(),1));
   VectorA uA;
   VectorB uB;
-  Eigen::Matrix<typename DerivedA::Index,Dynamic,1> uIA,uIuA,uIB,uIuB;
+  Eigen::Matrix<typename DerivedA::Index ,Eigen::Dynamic,1> uIA,uIuA,uIB,uIuB;
   unique(vA,uA,uIA,uIuA);
   unique(vB,uB,uIB,uIuB);
   // Sort both
   VectorA sA;
   VectorB sB;
-  Eigen::Matrix<typename DerivedA::Index,Dynamic,1> sIA,sIB;
+  Eigen::Matrix<typename DerivedA::Index ,Eigen::Dynamic,1> sIA,sIB;
   sort(uA,1,true,sA,sIA);
   sort(uB,1,true,sB,sIB);
 
@@ -81,9 +80,9 @@ IGL_INLINE void igl::ismember(
     }
   }
 
-  Map< Matrix<typename DerivedIA::Scalar,Dynamic,1> > 
+  Eigen::Map< Eigen::Matrix<typename DerivedIA::Scalar ,Eigen::Dynamic,1> >
     vIA(IA.data(),IA.cols()*IA.rows(),1);
-  Map< Matrix<typename DerivedLOCB::Scalar,Dynamic,1> > 
+  Eigen::Map< Eigen::Matrix<typename DerivedLOCB::Scalar ,Eigen::Dynamic,1> >
     vLOCB(LOCB.data(),LOCB.cols()*LOCB.rows(),1);
   for(int a = 0;a<A.size();a++)
   {

--- a/include/igl/ismember.cpp
+++ b/include/igl/ismember.cpp
@@ -26,7 +26,6 @@ IGL_INLINE void igl::ismember(
   Eigen::PlainObjectBase<DerivedLOCB> & LOCB)
 {
   using namespace Eigen;
-  using namespace std;
   IA.resizeLike(A);
   IA.setConstant(false);
   LOCB.resizeLike(A);

--- a/include/igl/ismember_rows.cpp
+++ b/include/igl/ismember_rows.cpp
@@ -22,7 +22,6 @@ IGL_INLINE void igl::ismember_rows(
   Eigen::PlainObjectBase<DerivedIA> & IA,
   Eigen::PlainObjectBase<DerivedLOCB> & LOCB)
 {
-  using namespace Eigen;
   assert(A.cols() == B.cols() && "number of columns must match");
   IA.resize(A.rows(),1);
   IA.setConstant(false);
@@ -49,13 +48,13 @@ IGL_INLINE void igl::ismember_rows(
   // etc. we should assume the inputs don't exceed 2147483647, which is
   // reasonable.
   typedef int Index;
-  Eigen::Matrix<Index,Dynamic,1> uIA,uIuA,uIB,uIuB;
+  Eigen::Matrix<Index ,Eigen::Dynamic,1> uIA,uIuA,uIB,uIuB;
   unique_rows(A,uA,uIA,uIuA);
   unique_rows(B,uB,uIB,uIuB);
   // Sort both
   MatrixA sA;
   MatrixB sB;
-  Eigen::Matrix<Index,Dynamic,1> sIA,sIB;
+  Eigen::Matrix<Index ,Eigen::Dynamic,1> sIA,sIB;
   sortrows(uA,true,sA,sIA);
   sortrows(uB,true,sB,sIB);
 

--- a/include/igl/ismember_rows.cpp
+++ b/include/igl/ismember_rows.cpp
@@ -23,7 +23,6 @@ IGL_INLINE void igl::ismember_rows(
   Eigen::PlainObjectBase<DerivedLOCB> & LOCB)
 {
   using namespace Eigen;
-  using namespace std;
   assert(A.cols() == B.cols() && "number of columns must match");
   IA.resize(A.rows(),1);
   IA.setConstant(false);

--- a/include/igl/launch_medit.cpp
+++ b/include/igl/launch_medit.cpp
@@ -23,9 +23,8 @@ IGL_INLINE int igl::launch_medit(
   const Eigen::MatrixBase<DerivedF> & F,
   const bool wait)
 {
-  using namespace std;
   // Build medit command, end with & so command returns without waiting
-  stringstream command; 
+  std::stringstream command;
   command<<MEDIT_PATH<<" "<<TEMP_MESH_FILE<<" "<<TEMP_MEDIT_FILE;
   if(!wait)
   {
@@ -37,7 +36,7 @@ IGL_INLINE int igl::launch_medit(
     return -1;
   }
   // Write default medit options
-  const string default_medit_file_contents = 
+  const std::string default_medit_file_contents =
     "BackgroundColor 1 1 1\n"
     "LineColor 0 0 0\n"
     "WindowSize 1024 800\n"
@@ -45,7 +44,7 @@ IGL_INLINE int igl::launch_medit(
   FILE * fp = fopen(TEMP_MEDIT_FILE,"w");
   if(fp == NULL)
   {
-    cerr<<"^"<<__FUNCTION__<<": Could not write to "<<TEMP_MEDIT_FILE<<endl;
+    std::cerr<<"^"<<__FUNCTION__<<": Could not write to "<<TEMP_MEDIT_FILE<<std::endl;
     return -1;
   }
   fprintf(fp,"%s",default_medit_file_contents.c_str());
@@ -57,7 +56,7 @@ IGL_INLINE int igl::launch_medit(
   }catch(int e)
   {
     (void)e;
-    cerr<<"^"<<__FUNCTION__<<": Calling to medit crashed..."<<endl;
+    std::cerr<<"^"<<__FUNCTION__<<": Calling to medit crashed..."<<std::endl;
     return -1;
   }
   // Could clean up and delete these files but not really worth it

--- a/include/igl/launch_medit.h
+++ b/include/igl/launch_medit.h
@@ -16,9 +16,9 @@ namespace igl
   /// Writes the tetmesh in (V,T,F) to a temporary file, opens it with medit
   /// (forking with a system call) and returns
   ///
-  /// @tparam DerivedV  real-value: i.e. from MatrixXd
-  /// @tparam DerivedT  integer-value: i.e. from MatrixXi
-  /// @tparam DerivedF  integer-value: i.e. from MatrixXi
+  /// @tparam DerivedV  real-value: i.e. from Eigen::MatrixXd
+  /// @tparam DerivedT  integer-value: i.e. from Eigen::MatrixXi
+  /// @tparam DerivedF  integer-value: i.e. from Eigen::MatrixXi
   /// @param[in] V  double matrix of vertex positions  #V by 3
   /// @param[in] T  #T list of tet indices into vertex positions
   /// @param[in] F  #F list of face indices into vertex positions

--- a/include/igl/lbs_matrix.cpp
+++ b/include/igl/lbs_matrix.cpp
@@ -12,7 +12,6 @@ IGL_INLINE void igl::lbs_matrix(
   const Eigen::MatrixXd & W,
   Eigen::MatrixXd & M)
 {
-  using namespace Eigen;
   // Number of dimensions
   const int dim = V.cols();
   // Number of model points
@@ -26,7 +25,7 @@ IGL_INLINE void igl::lbs_matrix(
   M.resize(n,(dim+1)*m);
   for(int j = 0;j<m;j++)
   {
-    VectorXd Wj = W.block(0,j,V.rows(),1);
+    Eigen::VectorXd Wj = W.block(0,j,V.rows(),1);
     for(int i = 0;i<(dim+1);i++)
     {
       if(i<dim)
@@ -177,8 +176,7 @@ IGL_INLINE void igl::lbs_matrix_column(
   Eigen::MatrixXd & M)
 {
   // Cheapskate wrapper
-  using namespace Eigen;
-  SparseMatrix<double> sM;
+  Eigen::SparseMatrix<double> sM;
   lbs_matrix_column(V,W,WI,sM);
-  M = MatrixXd(sM);
+  M = Eigen::MatrixXd(sM);
 }

--- a/include/igl/limit_faces.cpp
+++ b/include/igl/limit_faces.cpp
@@ -17,7 +17,6 @@ IGL_INLINE void igl::limit_faces(
   const bool exclusive,
   MatF & LF)
 {
-  using namespace Eigen;
   std::vector<bool> in(F.rows(),false);
   int num_in = 0;
   // loop over faces

--- a/include/igl/limit_faces.cpp
+++ b/include/igl/limit_faces.cpp
@@ -17,9 +17,8 @@ IGL_INLINE void igl::limit_faces(
   const bool exclusive,
   MatF & LF)
 {
-  using namespace std;
   using namespace Eigen;
-  vector<bool> in(F.rows(),false);
+  std::vector<bool> in(F.rows(),false);
   int num_in = 0;
   // loop over faces
   for(int i = 0;i<F.rows();i++)

--- a/include/igl/limit_faces.h
+++ b/include/igl/limit_faces.h
@@ -13,8 +13,8 @@ namespace igl
   /// Limit given faces F to those which contain (only) indices found
   /// in L.
   ///
-  /// @tparam MatF matrix type of faces, matrixXi
-  /// @tparam VecL  matrix type of vertex indices, VectorXi
+  /// @tparam MatF matrix type of faces, Eigen::MatrixXi
+  /// @tparam VecL  matrix type of vertex indices, Eigen::VectorXi
   /// @param[in] F  #F by 3 list of face indices
   /// @param[in] L  #L by 1 list of allowed indices
   /// @param[in] exclusive  flag specifying whether a face is included only if all its

--- a/include/igl/line_segment_in_rectangle.cpp
+++ b/include/igl/line_segment_in_rectangle.cpp
@@ -13,7 +13,6 @@ IGL_INLINE bool igl::line_segment_in_rectangle(
   const Eigen::Vector2d & A,
   const Eigen::Vector2d & B)
 {
-  using namespace Eigen;
   // http://stackoverflow.com/a/100165/148668
   const auto SegmentIntersectRectangle = [](double a_rectangleMinX,
                                  double a_rectangleMinY,

--- a/include/igl/line_segment_in_rectangle.cpp
+++ b/include/igl/line_segment_in_rectangle.cpp
@@ -13,7 +13,6 @@ IGL_INLINE bool igl::line_segment_in_rectangle(
   const Eigen::Vector2d & A,
   const Eigen::Vector2d & B)
 {
-  using namespace std;
   using namespace Eigen;
   // http://stackoverflow.com/a/100165/148668
   const auto SegmentIntersectRectangle = [](double a_rectangleMinX,

--- a/include/igl/linprog.cpp
+++ b/include/igl/linprog.cpp
@@ -21,7 +21,6 @@ IGL_INLINE bool igl::linprog(
   // This is a very literal translation of
   // http://www.mathworks.com/matlabcentral/fileexchange/2166-introduction-to-linear-algebra/content/strang/linprog.m
   using namespace Eigen;
-  using namespace std;
   bool success = true;
   // number of constraints
   const int m = _A.rows();
@@ -253,7 +252,6 @@ IGL_INLINE bool igl::linprog(
   Eigen::VectorXd & x)
 {
   using namespace Eigen;
-  using namespace std;
   const int m = A.rows();
   const int n = A.cols();
   const int p = B.rows();

--- a/include/igl/linprog.cpp
+++ b/include/igl/linprog.cpp
@@ -20,7 +20,6 @@ IGL_INLINE bool igl::linprog(
 {
   // This is a very literal translation of
   // http://www.mathworks.com/matlabcentral/fileexchange/2166-introduction-to-linear-algebra/content/strang/linprog.m
-  using namespace Eigen;
   bool success = true;
   // number of constraints
   const int m = _A.rows();
@@ -43,29 +42,29 @@ IGL_INLINE bool igl::linprog(
     return Bsign;
   };
   // initial (inverse) basis matrix
-  VectorXd Dv = sign(sign(b).array()+0.5);
+  Eigen::VectorXd Dv = sign(sign(b).array()+0.5);
   Dv.head(k).setConstant(1.);
-  MatrixXd D = Dv.asDiagonal();
+  Eigen::MatrixXd D = Dv.asDiagonal();
   // Incorporate slack variables
-  MatrixXd A(_A.rows(),_A.cols()+D.cols());
+  Eigen::MatrixXd A(_A.rows(),_A.cols()+D.cols());
   A<<_A,D;
   // Initial basis
-  VectorXi B = igl::colon<int>(n,n+m-1);
+  Eigen::VectorXi B = igl::colon<int>(n,n+m-1);
   // non-basis, may turn out that vector<> would be better here
-  VectorXi N = igl::colon<int>(0,n-1);
+  Eigen::VectorXi N = igl::colon<int>(0,n-1);
   int j;
   double bmin = b.minCoeff(&j);
   int phase;
-  VectorXd xb;
-  VectorXd s;
-  VectorXi J;
+  Eigen::VectorXd xb;
+  Eigen::VectorXd s;
+  Eigen::VectorXi J;
   if(k>0 && bmin<0)
   {
     phase = 1;
-    xb = VectorXd::Ones(m);
+    xb = Eigen::VectorXd::Ones(m);
     // super cost
     s.resize(n+m+1);
-    s<<VectorXd::Zero(n+k),VectorXd::Ones(m-k+1);
+    s<<Eigen::VectorXd::Zero(n+k),Eigen::VectorXd::Ones(m-k+1);
     N.resize(n+1);
     N<<igl::colon<int>(0,n-1),B(j);
     J.resize(B.size()-1);
@@ -76,10 +75,10 @@ IGL_INLINE bool igl::linprog(
     J.head(j) = B.head(j);
     J.tail(B.size()-j-1) = B.tail(B.size()-j-1);
     B(j) = n+m;
-    MatrixXd AJ = A(igl::placeholders::all,J);
-    const VectorXd a = b - AJ.rowwise().sum();
+    Eigen::MatrixXd AJ = A(igl::placeholders::all,J);
+    const Eigen::VectorXd a = b - AJ.rowwise().sum();
     {
-      MatrixXd old_A = A;
+      Eigen::MatrixXd old_A = A;
       A.resize(A.rows(),A.cols()+a.cols());
       A<<old_A,a;
     }
@@ -91,21 +90,21 @@ IGL_INLINE bool igl::linprog(
     xb = b;
     s.resize(c.size()+m);
     // cost function
-    s<<c,VectorXd::Zero(m);
+    s<<c,Eigen::VectorXd::Zero(m);
   }else //k = 0 or bmin >=0
   {
     phase = 1;
     xb = b.array().abs();
     s.resize(n+m);
     // super cost
-    s<<VectorXd::Zero(n+k),VectorXd::Ones(m-k);
+    s<<Eigen::VectorXd::Zero(n+k),Eigen::VectorXd::Ones(m-k);
   }
   while(phase<3)
   {
     double df = -1;
     int t = std::numeric_limits<int>::max();
     // Lagrange mutipliers fro Ax=b
-    VectorXd yb = D.transpose() * s(B);
+    Eigen::VectorXd yb = D.transpose() * s(B);
     while(true)
     {
       if(MAXIT>0 && it>=MAXIT)
@@ -122,9 +121,9 @@ IGL_INLINE bool igl::linprog(
         break;
       }
       // reduced costs
-      VectorXd sN = s(N);
-      MatrixXd AN = A(igl::placeholders::all,N);
-      VectorXd r = sN - AN.transpose() * yb;
+      Eigen::VectorXd sN = s(N);
+      Eigen::MatrixXd AN = A(igl::placeholders::all,N);
+      Eigen::VectorXd r = sN - AN.transpose() * yb;
       int q;
       // determine new basic variable
       double rmin = r.minCoeff(&q);
@@ -151,8 +150,8 @@ IGL_INLINE bool igl::linprog(
         // could produce a vector for multiple matches
         (N.array()==Nq).cast<int>().maxCoeff(&q);
       }
-      VectorXd d = D*A.col(N(q));
-      VectorXi I;
+      Eigen::VectorXd d = D*A.col(N(q));
+      Eigen::VectorXi I;
       igl::find((d.array()>tol).eval(),I);
       if(I.size() == 0)
       {
@@ -164,7 +163,7 @@ IGL_INLINE bool igl::linprog(
         success = false;
         break;
       }
-      VectorXd xbd = xb(I).array()/d(I).array();
+      Eigen::VectorXd xbd = xb(I).array()/d(I).array();
       // new use of r
       int p;
       {
@@ -188,7 +187,7 @@ IGL_INLINE bool igl::linprog(
         df = r*rmin;
       }
       // row vector
-      RowVectorXd v = D.row(p)/d(p);
+      Eigen::RowVectorXd v = D.row(p)/d(p);
       yb += v.transpose() * (s(N(q)) - d.transpose()*s(B));
       d(p)-=1;
       // update inverse basis matrix
@@ -198,7 +197,7 @@ IGL_INLINE bool igl::linprog(
       if(t>(n+k-1))
       {
         // remove qth entry from N
-        VectorXi old_N = N;
+        Eigen::VectorXi old_N = N;
         N.resize(N.size()-1);
         N.head(q) = old_N.head(q);
         N.head(q) = old_N.head(q);
@@ -211,12 +210,12 @@ IGL_INLINE bool igl::linprog(
     // iterative refinement
     xb = (xb+D*(b-A(igl::placeholders::all,B)*xb)).eval();
     // must be due to rounding
-    VectorXi I;
+    Eigen::VectorXi I;
     igl::find((xb.array()<0).eval(),I);
     if(I.size()>0)
     {
       // so correct
-      xb(I) = VectorXd::Zero(I.size(),1);
+      xb(I) = Eigen::VectorXd::Zero(I.size(),1);
     }
     // B, xb,n,m,res=A(:,B)*xb-b
     if(phase == 2 || it<0)
@@ -251,14 +250,13 @@ IGL_INLINE bool igl::linprog(
   const Eigen::VectorXd & c,
   Eigen::VectorXd & x)
 {
-  using namespace Eigen;
   const int m = A.rows();
   const int n = A.cols();
   const int p = B.rows();
-  MatrixXd Im = MatrixXd::Identity(m,m);
-  MatrixXd AS(m,n+m);
+  Eigen::MatrixXd Im = Eigen::MatrixXd::Identity(m,m);
+  Eigen::MatrixXd AS(m,n+m);
   AS<<A,Im;
-  MatrixXd bS = b.array().abs();
+  Eigen::MatrixXd bS = b.array().abs();
   for(int i = 0;i<m;i++)
   {
     const auto & sign = [](double x)->double
@@ -267,32 +265,32 @@ IGL_INLINE bool igl::linprog(
     };
     AS.row(i) *= sign(b(i));
   }
-  MatrixXd In = MatrixXd::Identity(n,n);
-  MatrixXd P(n+m,2*n+m);
-  P<<              In, -In, MatrixXd::Zero(n,m),
-     MatrixXd::Zero(m,2*n), Im;
-  MatrixXd ASP = AS*P;
-  MatrixXd BSP(0,2*n+m);
+  Eigen::MatrixXd In = Eigen::MatrixXd::Identity(n,n);
+  Eigen::MatrixXd P(n+m,2*n+m);
+  P<<              In, -In, Eigen::MatrixXd::Zero(n,m),
+     Eigen::MatrixXd::Zero(m,2*n), Im;
+  Eigen::MatrixXd ASP = AS*P;
+  Eigen::MatrixXd BSP(0,2*n+m);
   if(p>0)
   {
     // B ∈ ℝ^(p × n)
-    MatrixXd BS(p,n+m);
-    BS<<B,MatrixXd::Zero(p,m);
+    Eigen::MatrixXd BS(p,n+m);
+    BS<<B,Eigen::MatrixXd::Zero(p,m);
     // BS ∈ ℝ^(p × n+m)
     BSP = BS*P;
     // BSP ∈ ℝ^(p × 2n+m)
   }
 
-  VectorXd fSP = VectorXd::Ones(2*n+m);
+  Eigen::VectorXd fSP = Eigen::VectorXd::Ones(2*n+m);
   fSP.head(2*n) = P.block(0,0,n,2*n).transpose()*f;
-  const VectorXd & cc = fSP;
+  const Eigen::VectorXd & cc = fSP;
 
-  MatrixXd AA(m+p,2*n+m);
+  Eigen::MatrixXd AA(m+p,2*n+m);
   AA<<ASP,BSP;
-  VectorXd bb(m+p);
+  Eigen::VectorXd bb(m+p);
   bb<<bS,c;
 
-  VectorXd xxs;
+  Eigen::VectorXd xxs;
   // min   ccᵀxxs
   // s.t.  AA xxs ≤ bb
   //          xxs ≥ 0

--- a/include/igl/local_basis.cpp
+++ b/include/igl/local_basis.cpp
@@ -29,7 +29,6 @@ IGL_INLINE void igl::local_basis(
   Eigen::PlainObjectBase<DerivedB3>& B3)
 {
   using namespace Eigen;
-  using namespace std;
   assert(V.cols() == 3);
   B1.resize(F.rows(),3);
   B2.resize(F.rows(),3);

--- a/include/igl/local_basis.cpp
+++ b/include/igl/local_basis.cpp
@@ -28,7 +28,6 @@ IGL_INLINE void igl::local_basis(
   Eigen::PlainObjectBase<DerivedB2>& B2,
   Eigen::PlainObjectBase<DerivedB3>& B3)
 {
-  using namespace Eigen;
   assert(V.cols() == 3);
   B1.resize(F.rows(),3);
   B2.resize(F.rows(),3);

--- a/include/igl/local_basis.h
+++ b/include/igl/local_basis.h
@@ -17,8 +17,8 @@ namespace igl
 {
   /// Compute a local orthogonal reference system for each triangle in the given mesh
   ///
-  /// @tparam DerivedV derived from vertex positions matrix type: i.e. MatrixXd
-  /// @tparam DerivedF derived from face indices matrix type: i.e. MatrixXi
+  /// @tparam DerivedV derived from vertex positions matrix type: i.e. Eigen::MatrixXd
+  /// @tparam DerivedF derived from face indices matrix type: i.e. Eigen::MatrixXi
   /// @param[in] V  eigen matrix #V by 3
   /// @param[in] F  #F by 3 list of mesh faces (must be triangles)
   /// @param[out] B1 eigen matrix #F by 3, each vector is tangent to the triangle

--- a/include/igl/lscm.cpp
+++ b/include/igl/lscm.cpp
@@ -29,7 +29,6 @@ IGL_INLINE bool igl::lscm(
   Eigen::PlainObjectBase<DerivedV_uv> & V_uv,
   Eigen::SparseMatrix<QScalar> & Q)
 {
-  using namespace Eigen;
   igl::lscm_hessian(V,F,Q);
 
   Eigen::Matrix<typename Derivedb::Scalar,Eigen::Dynamic,1> b_flat(b.size()*bc.cols(),1);
@@ -40,15 +39,15 @@ IGL_INLINE bool igl::lscm(
     bc_flat.block(c*bc.rows(),0,bc.rows(),1) = bc.col(c);
   }
 
-  const VectorXd B_flat = VectorXd::Zero(V.rows()*2);
+  const Eigen::VectorXd B_flat = Eigen::VectorXd::Zero(V.rows()*2);
   igl::min_quad_with_fixed_data<QScalar> data;
-  if(!igl::min_quad_with_fixed_precompute(Q,b_flat,SparseMatrix<QScalar>(),true,data))
+  if(!igl::min_quad_with_fixed_precompute(Q,b_flat,Eigen::SparseMatrix<QScalar>(),true,data))
   {
     return false;
   }
 
-  MatrixXd W_flat;
-  if(!min_quad_with_fixed_solve(data,B_flat,bc_flat,VectorXd(),W_flat))
+  Eigen::MatrixXd W_flat;
+  if(!min_quad_with_fixed_solve(data,B_flat,bc_flat,Eigen::VectorXd(),W_flat))
   {
     return false;
   }

--- a/include/igl/lscm.cpp
+++ b/include/igl/lscm.cpp
@@ -30,7 +30,6 @@ IGL_INLINE bool igl::lscm(
   Eigen::SparseMatrix<QScalar> & Q)
 {
   using namespace Eigen;
-  using namespace std;
   igl::lscm_hessian(V,F,Q);
 
   Eigen::Matrix<typename Derivedb::Scalar,Eigen::Dynamic,1> b_flat(b.size()*bc.cols(),1);

--- a/include/igl/marching_tets.cpp
+++ b/include/igl/marching_tets.cpp
@@ -34,13 +34,12 @@ void igl::marching_tets(
     Eigen::PlainObjectBase<DerivedJ>& J,
     Eigen::SparseMatrix<BCType>& BC)
 {
-  using namespace std;
 
   // We're hashing edges to deduplicate using 64 bit ints. The upper and lower
   // 32 bits of a key are the indices of vertices in the mesh. The implication is
   // that you can only have 2^32 vertices which I have deemed sufficient for
   // anything reasonable.
-  const auto make_edge_key = [](const pair<int32_t, int32_t>& p) -> std::int64_t
+  const auto make_edge_key = [](const std::pair<int32_t, int32_t>& p) -> std::int64_t
   {
     std::int64_t ret = 0;
     ret |= p.first;
@@ -79,11 +78,11 @@ void igl::marching_tets(
   };
 
   // Store the faces and the tet they are in
-  vector<pair<Eigen::RowVector3i, int>> faces;
+  std::vector<std::pair<Eigen::RowVector3i, int>> faces;
 
   // Store the edges in the tet mesh which we add vertices on
   // so we can deduplicate
-  vector<pair<int, int>> edge_table;
+  std::vector<std::pair<int, int>> edge_table;
 
 
   assert(TT.cols() == 4 && TT.rows() >= 1);
@@ -110,7 +109,7 @@ void igl::marching_tets(
       const int tv1_idx = TT(i, mt_edge_lookup[mt_cell_lookup[key][e]][0]);
       const int tv2_idx = TT(i, mt_edge_lookup[mt_cell_lookup[key][e]][1]);
       const int vertex_id = edge_table.size();
-      edge_table.push_back(make_pair(std::min(tv1_idx, tv2_idx), std::max(tv1_idx, tv2_idx)));
+      edge_table.push_back(std::make_pair(std::min(tv1_idx, tv2_idx), std::max(tv1_idx, tv2_idx)));
       v_ids[e] = vertex_id;
     }
 
@@ -122,13 +121,13 @@ void igl::marching_tets(
       {
         const Eigen::RowVector3i f1(v_ids[0], v_ids[1], v_ids[3]);
         const Eigen::RowVector3i f2(v_ids[1], v_ids[2], v_ids[3]);
-        faces.push_back(make_pair(f1, i));
-        faces.push_back(make_pair(f2, i));
+        faces.push_back(std::make_pair(f1, i));
+        faces.push_back(std::make_pair(f2, i));
       }
       else
       {
         const Eigen::RowVector3i f(v_ids[0], v_ids[1], v_ids[2]);
-        faces.push_back(make_pair(f, i));
+        faces.push_back(std::make_pair(f, i));
       }
 
     }
@@ -140,11 +139,11 @@ void igl::marching_tets(
   J.resize(faces.size());
 
   // Sparse matrix triplets for BC
-  vector<Eigen::Triplet<BCType>> bc_triplets;
+  std::vector<Eigen::Triplet<BCType>> bc_triplets;
   bc_triplets.reserve(edge_table.size());
 
   // Deduplicate vertices
-  unordered_map<std::int64_t, int> emap;
+  std::unordered_map<std::int64_t, int> emap;
   emap.max_load_factor(0.5);
   emap.reserve(edge_table.size());
 
@@ -157,7 +156,7 @@ void igl::marching_tets(
     for (int v = 0; v < 3; v++)
     {
       const int vi = faces[f].first[v];
-      const pair<int32_t, int32_t> edge = edge_table[vi];
+      const std::pair<int32_t, int32_t> edge = edge_table[vi];
       const std::int64_t key = make_edge_key(edge);
       auto it = emap.find(key);
       if (it == emap.end()) // New unique vertex, insert it

--- a/include/igl/massmatrix.cpp
+++ b/include/igl/massmatrix.cpp
@@ -57,12 +57,12 @@ namespace igl
       using Eigen::Dynamic;
       MassMatrixType eff_type = 
         type == MASSMATRIX_TYPE_DEFAULT? MASSMATRIX_TYPE_BARYCENTRIC: type;
-      Eigen::Matrix<Scalar, Dynamic, 1> vol;
+      Eigen::Matrix<Scalar, Eigen::Dynamic, 1> vol;
       volume(V, F, vol);
       vol = vol.array().abs();
-      Matrix<typename DerivedF::Scalar,Dynamic,1> MI;
-      Matrix<typename DerivedF::Scalar,Dynamic,1> MJ;
-      Matrix<Scalar,Dynamic,1> MV;
+      Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,1> MI;
+      Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,1> MJ;
+      Eigen::Matrix<Scalar ,Eigen::Dynamic,1> MV;
   
       switch (eff_type)
       {

--- a/include/igl/massmatrix.h
+++ b/include/igl/massmatrix.h
@@ -34,9 +34,9 @@ namespace igl
   /// Constructs the mass (area) matrix for a given mesh (V,F).
   ///
   /// @tparam DerivedV  derived type of eigen matrix for V (e.g. derived from
-  ///     MatrixXd)
+  ///     Eigen::MatrixXd)
   /// @tparam DerivedF  derived type of eigen matrix for F (e.g. derived from
-  ///     MatrixXi)
+  ///     Eigen::MatrixXi)
   /// @tparam Scalar  scalar type for eigen sparse matrix (e.g. double)
   /// @param[in] V  #V by dim list of mesh vertex positions
   /// @param[in] F  #F by simplex_size list of mesh elements (triangles or tetrahedra)

--- a/include/igl/massmatrix_intrinsic.cpp
+++ b/include/igl/massmatrix_intrinsic.cpp
@@ -34,7 +34,6 @@ IGL_INLINE void igl::massmatrix_intrinsic(
   Eigen::SparseMatrix<Scalar>& M)
 {
   using namespace Eigen;
-  using namespace std;
   MassMatrixType eff_type = type;
   const int m = F.rows();
   const int simplex_size = F.cols();

--- a/include/igl/massmatrix_intrinsic.cpp
+++ b/include/igl/massmatrix_intrinsic.cpp
@@ -33,7 +33,6 @@ IGL_INLINE void igl::massmatrix_intrinsic(
   const int n,
   Eigen::SparseMatrix<Scalar>& M)
 {
-  using namespace Eigen;
   MassMatrixType eff_type = type;
   const int m = F.rows();
   const int simplex_size = F.cols();
@@ -43,11 +42,11 @@ IGL_INLINE void igl::massmatrix_intrinsic(
     eff_type = (simplex_size == 3?MASSMATRIX_TYPE_VORONOI:MASSMATRIX_TYPE_BARYCENTRIC);
   }
   assert(F.cols() == 3 && "only triangles supported");
-  Matrix<Scalar,Dynamic,1> dblA;
+  Eigen::Matrix<Scalar ,Eigen::Dynamic,1> dblA;
   doublearea(l,0.,dblA);
-  Matrix<typename DerivedF::Scalar,Dynamic,1> MI;
-  Matrix<typename DerivedF::Scalar,Dynamic,1> MJ;
-  Matrix<Scalar,Dynamic,1> MV;
+  Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,1> MI;
+  Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,1> MJ;
+  Eigen::Matrix<Scalar ,Eigen::Dynamic,1> MV;
 
   switch(eff_type)
   {
@@ -72,22 +71,22 @@ IGL_INLINE void igl::massmatrix_intrinsic(
         MJ = MI;
 
         // Holy shit this needs to be cleaned up and optimized
-        Matrix<Scalar,Dynamic,3> cosines(m,3);
+        Eigen::Matrix<Scalar ,Eigen::Dynamic,3> cosines(m,3);
         cosines.col(0) = 
           (l.col(2).array().pow(2)+l.col(1).array().pow(2)-l.col(0).array().pow(2))/(l.col(1).array()*l.col(2).array()*2.0);
         cosines.col(1) = 
           (l.col(0).array().pow(2)+l.col(2).array().pow(2)-l.col(1).array().pow(2))/(l.col(2).array()*l.col(0).array()*2.0);
         cosines.col(2) = 
           (l.col(1).array().pow(2)+l.col(0).array().pow(2)-l.col(2).array().pow(2))/(l.col(0).array()*l.col(1).array()*2.0);
-        Matrix<Scalar,Dynamic,3> barycentric = cosines.array() * l.array();
+        Eigen::Matrix<Scalar ,Eigen::Dynamic,3> barycentric = cosines.array() * l.array();
         // Replace this: normalize_row_sums(barycentric,barycentric);
         barycentric  = (barycentric.array().colwise() / barycentric.array().rowwise().sum()).eval();
 
-        Matrix<Scalar,Dynamic,3> partial = barycentric;
+        Eigen::Matrix<Scalar ,Eigen::Dynamic,3> partial = barycentric;
         partial.col(0).array() *= dblA.array() * 0.5;
         partial.col(1).array() *= dblA.array() * 0.5;
         partial.col(2).array() *= dblA.array() * 0.5;
-        Matrix<Scalar,Dynamic,3> quads(partial.rows(),partial.cols());
+        Eigen::Matrix<Scalar ,Eigen::Dynamic,3> quads(partial.rows(),partial.cols());
         quads.col(0) = (partial.col(1)+partial.col(2))*0.5;
         quads.col(1) = (partial.col(2)+partial.col(0))*0.5;
         quads.col(2) = (partial.col(0)+partial.col(1))*0.5;

--- a/include/igl/matlab/MatlabWorkspace.h
+++ b/include/igl/matlab/MatlabWorkspace.h
@@ -191,7 +191,6 @@ inline void igl::matlab::MatlabWorkspace::clear()
 
 inline bool igl::matlab::MatlabWorkspace::write(const std::string & path) const
 {
-  using namespace std;
   MATFile * mat_file = matOpen(path.c_str(), "w");
   if(mat_file == NULL)
   {
@@ -221,7 +220,6 @@ inline bool igl::matlab::MatlabWorkspace::write(const std::string & path) const
 
 inline bool igl::matlab::MatlabWorkspace::read(const std::string & path)
 {
-  using namespace std;
 
   MATFile * mat_file;
 
@@ -293,7 +291,6 @@ inline igl::matlab::MatlabWorkspace& igl::matlab::MatlabWorkspace::save(
   const Eigen::MatrixBase<DerivedM>& M,
   const std::string & name)
 {
-  using namespace std;
   const int m = M.rows();
   const int n = M.cols();
   mxArray * mx_data = mxCreateDoubleMatrix(m,n,mxREAL);
@@ -313,7 +310,6 @@ inline igl::matlab::MatlabWorkspace& igl::matlab::MatlabWorkspace::save(
   const Eigen::SparseMatrix<MT>& M,
   const std::string & name)
 {
-  using namespace std;
   const int m = M.rows();
   const int n = M.cols();
   // THIS WILL NOT WORK FOR ROW-MAJOR
@@ -423,7 +419,6 @@ inline bool igl::matlab::MatlabWorkspace::find(
   const std::string & name,
   Eigen::PlainObjectBase<DerivedM>& M)
 {
-  using namespace std;
   const int i = std::find(names.begin(), names.end(), name)-names.begin();
   if(i>=(int)names.size())
   {
@@ -458,7 +453,6 @@ inline bool igl::matlab::MatlabWorkspace::find(
   const std::string & name,
   Eigen::SparseMatrix<MT>& M)
 {
-  using namespace std;
   using namespace Eigen;
   const int i = std::find(names.begin(), names.end(), name)-names.begin();
   if(i>=(int)names.size())
@@ -511,7 +505,6 @@ inline bool igl::matlab::MatlabWorkspace::find(
   const std::string & name,
   int & v)
 {
-  using namespace std;
   const int i = std::find(names.begin(), names.end(), name)-names.begin();
   if(i>=(int)names.size())
   {
@@ -534,7 +527,6 @@ inline bool igl::matlab::MatlabWorkspace::find(
   const std::string & name,
   double & d)
 {
-  using namespace std;
   const int i = std::find(names.begin(), names.end(), name)-names.begin();
   if(i>=(int)names.size())
   {

--- a/include/igl/matlab/MatlabWorkspace.h
+++ b/include/igl/matlab/MatlabWorkspace.h
@@ -56,7 +56,7 @@ namespace igl
         inline bool read(const std::string & path);
         /// Assign data to a variable name in the workspace
         ///
-        /// @tparam DerivedM  eigen matrix (e.g. MatrixXd)
+        /// @tparam DerivedM  eigen matrix (e.g. Eigen::MatrixXd)
         /// @param[in] M  data (usually a matrix)
         /// @param[in] name  variable name to save into work space
         /// @return true on success, false on failure
@@ -99,7 +99,7 @@ namespace igl
           const std::string & name);
         /// Same as save() but adds 1 to each element, useful for saving "index"
         /// matrices like lists of faces or elements
-        /// @tparam DerivedM  eigen matrix (e.g. MatrixXd)
+        /// @tparam DerivedM  eigen matrix (e.g. Eigen::MatrixXd)
         template <typename DerivedM>
         inline MatlabWorkspace& save_index(
           const Eigen::DenseBase<DerivedM>& M,
@@ -120,7 +120,7 @@ namespace igl
         ///
         /// \bug Outputs the first found (not necessarily unique lists).
         ///
-        /// @tparam DerivedM  eigen matrix (e.g. MatrixXd)
+        /// @tparam DerivedM  eigen matrix (e.g. Eigen::MatrixXd)
         /// @param[in] name  exact name of matrix as string
         /// @param[out] M  matrix
         /// @return true only if found.
@@ -143,7 +143,7 @@ namespace igl
           const std::string & name,
           int & v);
         /// Subtracts 1 from all entries
-        /// @tparam DerivedM  eigen matrix (e.g. MatrixXd)
+        /// @tparam DerivedM  eigen matrix (e.g. Eigen::MatrixXd)
         /// @param[in] name  exact name of matrix as string
         /// @param[out] M  matrix
         template <typename DerivedM>
@@ -453,7 +453,6 @@ inline bool igl::matlab::MatlabWorkspace::find(
   const std::string & name,
   Eigen::SparseMatrix<MT>& M)
 {
-  using namespace Eigen;
   const int i = std::find(names.begin(), names.end(), name)-names.begin();
   if(i>=(int)names.size())
   {
@@ -478,7 +477,7 @@ inline bool igl::matlab::MatlabWorkspace::find(
   double * pr = mxGetPr(mx_data);
   mwIndex * ir = mxGetIr(mx_data);
   mwIndex * jc = mxGetJc(mx_data);
-  vector<Triplet<MT> > MIJV;
+  vector<Eigen::Triplet<MT> > MIJV;
   const int nnz = mxGetNzmax(mx_data);
   MIJV.reserve(nnz);
   // Iterate over outside
@@ -491,7 +490,7 @@ inline bool igl::matlab::MatlabWorkspace::find(
       //cout<<ir[k]<<" "<<j<<" "<<pr[k]<<endl;
       assert((int)ir[k]<m);
       assert((int)j<n);
-      MIJV.push_back(Triplet<MT >(ir[k],j,pr[k]));
+      MIJV.push_back(Eigen::Triplet<MT >(ir[k],j,pr[k]));
       k++;
     }
   }

--- a/include/igl/matlab/parse_rhs.cpp
+++ b/include/igl/matlab/parse_rhs.cpp
@@ -35,7 +35,6 @@ IGL_INLINE void igl::matlab::parse_rhs(
   Eigen::SparseMatrix<MT> & M)
 {
   using namespace Eigen;
-  using namespace std;
   const mxArray * mx_data = prhs[0];
   // Handle boring case where matrix is actually an empty dense matrix
   if(mxGetNumberOfElements(mx_data) == 0)

--- a/include/igl/matlab/parse_rhs.cpp
+++ b/include/igl/matlab/parse_rhs.cpp
@@ -14,7 +14,7 @@ IGL_INLINE void igl::matlab::parse_rhs_double(
     Eigen::PlainObjectBase<DerivedV> & V)
 {
   // Use Eigen's map and cast to copy
-  V = Map< Eigen::Matrix<double ,Eigen::Dynamic ,Eigen::Dynamic> >
+  V = Eigen::Map< Eigen::Matrix<double ,Eigen::Dynamic ,Eigen::Dynamic> >
     (mxGetPr(prhs[0]),mxGetM(prhs[0]),mxGetN(prhs[0]))
     .cast<typename DerivedV::Scalar>();
 }
@@ -51,7 +51,7 @@ IGL_INLINE void igl::matlab::parse_rhs(
   double * pr = mxGetPr(mx_data);
   mwIndex * ir = mxGetIr(mx_data);
   mwIndex * jc = mxGetJc(mx_data);
-  vector<Eigen::Triplet<MT> > MIJV;
+  std::vector<Eigen::Triplet<MT> > MIJV;
   MIJV.reserve(mxGetNumberOfElements(mx_data));
   // Iterate over outside
   int k = 0;

--- a/include/igl/matlab/parse_rhs.cpp
+++ b/include/igl/matlab/parse_rhs.cpp
@@ -13,9 +13,8 @@ IGL_INLINE void igl::matlab::parse_rhs_double(
     const mxArray *prhs[], 
     Eigen::PlainObjectBase<DerivedV> & V)
 {
-  using namespace Eigen;
   // Use Eigen's map and cast to copy
-  V = Map< Matrix<double,Dynamic,Dynamic> >
+  V = Map< Eigen::Matrix<double ,Eigen::Dynamic ,Eigen::Dynamic> >
     (mxGetPr(prhs[0]),mxGetM(prhs[0]),mxGetN(prhs[0]))
     .cast<typename DerivedV::Scalar>();
 }
@@ -34,7 +33,6 @@ IGL_INLINE void igl::matlab::parse_rhs(
   const mxArray *prhs[], 
   Eigen::SparseMatrix<MT> & M)
 {
-  using namespace Eigen;
   const mxArray * mx_data = prhs[0];
   // Handle boring case where matrix is actually an empty dense matrix
   if(mxGetNumberOfElements(mx_data) == 0)
@@ -53,7 +51,7 @@ IGL_INLINE void igl::matlab::parse_rhs(
   double * pr = mxGetPr(mx_data);
   mwIndex * ir = mxGetIr(mx_data);
   mwIndex * jc = mxGetJc(mx_data);
-  vector<Triplet<MT> > MIJV;
+  vector<Eigen::Triplet<MT> > MIJV;
   MIJV.reserve(mxGetNumberOfElements(mx_data));
   // Iterate over outside
   int k = 0;
@@ -65,7 +63,7 @@ IGL_INLINE void igl::matlab::parse_rhs(
       //cout<<ir[k]<<" "<<j<<" "<<pr[k]<<endl;
       assert((int)ir[k]<m);
       assert((int)j<n);
-      MIJV.push_back(Triplet<MT >(ir[k],j,pr[k]));
+      MIJV.push_back(Eigen::Triplet<MT >(ir[k],j,pr[k]));
       k++;
     }
   }

--- a/include/igl/matlab/prepare_lhs.cpp
+++ b/include/igl/matlab/prepare_lhs.cpp
@@ -12,7 +12,6 @@ IGL_INLINE void igl::matlab::prepare_lhs_double(
   const Eigen::DenseBase<DerivedV> & V,
   mxArray *plhs[])
 {
-  using namespace std;
   using namespace Eigen;
   const auto m = V.rows();
   const auto n = V.cols();
@@ -27,7 +26,6 @@ IGL_INLINE void igl::matlab::prepare_lhs_logical(
   const Eigen::DenseBase<DerivedV> & V,
   mxArray *plhs[])
 {
-  using namespace std;
   using namespace Eigen;
   const auto m = V.rows();
   const auto n = V.cols();
@@ -52,7 +50,6 @@ IGL_INLINE void igl::matlab::prepare_lhs_double(
   const Eigen::SparseMatrix<Vtype> & M,
   mxArray *plhs[])
 {
-  using namespace std;
   const auto m = M.rows();
   const auto n = M.cols();
   // THIS WILL NOT WORK FOR ROW-MAJOR

--- a/include/igl/matlab/prepare_lhs.cpp
+++ b/include/igl/matlab/prepare_lhs.cpp
@@ -12,7 +12,6 @@ IGL_INLINE void igl::matlab::prepare_lhs_double(
   const Eigen::DenseBase<DerivedV> & V,
   mxArray *plhs[])
 {
-  using namespace Eigen;
   const auto m = V.rows();
   const auto n = V.cols();
   plhs[0] = mxCreateDoubleMatrix(m,n, mxREAL);
@@ -26,7 +25,6 @@ IGL_INLINE void igl::matlab::prepare_lhs_logical(
   const Eigen::DenseBase<DerivedV> & V,
   mxArray *plhs[])
 {
-  using namespace Eigen;
   const auto m = V.rows();
   const auto n = V.cols();
   plhs[0] = mxCreateLogicalMatrix(m,n);

--- a/include/igl/matlab_format.cpp
+++ b/include/igl/matlab_format.cpp
@@ -14,8 +14,7 @@ IGL_INLINE const Eigen::WithFormat< DerivedM > igl::matlab_format(
   const Eigen::DenseBase<DerivedM> & M,
   const std::string name)
 {
-  using namespace std;
-  string prefix = "";
+  std::string prefix = "";
   if(!name.empty())
   {
     prefix = name + " = ";
@@ -50,7 +49,6 @@ igl::matlab_format(
   const std::string name)
 {
   using namespace Eigen;
-  using namespace std;
   Matrix<typename Eigen::SparseMatrix<DerivedS>::Scalar,Dynamic,1> I,J,V;
   Matrix<DerivedS,Dynamic,Dynamic> SIJV;
   find(S,I,J,V);
@@ -58,8 +56,8 @@ igl::matlab_format(
   J.array() += 1;
   SIJV.resize(V.rows(),3);
   SIJV << I,J,V;
-  string prefix = "";
-  string suffix = "";
+  std::string prefix = "";
+  std::string suffix = "";
   if(!name.empty())
   {
     prefix = name + "IJV = ";
@@ -104,8 +102,7 @@ IGL_INLINE const std::string igl::matlab_format(
  const double v,
  const std::string name)
 {
-  using namespace std;
-  string prefix = "";
+  std::string prefix = "";
   if(!name.empty())
   {
     prefix = name + " = ";

--- a/include/igl/matlab_format.cpp
+++ b/include/igl/matlab_format.cpp
@@ -48,9 +48,8 @@ igl::matlab_format(
   const Eigen::SparseMatrix<DerivedS> & S,
   const std::string name)
 {
-  using namespace Eigen;
-  Matrix<typename Eigen::SparseMatrix<DerivedS>::Scalar,Dynamic,1> I,J,V;
-  Matrix<DerivedS,Dynamic,Dynamic> SIJV;
+  Eigen::Matrix<typename Eigen::SparseMatrix<DerivedS>::Scalar ,Eigen::Dynamic,1> I,J,V;
+  Eigen::Matrix<DerivedS ,Eigen::Dynamic ,Eigen::Dynamic> SIJV;
   find(S,I,J,V);
   I.array() += 1;
   J.array() += 1;

--- a/include/igl/matlab_format.h
+++ b/include/igl/matlab_format.h
@@ -19,7 +19,7 @@ namespace igl
   /// This is a routine to print a matrix using format suitable for pasting into
   /// the matlab IDE
   ///
-  /// @tparam DerivedM  e.g. derived from MatrixXd
+  /// @tparam DerivedM  e.g. derived from Eigen::MatrixXd
   /// @param[in] input  some matrix to be formatted
   /// @param[in] name  name of matrix (optional)
   /// @return Formatted matrix

--- a/include/igl/matrix_to_list.cpp
+++ b/include/igl/matrix_to_list.cpp
@@ -14,8 +14,7 @@ IGL_INLINE void igl::matrix_to_list(
   const Eigen::MatrixBase<DerivedM> & M,
   std::vector<std::vector<typename DerivedM::Scalar > > & V)
 {
-  using namespace std;
-  V.resize(M.rows(),vector<typename DerivedM::Scalar >(M.cols()));
+  V.resize(M.rows(),std::vector<typename DerivedM::Scalar >(M.cols()));
   // loop over rows
   for(int i = 0;i<M.rows();i++)
   {
@@ -32,7 +31,6 @@ IGL_INLINE void igl::matrix_to_list(
   const Eigen::MatrixBase<DerivedM> & M,
   std::vector<typename DerivedM::Scalar > & V)
 {
-  using namespace std;
   V.resize(M.size());
   // loop over cols then rows
   for(int j = 0;j<M.cols();j++)

--- a/include/igl/median.cpp
+++ b/include/igl/median.cpp
@@ -15,19 +15,18 @@ template <typename DerivedV, typename mType>
 IGL_INLINE bool igl::median(
   const Eigen::MatrixBase<DerivedV> & V, mType & m)
 {
-  using namespace std;
   if(V.size() == 0)
   {
     return false;
   }
-  vector<typename DerivedV::Scalar> vV;
+  std::vector<typename DerivedV::Scalar> vV;
   matrix_to_list(V,vV);
   // http://stackoverflow.com/a/1719155/148668
   size_t n = vV.size()/2;
-  nth_element(vV.begin(),vV.begin()+n,vV.end());
+  std::nth_element(vV.begin(),vV.begin()+n,vV.end());
   if(vV.size()%2==0)
   {
-    nth_element(vV.begin(),vV.begin()+n-1,vV.end());
+    std::nth_element(vV.begin(),vV.begin()+n-1,vV.end());
     m = 0.5*(vV[n]+vV[n-1]);
   }else
   {

--- a/include/igl/min_quad_with_fixed.h
+++ b/include/igl/min_quad_with_fixed.h
@@ -57,8 +57,8 @@ namespace igl
   /// Solves a system previously factored using min_quad_with_fixed_precompute
   ///
   /// @tparam T  type of sparse matrix (e.g. double)
-  /// @tparam DerivedY  type of Y (e.g. derived from VectorXd or MatrixXd)
-  /// @tparam DerivedZ  type of Z (e.g. derived from VectorXd or MatrixXd)
+  /// @tparam DerivedY  type of Y (e.g. derived from Eigen::VectorXd or Eigen::MatrixXd)
+  /// @tparam DerivedZ  type of Z (e.g. derived from Eigen::VectorXd or Eigen::MatrixXd)
   /// @param[in] data  factorization struct with all necessary precomputation to solve
   /// @param[in] B  n by k column of linear coefficients
   /// @param[in] Y  b by k list of constant fixed values

--- a/include/igl/min_quad_with_fixed.impl.h
+++ b/include/igl/min_quad_with_fixed.impl.h
@@ -37,7 +37,6 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
   )
 {
 //#define MIN_QUAD_WITH_FIXED_CPP_DEBUG
-  using namespace Eigen;
   const Eigen::SparseMatrix<T> A = 0.5*A2;
 #ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
   cout<<"    pre"<<endl;
@@ -108,7 +107,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
     data.unknown_lagrange.tail(data.lagrange.size()) = data.lagrange;
   }
 
-  SparseMatrix<T> Auu;
+  Eigen::SparseMatrix<T> Auu;
   slice(A,data.unknown,data.unknown,Auu);
   assert(Auu.size() != 0 && Auu.rows() > 0 && "There should be at least one unknown.");
 
@@ -126,8 +125,8 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
   }else
   {
     // determine if A(unknown,unknown) is symmetric and/or positive definite
-    VectorXi AuuI,AuuJ;
-    Matrix<T,Eigen::Dynamic,Eigen::Dynamic> AuuV;
+    Eigen::VectorXi AuuI,AuuJ;
+    Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic> AuuV;
     find(Auu,AuuI,AuuJ,AuuV);
     data.Auu_sym = is_symmetric(Auu,EPS<T>()*AuuV.maxCoeff());
   }
@@ -185,9 +184,9 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
     cout<<"    Aeq_li=true"<<endl;
 #endif
     // Append lagrange multiplier quadratic terms
-    SparseMatrix<T> new_A;
-    SparseMatrix<T> AeqT = Aeq.transpose();
-    SparseMatrix<T> Z(neq,neq);
+    Eigen::SparseMatrix<T> new_A;
+    Eigen::SparseMatrix<T> AeqT = Aeq.transpose();
+    Eigen::SparseMatrix<T> Z(neq,neq);
     // This is a bit slower. But why isn't cat fast?
     new_A = cat(1, cat(2,   A, AeqT ),
                    cat(2, Aeq,    Z ));
@@ -195,7 +194,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
     // precompute RHS builders
     if(kr > 0)
     {
-      SparseMatrix<T> Aulk,Akul;
+      Eigen::SparseMatrix<T> Aulk,Akul;
       // Slow
       slice(new_A,data.unknown_lagrange,data.known,Aulk);
       //// This doesn't work!!!
@@ -207,7 +206,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
       }else
       {
         slice(new_A,data.known,data.unknown_lagrange,Akul);
-        SparseMatrix<T> AkulT = Akul.transpose();
+        Eigen::SparseMatrix<T> AkulT = Akul.transpose();
         data.preY = Aulk + AkulT;
       }
     }else
@@ -248,7 +247,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
         cout<<"    ldlt/lu"<<endl;
 #endif
       // Either not PD or there are equality constraints
-      SparseMatrix<T> NA;
+      Eigen::SparseMatrix<T> NA;
       slice(new_A,data.unknown_lagrange,data.unknown_lagrange,NA);
       data.NA = NA;
       if(data.Auu_pd)
@@ -316,7 +315,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
     //cout<<"neq: "<<neq<<endl;
     //cout<<"nc: "<<nc<<endl;
     //cout<<"    matrixR"<<endl;
-    SparseMatrix<T> AeqTR,AeqTQ;
+    Eigen::SparseMatrix<T> AeqTR,AeqTQ;
     AeqTR = data.AeqTQR.matrixR();
     // This shouldn't be necessary
     AeqTR.prune(static_cast<T>(0.0));
@@ -339,7 +338,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
     cout<<"      nnz: "<<AeqTQ.nonZeros()<<endl;
     cout<<"    perm"<<endl;
 #endif
-    SparseMatrix<T> I(neq,neq);
+    Eigen::SparseMatrix<T> I(neq,neq);
     I.setIdentity();
     data.AeqTE = data.AeqTQR.colsPermutation() * I;
     data.AeqTET = data.AeqTQR.colsPermutation().transpose() * I;
@@ -364,7 +363,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
     cout<<"    proj"<<endl;
 #endif
     // Projected hessian
-    SparseMatrix<T> QRAuu = data.AeqTQ2T * Auu * data.AeqTQ2;
+    Eigen::SparseMatrix<T> QRAuu = data.AeqTQ2T * Auu * data.AeqTQ2;
     {
 #ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
       cout<<"    factorize"<<endl;
@@ -392,11 +391,11 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
     cout<<"    smash"<<endl;
 #endif
     // Known value multiplier
-    SparseMatrix<T> Auk;
+    Eigen::SparseMatrix<T> Auk;
     slice(A,data.unknown,data.known,Auk);
-    SparseMatrix<T> Aku;
+    Eigen::SparseMatrix<T> Aku;
     slice(A,data.known,data.unknown,Aku);
-    SparseMatrix<T> AkuT = Aku.transpose();
+    Eigen::SparseMatrix<T> AkuT = Aku.transpose();
     data.preY = Auk + AkuT;
     // Needed during solve
     data.Auu = Auu;
@@ -423,8 +422,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_solve(
   Eigen::PlainObjectBase<DerivedZ> & Z,
   Eigen::PlainObjectBase<Derivedsol> & sol)
 {
-  using namespace Eigen;
-  typedef Matrix<T,Dynamic,Dynamic> MatrixXT;
+  typedef Eigen::Matrix<T ,Eigen::Dynamic ,Eigen::Dynamic> MatrixXT;
   // number of known rows
   int kr = data.known.size();
   if(kr!=0)
@@ -521,7 +519,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_solve(
     const int nc = data.AeqTQR.rank();
     const int neq = Beq.rows();
     eff_Beq = eff_Beq.topLeftCorner(nc,cols).eval();
-    data.AeqTR1T.template triangularView<Lower>().solveInPlace(eff_Beq);
+    data.AeqTR1T.template triangularView<Eigen::Lower>().solveInPlace(eff_Beq);
     // Now eff_Beq = (data.AeqTR1T \ (data.AeqTET * (-data.Aeqk * Y + Beq)))
     MatrixXT lambda_0;
     lambda_0 = data.AeqTQ1 * eff_Beq;
@@ -538,7 +536,7 @@ IGL_INLINE bool igl::min_quad_with_fixed_solve(
     {
       Derivedsol temp1,temp2;
       temp1 = (data.AeqTQ1T * NB - data.AeqTQ1T * data.Auu * solu);
-      data.AeqTR1.template triangularView<Upper>().solveInPlace(temp1);
+      data.AeqTR1.template triangularView<Eigen::Upper>().solveInPlace(temp1);
       //cout<<matlab_format(temp1,"temp1")<<endl;
       temp2 = Derivedsol::Zero(neq,cols);
       temp2.topLeftCorner(nc,cols) = temp1;

--- a/include/igl/min_quad_with_fixed.impl.h
+++ b/include/igl/min_quad_with_fixed.impl.h
@@ -38,7 +38,6 @@ IGL_INLINE bool igl::min_quad_with_fixed_precompute(
 {
 //#define MIN_QUAD_WITH_FIXED_CPP_DEBUG
   using namespace Eigen;
-  using namespace std;
   const Eigen::SparseMatrix<T> A = 0.5*A2;
 #ifdef MIN_QUAD_WITH_FIXED_CPP_DEBUG
   cout<<"    pre"<<endl;
@@ -424,7 +423,6 @@ IGL_INLINE bool igl::min_quad_with_fixed_solve(
   Eigen::PlainObjectBase<DerivedZ> & Z,
   Eigen::PlainObjectBase<Derivedsol> & sol)
 {
-  using namespace std;
   using namespace Eigen;
   typedef Matrix<T,Dynamic,Dynamic> MatrixXT;
   // number of known rows

--- a/include/igl/mode.cpp
+++ b/include/igl/mode.cpp
@@ -17,13 +17,12 @@ IGL_INLINE void igl::mode(
   Eigen::Matrix<T,Eigen::Dynamic,1> & M)
 {
   assert(d==1 || d==2);
-  using namespace std;
   int m = X.rows();
   int n = X.cols();
   M.resize((d==1)?n:m,1);
   for(int i = 0;i<((d==2)?m:n);i++)
   {
-    vector<int> counts(((d==2)?n:m),0);
+    std::vector<int> counts(((d==2)?n:m),0);
     for(int j = 0;j<((d==2)?n:m);j++)
     {
       T v = (d==2)?X(i,j):X(j,i);
@@ -40,7 +39,7 @@ IGL_INLINE void igl::mode(
     int max_count = -1;
     int max_count_j = -1;
     int j =0;
-    for(vector<int>::iterator it = counts.begin();it<counts.end();it++)
+    for(std::vector<int>::iterator it = counts.begin();it<counts.end();it++)
     {
       if(max_count < *it)
       {

--- a/include/igl/moments.cpp
+++ b/include/igl/moments.cpp
@@ -14,7 +14,7 @@
 //   - RowVector3d
 //   - Vector3d
 //   - RowVectorXd
-//   - VectorXd
+//   - Eigen::VectorXd
 namespace igl
 {
   template <bool SingleRow, bool SingleCol> struct moments_resize_3;

--- a/include/igl/mosek/bbw.cpp
+++ b/include/igl/mosek/bbw.cpp
@@ -29,7 +29,6 @@ IGL_INLINE bool igl::mosek::bbw(
   Eigen::PlainObjectBase<DerivedW> & W
   )
 {
-  using namespace Eigen;
   assert(!data.partition_unity && "partition_unity not implemented yet");
   // number of domain vertices
   int n = V.rows();
@@ -40,13 +39,13 @@ IGL_INLINE bool igl::mosek::bbw(
   harmonic(V,Ele,2,Q);
   W.derived().resize(n,m);
   // No linear terms
-  VectorXd c = VectorXd::Zero(n);
+  Eigen::VectorXd c = Eigen::VectorXd::Zero(n);
   // No linear constraints
-  SparseMatrix<typename DerivedW::Scalar> A(0,n);
-  VectorXd uc(0,1),lc(0,1);
+  Eigen::SparseMatrix<typename DerivedW::Scalar> A(0,n);
+  Eigen::VectorXd uc(0,1),lc(0,1);
   // Upper and lower box constraints (Constant bounds)
-  VectorXd ux = VectorXd::Ones(n);
-  VectorXd lx = VectorXd::Zero(n);
+  Eigen::VectorXd ux = Eigen::VectorXd::Ones(n);
+  Eigen::VectorXd lx = Eigen::VectorXd::Zero(n);
   // Loop over handles
   for(int i = 0;i<m;i++)
   {
@@ -55,8 +54,8 @@ IGL_INLINE bool igl::mosek::bbw(
       cout<<"BBW: Computing weight for handle "<<i+1<<" out of "<<m<<
         "."<<endl;
     }
-    VectorXd bci = bc.col(i);
-    VectorXd Wi;
+    Eigen::VectorXd bci = bc.col(i);
+    Eigen::VectorXd Wi;
     // impose boundary conditions via bounds
     ux(b) = bci;
     lx(b) = bci;

--- a/include/igl/mosek/bbw.cpp
+++ b/include/igl/mosek/bbw.cpp
@@ -29,7 +29,6 @@ IGL_INLINE bool igl::mosek::bbw(
   Eigen::PlainObjectBase<DerivedW> & W
   )
 {
-  using namespace std;
   using namespace Eigen;
   assert(!data.partition_unity && "partition_unity not implemented yet");
   // number of domain vertices

--- a/include/igl/mosek/bbw.h
+++ b/include/igl/mosek/bbw.h
@@ -19,11 +19,11 @@ namespace igl
     /// Compute Bounded Biharmonic Weights on a given domain (V,Ele) with a given
     /// set of boundary conditions
     ///
-    /// @tparam DerivedV  derived type of eigen matrix for V (e.g. MatrixXd)
-    /// @tparam DerivedF  derived type of eigen matrix for F (e.g. MatrixXi)
-    /// @tparam Derivedb  derived type of eigen matrix for b (e.g. VectorXi)
-    /// @tparam Derivedbc  derived type of eigen matrix for bc (e.g. MatrixXd)
-    /// @tparam DerivedW  derived type of eigen matrix for W (e.g. MatrixXd)
+    /// @tparam DerivedV  derived type of eigen matrix for V (e.g. Eigen::MatrixXd)
+    /// @tparam DerivedF  derived type of eigen matrix for F (e.g. Eigen::MatrixXi)
+    /// @tparam Derivedb  derived type of eigen matrix for b (e.g. Eigen::VectorXi)
+    /// @tparam Derivedbc  derived type of eigen matrix for bc (e.g. Eigen::MatrixXd)
+    /// @tparam DerivedW  derived type of eigen matrix for W (e.g. Eigen::MatrixXd)
     /// @param[in] V  #V by dim vertex positions
     /// @param[in] Ele  #Elements by simplex-size list of element indices
     /// @param[in] b  #b boundary indices into V

--- a/include/igl/mosek/mosek_guarded.cpp
+++ b/include/igl/mosek/mosek_guarded.cpp
@@ -10,7 +10,6 @@
 
 IGL_INLINE MSKrescodee igl::mosek::mosek_guarded(const MSKrescodee r)
 {
-  using namespace std;
   if(r != MSK_RES_OK)
   {
     /* In case of an error print error code and description. */      

--- a/include/igl/mosek/mosek_linprog.cpp
+++ b/include/igl/mosek/mosek_linprog.cpp
@@ -45,7 +45,6 @@ IGL_INLINE bool igl::mosek::mosek_linprog(
   Eigen::VectorXd & x)
 {
   // following http://docs.mosek.com/7.1/capi/Linear_optimization.html
-  using namespace std;
   // number of constraints
   const int m = A.rows();
   // number of variables

--- a/include/igl/mosek/mosek_quadprog.cpp
+++ b/include/igl/mosek/mosek_quadprog.cpp
@@ -285,8 +285,6 @@ IGL_INLINE bool igl::mosek::mosek_quadprog(
   MosekData & mosek_data,
   Eigen::VectorXd & x)
 {
-  using namespace Eigen;
-
   typedef int Index;
   typedef double Scalar;
   // Q should be square
@@ -296,11 +294,11 @@ IGL_INLINE bool igl::mosek::mosek_quadprog(
   assert( (Q-Q.transpose()).sum() < FLOAT_EPS);
 #endif
   // Only keep lower triangular part of Q
-  SparseMatrix<Scalar> QL;
-  //QL = Q.template triangularView<Lower>();
-  QL = Q.triangularView<Lower>();
-  VectorXi Qi,Qj;
-  VectorXd Qv;
+  Eigen::SparseMatrix<Scalar> QL;
+  //QL = Q.template triangularView<Eigen::Lower>();
+  QL = Q.triangularView<Eigen::Lower>();
+  Eigen::VectorXi Qi,Qj;
+  Eigen::VectorXd Qv;
   find(QL,Qi,Qj,Qv);
   vector<Index> vQi = matrix_to_list(Qi);
   vector<Index> vQj = matrix_to_list(Qj);

--- a/include/igl/mosek/mosek_quadprog.cpp
+++ b/include/igl/mosek/mosek_quadprog.cpp
@@ -286,7 +286,6 @@ IGL_INLINE bool igl::mosek::mosek_quadprog(
   Eigen::VectorXd & x)
 {
   using namespace Eigen;
-  using namespace std;
 
   typedef int Index;
   typedef double Scalar;

--- a/include/igl/nchoosek.cpp
+++ b/include/igl/nchoosek.cpp
@@ -34,7 +34,6 @@ IGL_INLINE void igl::nchoosek(
   const int k,
   Eigen::PlainObjectBase<DerivedU> & U)
 {
-  using namespace Eigen;
   if(V.size() == 0)
   {
     U.resize(0,k);
@@ -44,7 +43,7 @@ IGL_INLINE void igl::nchoosek(
   U.resize(nchoosek(V.size(),k),k);
   int running_i  = 0;
   int running_j = 0;
-  Matrix<typename DerivedU::Scalar,1,Dynamic> running(1,k);
+  Eigen::Matrix<typename DerivedU::Scalar,1 ,Eigen::Dynamic> running(1,k);
   int N = V.size();
   const std::function<void(int,int)> doCombs =
     [&running,&N,&doCombs,&running_i,&running_j,&U,&V](int offset, int k)

--- a/include/igl/next_filename.cpp
+++ b/include/igl/next_filename.cpp
@@ -17,13 +17,12 @@ bool igl::next_filename(
   const std::string & suffix,
   std::string & next)
 {
-  using namespace std;
   // O(n), for huge lists could at least find bounds with exponential search
   // and then narrow with binary search O(log(n))
   int i = 0;
   while(true)
   {
-    next = STR(prefix << setfill('0') << setw(zeros)<<i<<suffix);
+    next = STR(prefix << std::setfill('0') << std::setw(zeros)<<i<<suffix);
     if(!file_exists(next))
     {
       return true;

--- a/include/igl/normal_derivative.cpp
+++ b/include/igl/normal_derivative.cpp
@@ -21,14 +21,13 @@ IGL_INLINE void igl::normal_derivative(
   Eigen::SparseMatrix<Scalar>& DD)
 {
   using namespace Eigen;
-  using namespace std;
   // Element simplex-size
   const size_t ss = Ele.cols();
   assert( ((ss==3) || (ss==4)) && "Only triangles or tets");
   // cotangents
   Matrix<Scalar,Dynamic,Dynamic> C;
   cotmatrix_entries(V,Ele,C);
-  vector<Triplet<Scalar> > IJV;
+  std::vector<Triplet<Scalar> > IJV;
   // Number of elements
   const size_t m = Ele.rows();
   // Number of vertices

--- a/include/igl/normal_derivative.cpp
+++ b/include/igl/normal_derivative.cpp
@@ -20,14 +20,13 @@ IGL_INLINE void igl::normal_derivative(
   const Eigen::MatrixBase<DerivedEle> & Ele,
   Eigen::SparseMatrix<Scalar>& DD)
 {
-  using namespace Eigen;
   // Element simplex-size
   const size_t ss = Ele.cols();
   assert( ((ss==3) || (ss==4)) && "Only triangles or tets");
   // cotangents
-  Matrix<Scalar,Dynamic,Dynamic> C;
+  Eigen::Matrix<Scalar ,Eigen::Dynamic ,Eigen::Dynamic> C;
   cotmatrix_entries(V,Ele,C);
-  std::vector<Triplet<Scalar> > IJV;
+  std::vector<Eigen::Triplet<Scalar> > IJV;
   // Number of elements
   const size_t m = Ele.rows();
   // Number of vertices
@@ -39,20 +38,20 @@ IGL_INLINE void igl::normal_derivative(
       return;
     case 4:
     {
-      const MatrixXi DDJ = 
+      const Eigen::MatrixXi DDJ =
         Ele(igl::placeholders::all,{1,0,2,0,3,0,2,1,3,1,0,1,3,2,0,2,1,2,0,3,1,3,2,3});
-      MatrixXi DDI(m,24);
+      Eigen::MatrixXi DDI(m,24);
       for(size_t f = 0;f<4;f++)
       {
-        const auto & I = (igl::LinSpaced<VectorXi >(m,0,m-1).array()+f*m).eval();
+        const auto & I = (igl::LinSpaced<Eigen::VectorXi >(m,0,m-1).array()+f*m).eval();
         for(size_t r = 0;r<6;r++)
         {
           DDI.col(f*6+r) = I;
         }
       }
-      const DiagonalMatrix<Scalar,24,24> S =
-        (Matrix<Scalar,2,1>(1,-1).template replicate<12,1>()).asDiagonal();
-      Matrix<Scalar,Dynamic,Dynamic> DDV =
+      const Eigen::DiagonalMatrix<Scalar,24,24> S =
+        (Eigen::Matrix<Scalar,2,1>(1,-1).template replicate<12,1>()).asDiagonal();
+      Eigen::Matrix<Scalar ,Eigen::Dynamic ,Eigen::Dynamic> DDV =
         C(igl::placeholders::all,{2,2,1,1,3,3,0,0,4,4,2,2,5,5,1,1,0,0,3,3,4,4,5,5});
       DDV *= S;
 
@@ -61,7 +60,7 @@ IGL_INLINE void igl::normal_derivative(
       {
         for(size_t e = 0;e<m;e++)
         {
-          IJV.push_back(Triplet<Scalar>(DDI(e,f),DDJ(e,f),DDV(e,f)));
+          IJV.push_back(Eigen::Triplet<Scalar>(DDI(e,f),DDJ(e,f),DDV(e,f)));
         }
       }
       DD.resize(m*4,n);
@@ -70,19 +69,19 @@ IGL_INLINE void igl::normal_derivative(
     }
     case 3:
     {
-      const MatrixXi DDJ = Ele(igl::placeholders::all,{2,0,1,0,0,1,2,1,1,2,0,2});
-      MatrixXi DDI(m,12);
+      const Eigen::MatrixXi DDJ = Ele(igl::placeholders::all,{2,0,1,0,0,1,2,1,1,2,0,2});
+      Eigen::MatrixXi DDI(m,12);
       for(size_t f = 0;f<3;f++)
       {
-        const auto & I = (igl::LinSpaced<VectorXi >(m,0,m-1).array()+f*m).eval();
+        const auto & I = (igl::LinSpaced<Eigen::VectorXi >(m,0,m-1).array()+f*m).eval();
         for(size_t r = 0;r<4;r++)
         {
           DDI.col(f*4+r) = I;
         }
       }
-      const DiagonalMatrix<Scalar,12,12> S =
-        (Matrix<Scalar,2,1>(1,-1).template replicate<6,1>()).asDiagonal();
-      Matrix<Scalar,Dynamic,Dynamic> DDV = C(igl::placeholders::all,{1,1,2,2,2,2,0,0,0,0,1,1});
+      const Eigen::DiagonalMatrix<Scalar,12,12> S =
+        (Eigen::Matrix<Scalar,2,1>(1,-1).template replicate<6,1>()).asDiagonal();
+      Eigen::Matrix<Scalar ,Eigen::Dynamic ,Eigen::Dynamic> DDV = C(igl::placeholders::all,{1,1,2,2,2,2,0,0,0,0,1,1});
       DDV *= S;
 
       IJV.reserve(DDV.size());
@@ -90,7 +89,7 @@ IGL_INLINE void igl::normal_derivative(
       {
         for(size_t e = 0;e<m;e++)
         {
-          IJV.push_back(Triplet<Scalar>(DDI(e,f),DDJ(e,f),DDV(e,f)));
+          IJV.push_back(Eigen::Triplet<Scalar>(DDI(e,f),DDJ(e,f),DDV(e,f)));
         }
       }
       DD.resize(m*3,n);

--- a/include/igl/null.cpp
+++ b/include/igl/null.cpp
@@ -13,9 +13,8 @@ IGL_INLINE void igl::null(
   const Eigen::MatrixBase<DerivedA> & A,
   Eigen::PlainObjectBase<DerivedN> & N)
 {
-  using namespace Eigen;
   typedef typename DerivedA::Scalar Scalar;
-  JacobiSVD<Eigen::Matrix<Scalar,Eigen::Dynamic,Eigen::Dynamic> > svd(A, ComputeFullV);
+  Eigen::JacobiSVD<Eigen::Matrix<Scalar,Eigen::Dynamic,Eigen::Dynamic> > svd(A, Eigen::ComputeFullV);
   svd.setThreshold(A.cols() * svd.singularValues().maxCoeff() * EPS<Scalar>());
   N = svd.matrixV().rightCols(A.cols()-svd.rank());
 }

--- a/include/igl/on_boundary.cpp
+++ b/include/igl/on_boundary.cpp
@@ -19,7 +19,6 @@ IGL_INLINE void igl::on_boundary(
   std::vector<bool> & I,
   std::vector<std::vector<bool> > & C)
 {
-  using namespace std;
   if(T.empty())
   {
     I.clear();
@@ -32,7 +31,7 @@ IGL_INLINE void igl::on_boundary(
     case 3:
     {
       // Get a list of all faces
-      vector<vector<IntegerT> > F(T.size()*3,vector<IntegerT>(2));
+      std::vector<std::vector<IntegerT> > F(T.size()*3,std::vector<IntegerT>(2));
       // Gather faces, loop over tets
       for(int i = 0; i< (int)T.size();i++)
       {
@@ -46,9 +45,9 @@ IGL_INLINE void igl::on_boundary(
         F[i*3+2][1] = T[i][1];
       }
       // Counts
-      vector<int> FC;
+      std::vector<int> FC;
       face_occurrences(F,FC);
-      C.resize(T.size(),vector<bool>(3));
+      C.resize(T.size(),std::vector<bool>(3));
       I.resize(T.size(),false);
       for(int i = 0; i< (int)T.size();i++)
       {
@@ -65,7 +64,7 @@ IGL_INLINE void igl::on_boundary(
     case 4:
     {
       // Get a list of all faces
-      vector<vector<IntegerT> > F(T.size()*4,vector<IntegerT>(3));
+      std::vector<std::vector<IntegerT> > F(T.size()*4,std::vector<IntegerT>(3));
       // Gather faces, loop over tets
       for(int i = 0; i< (int)T.size();i++)
       {
@@ -88,9 +87,9 @@ IGL_INLINE void igl::on_boundary(
         F[i*4+3][2] = T[i][2];
       }
       // Counts
-      vector<int> FC;
+      std::vector<int> FC;
       face_occurrences(F,FC);
-      C.resize(T.size(),vector<bool>(4));
+      C.resize(T.size(),std::vector<bool>(4));
       I.resize(T.size(),false);
       for(int i = 0; i< (int)T.size();i++)
       {
@@ -119,13 +118,12 @@ IGL_INLINE void igl::on_boundary(
   Eigen::PlainObjectBase<DerivedC>& C)
 {
   assert(T.cols() == 0 || T.cols() == 4 || T.cols() == 3);
-  using namespace std;
   using namespace Eigen;
   // Cop out: use vector of vectors version
-  vector<vector<typename DerivedT::Scalar> > vT;
+  std::vector<std::vector<typename DerivedT::Scalar> > vT;
   matrix_to_list(T,vT);
-  vector<bool> vI;
-  vector<vector<bool> > vC;
+  std::vector<bool> vI;
+  std::vector<std::vector<bool> > vC;
   on_boundary(vT,vI,vC);
   list_to_matrix(vI,I);
   list_to_matrix(vC,C);

--- a/include/igl/on_boundary.cpp
+++ b/include/igl/on_boundary.cpp
@@ -118,7 +118,6 @@ IGL_INLINE void igl::on_boundary(
   Eigen::PlainObjectBase<DerivedC>& C)
 {
   assert(T.cols() == 0 || T.cols() == 4 || T.cols() == 3);
-  using namespace Eigen;
   // Cop out: use vector of vectors version
   std::vector<std::vector<typename DerivedT::Scalar> > vT;
   matrix_to_list(T,vT);

--- a/include/igl/opengl/ViewerCore.cpp
+++ b/include/igl/opengl/ViewerCore.cpp
@@ -107,7 +107,6 @@ IGL_INLINE void igl::opengl::ViewerCore::draw(
   ViewerData& data,
   bool update_matrices)
 {
-  using namespace std;
   using namespace Eigen;
 
   if (depth_test)
@@ -495,7 +494,6 @@ IGL_INLINE void igl::opengl::ViewerCore::set_rotation_type(
   const igl::opengl::ViewerCore::RotationType & value)
 {
   using namespace Eigen;
-  using namespace std;
   const RotationType old_rotation_type = rotation_type;
   rotation_type = value;
   if(rotation_type == ROTATION_TYPE_TWO_AXIS_VALUATOR_FIXED_UP &&

--- a/include/igl/opengl/ViewerCore.cpp
+++ b/include/igl/opengl/ViewerCore.cpp
@@ -107,8 +107,6 @@ IGL_INLINE void igl::opengl::ViewerCore::draw(
   ViewerData& data,
   bool update_matrices)
 {
-  using namespace Eigen;
-
   if (depth_test)
     glEnable(GL_DEPTH_TEST);
   else
@@ -493,13 +491,12 @@ IGL_INLINE void igl::opengl::ViewerCore::draw_labels(
 IGL_INLINE void igl::opengl::ViewerCore::set_rotation_type(
   const igl::opengl::ViewerCore::RotationType & value)
 {
-  using namespace Eigen;
   const RotationType old_rotation_type = rotation_type;
   rotation_type = value;
   if(rotation_type == ROTATION_TYPE_TWO_AXIS_VALUATOR_FIXED_UP &&
     old_rotation_type != ROTATION_TYPE_TWO_AXIS_VALUATOR_FIXED_UP)
   {
-    snap_to_fixed_up(Quaternionf(trackball_angle),trackball_angle);
+    snap_to_fixed_up(Eigen::Quaternionf(trackball_angle),trackball_angle);
   }
 }
 

--- a/include/igl/opengl/ViewerData.cpp
+++ b/include/igl/opengl/ViewerData.cpp
@@ -141,7 +141,6 @@ IGL_INLINE void igl::opengl::ViewerData::copy_options(const ViewerCore &from, co
 
 IGL_INLINE void igl::opengl::ViewerData::set_colors(const Eigen::MatrixXd &C)
 {
-  using namespace Eigen;
   // This Gouraud coloring should be deprecated in favor of Phong coloring in
   // set-data
   if(C.rows()>0 && C.cols() == 1)
@@ -150,18 +149,18 @@ IGL_INLINE void igl::opengl::ViewerData::set_colors(const Eigen::MatrixXd &C)
     return set_data(C);
   }
   // Ambient color should be darker color
-  const auto ambient = [](const MatrixXd & C)->MatrixXd
+  const auto ambient = [](const Eigen::MatrixXd & C)->Eigen::MatrixXd
   {
-    MatrixXd T = 0.1*C;
+    Eigen::MatrixXd T = 0.1*C;
     T.col(3) = C.col(3);
     return T;
   };
   // Specular color should be a less saturated and darker color: dampened
   // highlights
-  const auto specular = [](const MatrixXd & C)->MatrixXd
+  const auto specular = [](const Eigen::MatrixXd & C)->Eigen::MatrixXd
   {
     const double grey = 0.3;
-    MatrixXd T = grey+0.1*(C.array()-grey);
+    Eigen::MatrixXd T = grey+0.1*(C.array()-grey);
     T.col(3) = C.col(3);
     return T;
   };
@@ -356,12 +355,11 @@ IGL_INLINE void igl::opengl::ViewerData::set_edges(
   const Eigen::MatrixXi& E,
   const Eigen::MatrixXd& C)
 {
-  using namespace Eigen;
   lines.resize(E.rows(),9);
   assert(C.cols() == 3);
   for(int e = 0;e<E.rows();e++)
   {
-    RowVector3d color;
+    Eigen::RowVector3d color;
     if(C.size() == 3)
     {
       color<<C;

--- a/include/igl/opengl/ViewerData.cpp
+++ b/include/igl/opengl/ViewerData.cpp
@@ -59,8 +59,6 @@ IGL_INLINE void igl::opengl::ViewerData::set_face_based(bool newvalue)
 IGL_INLINE void igl::opengl::ViewerData::set_mesh(
     const Eigen::MatrixXd& _V, const Eigen::MatrixXi& _F)
 {
-  using namespace std;
-
   Eigen::MatrixXd V_temp;
 
   // If V only has two columns, pad with a column of zeros
@@ -94,7 +92,7 @@ IGL_INLINE void igl::opengl::ViewerData::set_mesh(
       F = _F;
     }
     else
-      cerr << "ERROR (set_mesh): The new mesh has a different number of vertices/faces. Please clear the mesh before plotting."<<endl;
+      std::cerr << "ERROR (set_mesh): The new mesh has a different number of vertices/faces. Please clear the mesh before plotting."<<std::endl;
   }
   dirty |= MeshGL::DIRTY_FACE | MeshGL::DIRTY_POSITION;
 }
@@ -108,7 +106,6 @@ IGL_INLINE void igl::opengl::ViewerData::set_vertices(const Eigen::MatrixXd& _V)
 
 IGL_INLINE void igl::opengl::ViewerData::set_normals(const Eigen::MatrixXd& N)
 {
-  using namespace std;
   if (N.rows() == V.rows())
   {
     set_face_based(false);
@@ -120,7 +117,7 @@ IGL_INLINE void igl::opengl::ViewerData::set_normals(const Eigen::MatrixXd& N)
     F_normals = N;
   }
   else
-    cerr << "ERROR (set_normals): Please provide a normal per face, per corner or per vertex."<<endl;
+    std::cerr << "ERROR (set_normals): Please provide a normal per face, per corner or per vertex."<<std::endl;
   dirty |= MeshGL::DIRTY_NORMAL;
 }
 
@@ -144,7 +141,6 @@ IGL_INLINE void igl::opengl::ViewerData::copy_options(const ViewerCore &from, co
 
 IGL_INLINE void igl::opengl::ViewerData::set_colors(const Eigen::MatrixXd &C)
 {
-  using namespace std;
   using namespace Eigen;
   // This Gouraud coloring should be deprecated in favor of Phong coloring in
   // set-data
@@ -222,20 +218,19 @@ IGL_INLINE void igl::opengl::ViewerData::set_colors(const Eigen::MatrixXd &C)
     }
   }
   else
-    cerr << "ERROR (set_colors): Please provide a single color, or a color per face or per vertex."<<endl;
+    std::cerr << "ERROR (set_colors): Please provide a single color, or a color per face or per vertex."<<std::endl;
   dirty |= MeshGL::DIRTY_DIFFUSE | MeshGL::DIRTY_SPECULAR | MeshGL::DIRTY_AMBIENT;
 
 }
 
 IGL_INLINE void igl::opengl::ViewerData::set_uv(const Eigen::MatrixXd& UV)
 {
-  using namespace std;
   if (UV.rows() == V.rows())
   {
     V_uv = UV;
   }
   else
-    cerr << "ERROR (set_UV): Please provide uv per vertex."<<endl;;
+    std::cerr << "ERROR (set_UV): Please provide uv per vertex."<<std::endl;;
   dirty |= MeshGL::DIRTY_UV;
 }
 

--- a/include/igl/opengl/create_mesh_vbo.h
+++ b/include/igl/opengl/create_mesh_vbo.h
@@ -25,8 +25,8 @@ namespace igl
     /// @param[out] V_vbo_id  buffer id for vertex positions
     /// @param[out] F_vbo_id  buffer id for face indices
     ///
-    /// \note when using glDrawElements VBOs for V and F using MatrixXd and
-    /// MatrixXi will have types GL_DOUBLE and GL_UNSIGNED_INT respectively
+    /// \note when using glDrawElements VBOs for V and F using Eigen::MatrixXd and
+    /// Eigen::MatrixXi will have types GL_DOUBLE and GL_UNSIGNED_INT respectively
     ///
     IGL_INLINE void create_mesh_vbo(
       const Eigen::MatrixXd & V,

--- a/include/igl/opengl/create_shader_program.cpp
+++ b/include/igl/opengl/create_shader_program.cpp
@@ -19,12 +19,11 @@ IGL_INLINE bool igl::opengl::create_shader_program(
   const std::map<std::string,GLuint> & attrib,
   GLuint & id)
 {
-  using namespace std;
   if(vert_source == "" && frag_source == "")
   {
-    cerr<<
+    std::cerr<<
       "create_shader_program() could not create shader program,"
-      " both .vert and .frag source given were empty"<<endl;
+      " both .vert and .frag source given were empty"<<std::endl;
     return false;
   }
 
@@ -32,7 +31,7 @@ IGL_INLINE bool igl::opengl::create_shader_program(
   id = glCreateProgram();
   if(id == 0)
   {
-    cerr<<"create_shader_program() could not create shader program."<<endl;
+    std::cerr<<"create_shader_program() could not create shader program."<<std::endl;
     return false;
   }
   GLuint g = 0,f = 0,v = 0;
@@ -43,7 +42,7 @@ IGL_INLINE bool igl::opengl::create_shader_program(
     g = igl::opengl::load_shader(geom_source.c_str(),GL_GEOMETRY_SHADER);
     if(g == 0)
     {
-      cerr<<"geometry shader failed to compile."<<endl;
+      std::cerr<<"geometry shader failed to compile."<<std::endl;
       return false;
     }
     glAttachShader(id,g);
@@ -55,7 +54,7 @@ IGL_INLINE bool igl::opengl::create_shader_program(
     v = igl::opengl::load_shader(vert_source.c_str(),GL_VERTEX_SHADER);
     if(v == 0)
     {
-      cerr<<"vertex shader failed to compile."<<endl;
+      std::cerr<<"vertex shader failed to compile."<<std::endl;
       return false;
     }
     glAttachShader(id,v);
@@ -67,7 +66,7 @@ IGL_INLINE bool igl::opengl::create_shader_program(
     f = igl::opengl::load_shader(frag_source.c_str(),GL_FRAGMENT_SHADER);
     if(f == 0)
     {
-      cerr<<"fragment shader failed to compile."<<endl;
+      std::cerr<<"fragment shader failed to compile."<<std::endl;
       return false;
     }
     glAttachShader(id,f);

--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -106,7 +106,6 @@ static void glfw_mouse_move(GLFWwindow* /*window*/ , double x, double y)
 
 static void glfw_mouse_scroll(GLFWwindow* /*window*/ , double x, double y)
 {
-  using namespace std;
   scroll_x += x;
   scroll_y += y;
 
@@ -919,7 +918,6 @@ namespace glfw
 
   IGL_INLINE void Viewer::draw()
   {
-    using namespace std;
     using namespace Eigen;
 
     int width, height;

--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -918,8 +918,6 @@ namespace glfw
 
   IGL_INLINE void Viewer::draw()
   {
-    using namespace Eigen;
-
     int width, height;
     glfwGetFramebufferSize(window, &width, &height);
 

--- a/include/igl/opengl/init_render_to_texture.cpp
+++ b/include/igl/opengl/init_render_to_texture.cpp
@@ -17,7 +17,6 @@ IGL_INLINE void igl::opengl::init_render_to_texture(
   GLuint & fbo_id,
   GLuint & d_id)
 {
-  using namespace std;
   // http://www.opengl.org/wiki/Framebuffer_Object_Examples#Quick_example.2C_render_to_texture_.282D.29
   const auto & gen_tex = [](GLuint & tex_id)
   {

--- a/include/igl/orient_outward.cpp
+++ b/include/igl/orient_outward.cpp
@@ -25,7 +25,6 @@ IGL_INLINE void igl::orient_outward(
   Eigen::PlainObjectBase<DerivedFF> & FF,
   Eigen::PlainObjectBase<DerivedI> & I)
 {
-  using namespace Eigen;
   assert(C.rows() == F.rows());
   assert(F.cols() == 3);
   assert(V.cols() == 3);
@@ -40,9 +39,9 @@ IGL_INLINE void igl::orient_outward(
     FF = F;
   }
   PlainMatrix<DerivedV,Eigen::Dynamic,Eigen::Dynamic> N,BC,BCmean;
-  Matrix<typename DerivedV::Scalar,Dynamic,1> A;
-  VectorXd totA(num_cc), dot(num_cc);
-  Matrix<typename DerivedV::Scalar,3,1> Z(1,1,1);
+  Eigen::Matrix<typename DerivedV::Scalar ,Eigen::Dynamic,1> A;
+  Eigen::VectorXd totA(num_cc), dot(num_cc);
+  Eigen::Matrix<typename DerivedV::Scalar,3,1> Z(1,1,1);
   per_face_normals(V,F,Z.normalized(),N);
   barycenter(V,F,BC);
   doublearea(V,F,A);

--- a/include/igl/orient_outward.cpp
+++ b/include/igl/orient_outward.cpp
@@ -26,7 +26,6 @@ IGL_INLINE void igl::orient_outward(
   Eigen::PlainObjectBase<DerivedI> & I)
 {
   using namespace Eigen;
-  using namespace std;
   assert(C.rows() == F.rows());
   assert(F.cols() == 3);
   assert(V.cols() == 3);

--- a/include/igl/orientable_patches.cpp
+++ b/include/igl/orientable_patches.cpp
@@ -19,7 +19,6 @@ IGL_INLINE void igl::orientable_patches(
   Eigen::SparseMatrix<AScalar> & A)
 {
   using namespace Eigen;
-  using namespace std;
 
   // simplex size
   assert(F.cols() == 3);
@@ -41,7 +40,7 @@ IGL_INLINE void igl::orientable_patches(
   // so that sortallE(i,:) = uE(IC(i),:)
   unique_rows(sortallE,uE,IA,IC);
   // uE2FT(e,f) = 1 means face f is adjacent to unique edge e
-  vector<Triplet<AScalar> > uE2FTijv(IC.rows());
+  std::vector<Triplet<AScalar> > uE2FTijv(IC.rows());
   for(int e = 0;e<IC.rows();e++)
   {
     uE2FTijv[e] = Triplet<AScalar>(e%F.rows(),IC(e),1);

--- a/include/igl/orientable_patches.cpp
+++ b/include/igl/orientable_patches.cpp
@@ -18,16 +18,14 @@ IGL_INLINE void igl::orientable_patches(
   Eigen::PlainObjectBase<DerivedC> & C,
   Eigen::SparseMatrix<AScalar> & A)
 {
-  using namespace Eigen;
-
   // simplex size
   assert(F.cols() == 3);
 
   // List of all "half"-edges: 3*#F by 2
-  Matrix<typename DerivedF::Scalar, Dynamic, 2> allE,sortallE,uE;
+  Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, 2> allE,sortallE,uE;
   allE.resize(F.rows()*3,2);
-  Matrix<typename DerivedF::Scalar,Dynamic,2> IX;
-  VectorXi IA,IC;
+  Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,2> IX;
+  Eigen::VectorXi IA,IC;
   allE.block(0*F.rows(),0,F.rows(),1) = F.col(1);
   allE.block(0*F.rows(),1,F.rows(),1) = F.col(2);
   allE.block(1*F.rows(),0,F.rows(),1) = F.col(2);
@@ -40,39 +38,39 @@ IGL_INLINE void igl::orientable_patches(
   // so that sortallE(i,:) = uE(IC(i),:)
   unique_rows(sortallE,uE,IA,IC);
   // uE2FT(e,f) = 1 means face f is adjacent to unique edge e
-  std::vector<Triplet<AScalar> > uE2FTijv(IC.rows());
+  std::vector<Eigen::Triplet<AScalar> > uE2FTijv(IC.rows());
   for(int e = 0;e<IC.rows();e++)
   {
-    uE2FTijv[e] = Triplet<AScalar>(e%F.rows(),IC(e),1);
+    uE2FTijv[e] = Eigen::Triplet<AScalar>(e%F.rows(),IC(e),1);
   }
-  SparseMatrix<AScalar> uE2FT(F.rows(),uE.rows());
+  Eigen::SparseMatrix<AScalar> uE2FT(F.rows(),uE.rows());
   uE2FT.setFromTriplets(uE2FTijv.begin(),uE2FTijv.end());
   // kill non-manifold edges
   for(int j=0; j<(int)uE2FT.outerSize();j++)
   {
     int degree = 0;
-    for(typename SparseMatrix<AScalar>::InnerIterator it (uE2FT,j); it; ++it)
+    for(typename Eigen::SparseMatrix<AScalar>::InnerIterator it (uE2FT,j); it; ++it)
     {
       degree++;
     }
     // Iterate over inside
     if(degree > 2)
     {
-      for(typename SparseMatrix<AScalar>::InnerIterator it (uE2FT,j); it; ++it)
+      for(typename Eigen::SparseMatrix<AScalar>::InnerIterator it (uE2FT,j); it; ++it)
       {
         uE2FT.coeffRef(it.row(),it.col()) = 0;
       }
     }
   }
   // Face-face Adjacency matrix
-  SparseMatrix<AScalar> uE2F;
+  Eigen::SparseMatrix<AScalar> uE2F;
   uE2F = uE2FT.transpose().eval();
   A = uE2FT*uE2F;
   // All ones
   for(int j=0; j<A.outerSize();j++)
   {
     // Iterate over inside
-    for(typename SparseMatrix<AScalar>::InnerIterator it (A,j); it; ++it)
+    for(typename Eigen::SparseMatrix<AScalar>::InnerIterator it (A,j); it; ++it)
     {
       if(it.value() > 1)
       {

--- a/include/igl/parallel_for.h
+++ b/include/igl/parallel_for.h
@@ -125,7 +125,6 @@ inline bool igl::parallel_for(
   const FunctionType & func,
   const size_t min_parallel)
 {
-  using namespace std;
   // no op preparation/accumulation
   const auto & no_op = [](const size_t /*n/t*/){};
   // two-parameter wrapper ignoring thread id

--- a/include/igl/path_to_executable.cpp
+++ b/include/igl/path_to_executable.cpp
@@ -19,7 +19,6 @@
 IGL_INLINE std::string igl::path_to_executable()
 {
   // http://pastebin.com/ffzzxPzi
-  using namespace std;
   std::string path;
   char buffer[1024];
   std::uint32_t size = sizeof(buffer);

--- a/include/igl/per_edge_normals.cpp
+++ b/include/igl/per_edge_normals.cpp
@@ -32,15 +32,14 @@ IGL_INLINE void igl::per_edge_normals(
   static_assert(
     (DerivedEMAP::RowsAtCompileTime == 1 || DerivedEMAP::ColsAtCompileTime == 1) ,
     "EMAP need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
-  using namespace Eigen;
   assert(F.cols() == 3 && "Faces must be triangles");
   // number of faces
   const int m = F.rows();
   // All occurrences of directed edges
-  Matrix<typename DerivedF::Scalar, Dynamic, Dynamic> allE;
+  Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, Eigen::Dynamic> allE;
   oriented_facets(F,allE);
   // Find unique undirected edges and mapping
-  Matrix<typename DerivedF::Scalar, Dynamic, 1> _;
+  Eigen::Matrix<typename DerivedF::Scalar, Eigen::Dynamic, 1> _;
   unique_simplices(allE,E,_,EMAP);
   // now sort(allE,2) == E(EMAP,:), that is, if EMAP(i) = j, then E.row(j) is
   // the undirected edge corresponding to the directed edge allE.row(i).

--- a/include/igl/per_edge_normals.cpp
+++ b/include/igl/per_edge_normals.cpp
@@ -33,7 +33,6 @@ IGL_INLINE void igl::per_edge_normals(
     (DerivedEMAP::RowsAtCompileTime == 1 || DerivedEMAP::ColsAtCompileTime == 1) ,
     "EMAP need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
   using namespace Eigen;
-  using namespace std;
   assert(F.cols() == 3 && "Faces must be triangles");
   // number of faces
   const int m = F.rows();

--- a/include/igl/per_vertex_normals.cpp
+++ b/include/igl/per_vertex_normals.cpp
@@ -45,7 +45,6 @@ IGL_INLINE void igl::per_vertex_normals(
   const Eigen::MatrixBase<DerivedFN>& FN,
   Eigen::PlainObjectBase<DerivedN> & N)
 {
-  using namespace std;
   // Resize for output
   N.setZero(V.rows(),3);
 

--- a/include/igl/per_vertex_point_to_plane_quadrics.cpp
+++ b/include/igl/per_vertex_point_to_plane_quadrics.cpp
@@ -21,7 +21,6 @@ IGL_INLINE void igl::per_vertex_point_to_plane_quadrics(
   std::vector<
     std::tuple<Eigen::MatrixXd,Eigen::RowVectorXd,double> > & quadrics)
 {
-  using namespace std;
   typedef std::tuple<Eigen::MatrixXd,Eigen::RowVectorXd,double> Quadric;
   const int dim = V.cols();
   //// Quadrics per face

--- a/include/igl/polar_dec.cpp
+++ b/include/igl/polar_dec.cpp
@@ -34,7 +34,6 @@ IGL_INLINE void igl::polar_dec(
   Eigen::PlainObjectBase<DerivedS> & S,
   Eigen::PlainObjectBase<DerivedV> & V)
 {
-  using namespace std;
   using namespace Eigen;
   typedef typename DerivedA::Scalar Scalar;
 
@@ -45,7 +44,7 @@ IGL_INLINE void igl::polar_dec(
   eig.computeDirect(A.transpose()*A);
   if(fetestexcept(FE_UNDERFLOW) || eig.eigenvalues()(0)/eig.eigenvalues()(2)<th)
   {
-    cout<<"resorting to svd 1..."<<endl;
+    std::cout<<"resorting to svd 1..."<<std::endl;
     return polar_svd(A,includeReflections,R,T,U,S,V);
   }
 
@@ -72,7 +71,7 @@ IGL_INLINE void igl::polar_dec(
 
   if(std::fabs(R.squaredNorm()-3.) > th)
   {
-    cout<<"resorting to svd 2..."<<endl;
+    std::cout<<"resorting to svd 2..."<<std::endl;
     return polar_svd(A,includeReflections,R,T,U,S,V);
   }
 }

--- a/include/igl/polar_dec.cpp
+++ b/include/igl/polar_dec.cpp
@@ -34,7 +34,6 @@ IGL_INLINE void igl::polar_dec(
   Eigen::PlainObjectBase<DerivedS> & S,
   Eigen::PlainObjectBase<DerivedV> & V)
 {
-  using namespace Eigen;
   typedef typename DerivedA::Scalar Scalar;
 
   const Scalar th = std::sqrt(Eigen::NumTraits<Scalar>::dummy_precision());

--- a/include/igl/polar_svd.cpp
+++ b/include/igl/polar_svd.cpp
@@ -48,8 +48,7 @@ IGL_INLINE void igl::polar_svd(
   Eigen::PlainObjectBase<DerivedS> & S,
   Eigen::PlainObjectBase<DerivedV> & V)
 {
-  using namespace std;
-  typedef 
+  typedef
     Eigen::Matrix<typename DerivedA::Scalar,
     DerivedA::RowsAtCompileTime,
     DerivedA::ColsAtCompileTime>

--- a/include/igl/predicates/polygons_to_triangles.cpp
+++ b/include/igl/predicates/polygons_to_triangles.cpp
@@ -119,9 +119,9 @@ IGL_INLINE void igl::predicates::polygons_to_triangles(
         //  igl::edge_lengths(pV,pF,pl);
 
         //  typedef Eigen::Matrix<Index,Eigen::Dynamic,2> MatrixX2I;
-        //  typedef Eigen::Matrix<Index,Eigen::Dynamic,1> VectorXI;
+        //  typedef Eigen::Matrix<Index,Eigen::Dynamic,1> Eigen::VectorXi;
         //  MatrixX2I E,uE;
-        //  VectorXI EMAP;
+        //  Eigen::VectorXi EMAP;
         //  std::vector<std::vector<Index> > uE2E;
         //  igl::unique_edge_map(pF, E, uE, EMAP, uE2E);
         //  typedef Index Index;

--- a/include/igl/principal_curvature.cpp
+++ b/include/igl/principal_curvature.cpp
@@ -742,7 +742,6 @@ IGL_INLINE void CurvatureCalculator::computeCurvature()
 
 IGL_INLINE void CurvatureCalculator::printCurvature(const std::string& outpath)
 {
-  using namespace std;
   if (!curvatureComputed)
     return;
 
@@ -756,11 +755,11 @@ IGL_INLINE void CurvatureCalculator::printCurvature(const std::string& outpath)
   }
 
   int vertices_count=vertices.rows();
-  of << vertices_count << endl;
+  of << vertices_count << std::endl;
   for (int i=0; i<vertices_count; ++i)
   {
     of << curv[i][0] << " " << curv[i][1] << " " << curvDir[i][0][0] << " " << curvDir[i][0][1] << " " << curvDir[i][0][2] << " " <<
-    curvDir[i][1][0] << " " << curvDir[i][1][1] << " " << curvDir[i][1][2] << endl;
+    curvDir[i][1][0] << " " << curvDir[i][1][1] << " " << curvDir[i][1][2] << std::endl;
   }
 
   of.close();

--- a/include/igl/principal_curvature.h
+++ b/include/igl/principal_curvature.h
@@ -21,8 +21,8 @@
 namespace igl
 {
   /// Compute the principal curvature directions and magnitude of the given triangle mesh
-  ///   DerivedV derived from vertex positions matrix type: i.e. MatrixXd
-  ///   DerivedF derived from face indices matrix type: i.e. MatrixXi
+  ///   DerivedV derived from vertex positions matrix type: i.e. Eigen::MatrixXd
+  ///   DerivedF derived from face indices matrix type: i.e. Eigen::MatrixXi
   /// @param[in] V       eigen matrix #V by 3
   /// @param[in] F       #F by 3 list of mesh faces (must be triangles)
   /// @param[out] PD1 #V by 3 maximal curvature direction for each vertex.

--- a/include/igl/print_vector.cpp
+++ b/include/igl/print_vector.cpp
@@ -13,7 +13,6 @@
 template <typename T>
 IGL_INLINE void igl::print_vector( std::vector<T>& v)
 {
-  using namespace std;
   for (int i=0; i<v.size(); ++i)
     std::cerr << v[i] << " ";
   std::cerr << std::endl;
@@ -22,7 +21,6 @@ IGL_INLINE void igl::print_vector( std::vector<T>& v)
 template <typename T>
 IGL_INLINE void igl::print_vector( std::vector< std::vector<T> >& v)
 {
-  using namespace std;
   for (int i=0; i<v.size(); ++i)
   {
     std::cerr << i << ": ";
@@ -36,7 +34,6 @@ IGL_INLINE void igl::print_vector( std::vector< std::vector<T> >& v)
 template <typename T>
 IGL_INLINE void igl::print_vector( std::vector< std::vector< std::vector<T> > >& v)
 {
-  using namespace std;
   for (int m=0; m<v.size(); ++m)
   {
     std::cerr << "Matrix " << m << std::endl;

--- a/include/igl/procrustes.cpp
+++ b/include/igl/procrustes.cpp
@@ -23,21 +23,20 @@ IGL_INLINE void igl::procrustes(
     Eigen::PlainObjectBase<DerivedR>& R,
     Eigen::PlainObjectBase<DerivedT>& t)
 {
-  using namespace Eigen;
   assert (X.rows() == Y.rows() && "Same number of points");
   assert(X.cols() == Y.cols() && "Points have same dimensions");
 
   // Center data
-  const Matrix<typename DerivedX::Scalar, Dynamic, 1> Xmean = X.colwise().mean();
-  const Matrix<typename DerivedY::Scalar, Dynamic, 1> Ymean = Y.colwise().mean();
-  Matrix<typename DerivedX::Scalar, Dynamic, Dynamic> XC
+  const Eigen::Matrix<typename DerivedX::Scalar, Eigen::Dynamic, 1> Xmean = X.colwise().mean();
+  const Eigen::Matrix<typename DerivedY::Scalar, Eigen::Dynamic, 1> Ymean = Y.colwise().mean();
+  Eigen::Matrix<typename DerivedX::Scalar, Eigen::Dynamic, Eigen::Dynamic> XC
       = X.rowwise() - Xmean.transpose();
-  Matrix<typename DerivedY::Scalar, Dynamic, Dynamic> YC
+  Eigen::Matrix<typename DerivedY::Scalar, Eigen::Dynamic, Eigen::Dynamic> YC
       = Y.rowwise() - Ymean.transpose();
 
   // Rotation
-  Matrix<typename DerivedX::Scalar, Dynamic, Dynamic> S = XC.transpose() * YC;
-  Matrix<typename DerivedT::Scalar, Dynamic, Dynamic> T;
+  Eigen::Matrix<typename DerivedX::Scalar, Eigen::Dynamic, Eigen::Dynamic> S = XC.transpose() * YC;
+  Eigen::Matrix<typename DerivedT::Scalar, Eigen::Dynamic, Eigen::Dynamic> T;
   polar_dec(S, includeReflections, R, T);
 
   // Scale
@@ -65,14 +64,13 @@ IGL_INLINE void igl::procrustes(
     const bool includeReflections,
     Eigen::Transform<Scalar,DIM,TType>& T)
 {
-  using namespace Eigen;
   double scale;
-  MatrixXd R;
-  VectorXd t;
+  Eigen::MatrixXd R;
+  Eigen::VectorXd t;
   procrustes(X,Y,includeScaling,includeReflections,scale,R,t);
 
   // Combine
-  T = Translation<Scalar,DIM>(t) * R * Scaling(scale);
+  T = Eigen::Translation<Scalar,DIM>(t) * R * Eigen::Scaling(scale);
 }
 
 template <
@@ -118,9 +116,8 @@ IGL_INLINE void igl::procrustes(
     Eigen::Rotation2D<Scalar>& R,
     Eigen::PlainObjectBase<DerivedT>& t)
 {
-  using namespace Eigen;
   assert (X.cols() == 2 && Y.cols() == 2 && "Points must have dimension 2");
-  Matrix2d Rmat;
+  Eigen::Matrix2d Rmat;
   procrustes(X,Y,false,false,Rmat,t);
   R.fromRotationMatrix(Rmat);
 }

--- a/include/igl/procrustes.h
+++ b/include/igl/procrustes.h
@@ -33,13 +33,13 @@ namespace igl
   /// #### Example
   ///
   /// \code{cpp}
-  ///     MatrixXd X, Y; (containing 3d points as rows)
+  ///     Eigen::MatrixXd X, Y; (containing 3d points as rows)
   ///     double scale;
-  ///     MatrixXd R;
-  ///     VectorXd t;
+  ///     Eigen::MatrixXd R;
+  ///     Eigen::VectorXd t;
   ///     igl::procrustes(X,Y,true,false,scale,R,t);
   ///     R *= scale;
-  ///     MatrixXd Xprime = (X * R).rowwise() + t.transpose();
+  ///     Eigen::MatrixXd Xprime = (X * R).rowwise() + t.transpose();
   /// \endcode
   ///
   template <
@@ -63,10 +63,10 @@ namespace igl
   ///
   /// #### Example
   /// \code{cpp}
-  ///      MatrixXd X, Y; (containing 3d points as rows)
+  ///      Eigen::MatrixXd X, Y; (containing 3d points as rows)
   ///      AffineCompact3d T;
   ///      igl::procrustes(X,Y,true,false,T);
-  ///      MatrixXd Xprime = (X * T.linear()).rowwise() + T.translation().transpose();
+  ///      Eigen::MatrixXd Xprime = (X * T.linear()).rowwise() + T.translation().transpose();
   /// \endcode
   template <
     typename DerivedX, 

--- a/include/igl/project_isometrically_to_plane.cpp
+++ b/include/igl/project_isometrically_to_plane.cpp
@@ -21,7 +21,6 @@ IGL_INLINE void igl::project_isometrically_to_plane(
   Eigen::PlainObjectBase<DerivedUF> & UF,
   Eigen::SparseMatrix<Scalar>& I)
 {
-  using namespace std;
   using namespace Eigen;
   assert(F.cols() == 3 && "F should contain triangles");
   typedef Eigen::Matrix<typename DerivedV::Scalar, Eigen::Dynamic, Eigen::Dynamic> MatrixX;
@@ -43,7 +42,7 @@ IGL_INLINE void igl::project_isometrically_to_plane(
     (l.col(1).array().square()-U.block(m*2,0,m,1).array().square()).sqrt();
 
   typedef Triplet<Scalar> IJV;
-  vector<IJV > ijv;
+  std::vector<IJV > ijv;
   ijv.reserve(3*m);
   UF.resize(m,3);
   for(int f = 0;f<m;f++)

--- a/include/igl/project_isometrically_to_plane.cpp
+++ b/include/igl/project_isometrically_to_plane.cpp
@@ -21,7 +21,6 @@ IGL_INLINE void igl::project_isometrically_to_plane(
   Eigen::PlainObjectBase<DerivedUF> & UF,
   Eigen::SparseMatrix<Scalar>& I)
 {
-  using namespace Eigen;
   assert(F.cols() == 3 && "F should contain triangles");
   typedef Eigen::Matrix<typename DerivedV::Scalar, Eigen::Dynamic, Eigen::Dynamic> MatrixX;
   MatrixX l;
@@ -41,7 +40,7 @@ IGL_INLINE void igl::project_isometrically_to_plane(
   U.block(m*2,1,m,1) =
     (l.col(1).array().square()-U.block(m*2,0,m,1).array().square()).sqrt();
 
-  typedef Triplet<Scalar> IJV;
+  typedef Eigen::Triplet<Scalar> IJV;
   std::vector<IJV > ijv;
   ijv.reserve(3*m);
   UF.resize(m,3);

--- a/include/igl/pseudonormal_test.cpp
+++ b/include/igl/pseudonormal_test.cpp
@@ -47,7 +47,6 @@ IGL_INLINE void igl::pseudonormal_test(
   static_assert(
       Derivedn::ColsAtCompileTime*Derivedn::RowsAtCompileTime == 3 || 
       Derivedn::ColsAtCompileTime*Derivedn::RowsAtCompileTime == Eigen::Dynamic,"q must be size 3 or Dynamic");
-  using namespace Eigen;
   const auto & qc = q-c;
   typedef Eigen::Matrix<Scalar,1,3> RowVector3S;
   RowVector3S b;
@@ -62,7 +61,7 @@ IGL_INLINE void igl::pseudonormal_test(
 
   const double area = [&A,&B,&C]()
   {
-    Matrix<double,1,1> area;
+    Eigen::Matrix<double,1,1> area;
     doublearea(A,B,C,area);
     return area(0);
   }();
@@ -124,8 +123,8 @@ IGL_INLINE void igl::pseudonormal_test(
     {
       const RowVector3S s = V.row(F(f,(e+1)%3));
       const RowVector3S d = V.row(F(f,(e+2)%3));
-      Matrix<double,1,1> sqr_d_j_x(1,1);
-      Matrix<double,1,1> t(1,1);
+      Eigen::Matrix<double,1,1> sqr_d_j_x(1,1);
+      Eigen::Matrix<double,1,1> t(1,1);
       project_to_line_segment(c,s,d,t,sqr_d_j_x);
       if(sqrt(sqr_d_j_x(0)) < epsilon)
       {
@@ -162,7 +161,6 @@ IGL_INLINE void igl::pseudonormal_test(
   Scalar & s,
   Eigen::PlainObjectBase<Derivedn> & n)
 {
-  using namespace Eigen;
   static_assert(DerivedV::ColsAtCompileTime == 2 || DerivedV::ColsAtCompileTime == Eigen::Dynamic,"V must either have 2 or Dynamic columns");
   static_assert(DerivedEN::ColsAtCompileTime == 2 || DerivedEN::ColsAtCompileTime == Eigen::Dynamic,"EN must either have 2 or Dynamic columns");
   static_assert(DerivedVN::ColsAtCompileTime == 2 || DerivedVN::ColsAtCompileTime == Eigen::Dynamic,"VN must either have 2 or Dynamic columns");

--- a/include/igl/random_dir.cpp
+++ b/include/igl/random_dir.cpp
@@ -11,21 +11,19 @@
 
 IGL_INLINE Eigen::Vector3d igl::random_dir()
 {
-  using namespace Eigen;
   double z =  (double)rand() / (double)RAND_MAX*2.0 - 1.0;
   double t =  (double)rand() / (double)RAND_MAX*2.0*PI;
   // http://www.altdevblogaday.com/2012/05/03/generating-uniformly-distributed-points-on-sphere/
   double r = sqrt(1.0-z*z);
   double x = r * cos(t);
   double y = r * sin(t);
-  return Vector3d(x,y,z);
+  return Eigen::Vector3d(x,y,z);
 }
 
 IGL_INLINE Eigen::MatrixXd igl::random_dir_stratified(const int n)
 {
-  using namespace Eigen;
   const double m = std::floor(sqrt(double(n)));
-  MatrixXd N(n,3);
+  Eigen::MatrixXd N(n,3);
   int row = 0;
   for(int i = 0;i<m;i++)
   {

--- a/include/igl/random_dir.cpp
+++ b/include/igl/random_dir.cpp
@@ -24,7 +24,6 @@ IGL_INLINE Eigen::Vector3d igl::random_dir()
 IGL_INLINE Eigen::MatrixXd igl::random_dir_stratified(const int n)
 {
   using namespace Eigen;
-  using namespace std;
   const double m = std::floor(sqrt(double(n)));
   MatrixXd N(n,3);
   int row = 0;

--- a/include/igl/random_points_on_mesh.cpp
+++ b/include/igl/random_points_on_mesh.cpp
@@ -26,9 +26,8 @@ IGL_INLINE void igl::random_points_on_mesh(
   Eigen::PlainObjectBase<DerivedX> & X,
   URBG && urbg)
 {
-  using namespace Eigen;
   typedef typename DerivedV::Scalar Scalar;
-  typedef Matrix<Scalar,Dynamic,1> VectorXs;
+  typedef Eigen::Matrix<Scalar ,Eigen::Dynamic,1> VectorXs;
   VectorXs dblA;
   doublearea(V,F,dblA);
   random_points_on_mesh_intrinsic(n,dblA,B,FI,urbg);

--- a/include/igl/random_points_on_mesh.cpp
+++ b/include/igl/random_points_on_mesh.cpp
@@ -27,7 +27,6 @@ IGL_INLINE void igl::random_points_on_mesh(
   URBG && urbg)
 {
   using namespace Eigen;
-  using namespace std;
   typedef typename DerivedV::Scalar Scalar;
   typedef Matrix<Scalar,Dynamic,1> VectorXs;
   VectorXs dblA;

--- a/include/igl/random_points_on_mesh_intrinsic.cpp
+++ b/include/igl/random_points_on_mesh_intrinsic.cpp
@@ -16,9 +16,8 @@ IGL_INLINE void igl::random_points_on_mesh_intrinsic(
   Eigen::PlainObjectBase<DerivedFI > & FI,
   URBG && urbg)
 {
-  using namespace Eigen;
   typedef typename DeriveddblA::Scalar Scalar;
-  typedef Matrix<Scalar,Dynamic,1> VectorXs;
+  typedef Eigen::Matrix<Scalar ,Eigen::Dynamic,1> VectorXs;
   VectorXs C;
   VectorXs A0(dblA.size()+1);
   A0(0) = 0;
@@ -60,12 +59,11 @@ IGL_INLINE void igl::random_points_on_mesh_intrinsic(
   Eigen::PlainObjectBase<DerivedFI > & FI,
   URBG && urbg)
 {
-  using namespace Eigen;
-  Matrix<ScalarB,Dynamic,3> BC;
+  Eigen::Matrix<ScalarB ,Eigen::Dynamic,3> BC;
   // Should be traingle mesh. Although Turk's method 1 generalizes...
   assert(F.cols() == 3);
   random_points_on_mesh_intrinsic(n,dblA,BC,FI,urbg);
-  std::vector<Triplet<ScalarB> > BIJV;
+  std::vector<Eigen::Triplet<ScalarB> > BIJV;
   BIJV.reserve(n*3);
   for(int s = 0;s<n;s++)
   {
@@ -74,7 +72,7 @@ IGL_INLINE void igl::random_points_on_mesh_intrinsic(
       assert(FI(s) < dblA.rows());
       assert(FI(s) >= 0);
       const int v = F(FI(s),c);
-      BIJV.push_back(Triplet<ScalarB>(s,v,BC(s,c)));
+      BIJV.push_back(Eigen::Triplet<ScalarB>(s,v,BC(s,c)));
     }
   }
   B.resize(n,num_vertices);

--- a/include/igl/random_points_on_mesh_intrinsic.cpp
+++ b/include/igl/random_points_on_mesh_intrinsic.cpp
@@ -17,7 +17,6 @@ IGL_INLINE void igl::random_points_on_mesh_intrinsic(
   URBG && urbg)
 {
   using namespace Eigen;
-  using namespace std;
   typedef typename DeriveddblA::Scalar Scalar;
   typedef Matrix<Scalar,Dynamic,1> VectorXs;
   VectorXs C;
@@ -62,12 +61,11 @@ IGL_INLINE void igl::random_points_on_mesh_intrinsic(
   URBG && urbg)
 {
   using namespace Eigen;
-  using namespace std;
   Matrix<ScalarB,Dynamic,3> BC;
   // Should be traingle mesh. Although Turk's method 1 generalizes...
   assert(F.cols() == 3);
   random_points_on_mesh_intrinsic(n,dblA,BC,FI,urbg);
-  vector<Triplet<ScalarB> > BIJV;
+  std::vector<Triplet<ScalarB> > BIJV;
   BIJV.reserve(n*3);
   for(int s = 0;s<n;s++)
   {

--- a/include/igl/ray_box_intersect.cpp
+++ b/include/igl/ray_box_intersect.cpp
@@ -24,8 +24,7 @@ IGL_INLINE bool igl::ray_box_intersect(
   Scalar & tmin,
   Scalar & tmax)
 {
-  using namespace Eigen;
-  typedef Matrix<Scalar,1,3>  RowVector3S;
+  typedef Eigen::Matrix<Scalar,1,3>  RowVector3S;
   const std::array<bool, 3> sign = { inv_dir(0)<0, inv_dir(1)<0, inv_dir(2)<0};
   // http://people.csail.mit.edu/amy/papers/box-jgt.pdf
   // "An Efficient and Robust Ray–Box Intersection Algorithm"

--- a/include/igl/ray_mesh_intersect.cpp
+++ b/include/igl/ray_mesh_intersect.cpp
@@ -26,14 +26,12 @@ IGL_INLINE bool ray_triangle_intersect(
   const int f,
   igl::Hit<typename DerivedV::Scalar> & hit)
 {
-  using namespace Eigen;
-
   // intersect_triangle1 needs non-const inputs.
-  Vector3d s_d = s.template cast<double>();
-  Vector3d dir_d = dir.template cast<double>();
-  RowVector3d v0 = V.row(F(f,0)).template cast<double>();
-  RowVector3d v1 = V.row(F(f,1)).template cast<double>();
-  RowVector3d v2 = V.row(F(f,2)).template cast<double>();
+  Eigen::Vector3d s_d = s.template cast<double>();
+  Eigen::Vector3d dir_d = dir.template cast<double>();
+  Eigen::RowVector3d v0 = V.row(F(f,0)).template cast<double>();
+  Eigen::RowVector3d v1 = V.row(F(f,1)).template cast<double>();
+  Eigen::RowVector3d v2 = V.row(F(f,2)).template cast<double>();
 
   // shoot ray, record hit
   double t,u,v;
@@ -62,8 +60,6 @@ IGL_INLINE bool ray_mesh_intersect(
   const Eigen::MatrixBase<DerivedF> & F,
   std::vector<igl::Hit<typename DerivedV::Scalar> > & hits)
 {
-  using namespace Eigen;
-
   hits.clear();
   hits.reserve(F.rows());
 

--- a/include/igl/readBF.cpp
+++ b/include/igl/readBF.cpp
@@ -65,7 +65,6 @@ IGL_INLINE bool igl::readBF(
   Eigen::PlainObjectBase<DerivedBE> & BE,
   Eigen::PlainObjectBase<DerivedP> & P)
 {
-  using namespace Eigen;
   if(!readBF(filename,WI,bfP,offsets))
   {
     return false;

--- a/include/igl/readBF.cpp
+++ b/include/igl/readBF.cpp
@@ -22,13 +22,12 @@ IGL_INLINE bool igl::readBF(
   Eigen::PlainObjectBase<DerivedP> & P,
   Eigen::PlainObjectBase<DerivedO> & O)
 {
-  using namespace std;
-  ifstream is(filename);
+  std::ifstream is(filename);
   if(!is.is_open())
   {
     return false;
   }
-  string line;
+  std::string line;
   std::vector<typename DerivedWI::Scalar> vWI;
   std::vector<typename DerivedP::Scalar> vP;
   std::vector<std::vector<typename DerivedO::Scalar> > vO;
@@ -67,14 +66,13 @@ IGL_INLINE bool igl::readBF(
   Eigen::PlainObjectBase<DerivedP> & P)
 {
   using namespace Eigen;
-  using namespace std;
   if(!readBF(filename,WI,bfP,offsets))
   {
     return false;
   }
 
   C.resize(WI.rows(),3);
-  vector<bool> computed(C.rows(),false);
+  std::vector<bool> computed(C.rows(),false);
   // better not be cycles in bfP
   std::function<Eigen::RowVector3d(const int)> locate_tip;
   locate_tip = 

--- a/include/igl/readCSV.cpp
+++ b/include/igl/readCSV.cpp
@@ -19,8 +19,6 @@ IGL_INLINE bool igl::readCSV(
   const std::string str, 
   Eigen::Matrix<Scalar,Eigen::Dynamic,Eigen::Dynamic>& M)
 {
-  using namespace std;
-
   std::vector<std::vector<Scalar> > Mt;
   
   std::ifstream infile(str.c_str());
@@ -28,7 +26,7 @@ IGL_INLINE bool igl::readCSV(
   while (std::getline(infile, line))
   {
     std::istringstream iss(line);
-    vector<Scalar> temp;
+    std::vector<Scalar> temp;
     Scalar a;
     char ch;
     while (iss >> a){

--- a/include/igl/readMESH.cpp
+++ b/include/igl/readMESH.cpp
@@ -16,7 +16,6 @@ IGL_INLINE bool igl::readMESH(
   Eigen::PlainObjectBase<DerivedT>& T,
   Eigen::PlainObjectBase<DerivedF>& F)
 {
-  using namespace std;
   FILE * mesh_file = fopen(mesh_file_name.c_str(),"r");
   if(NULL==mesh_file)
   {
@@ -33,7 +32,6 @@ IGL_INLINE bool igl::readMESH(
   Eigen::PlainObjectBase<DerivedT>& T,
   Eigen::PlainObjectBase<DerivedF>& F)
 {
-  using namespace std;
 #ifndef LINE_MAX
 #  define LINE_MAX 2048
 #endif

--- a/include/igl/readNODE.cpp
+++ b/include/igl/readNODE.cpp
@@ -35,7 +35,6 @@ IGL_INLINE bool igl::readNODE(
   Eigen::PlainObjectBase<DerivedV>& V,
   Eigen::PlainObjectBase<DerivedI>& I)
 {
-  using namespace std;
   FILE * node_file = fopen(node_file_name.c_str(),"r");
   if(NULL==node_file)
   {

--- a/include/igl/readOFF.cpp
+++ b/include/igl/readOFF.cpp
@@ -16,7 +16,6 @@ IGL_INLINE bool igl::readOFF(
   std::vector<std::vector<Scalar > > & N,
   std::vector<std::vector<Scalar > > & C)
 {
-  using namespace std;
   FILE * off_file = fopen(off_file_name.c_str(),"r");
   if(NULL==off_file)
   {
@@ -34,7 +33,6 @@ IGL_INLINE bool igl::readOFF(
   std::vector<std::vector<Scalar > > & N,
   std::vector<std::vector<Scalar > > & C)
 {
-  using namespace std;
   V.clear();
   F.clear();
   N.clear();
@@ -47,16 +45,16 @@ IGL_INLINE bool igl::readOFF(
   const std::string COFF("COFF");
   if(fscanf(off_file,"%s\n",header)!=1
      || !(
-       string(header).compare(0, OFF.length(), OFF)==0 ||
-       string(header).compare(0, COFF.length(), COFF)==0 ||
-       string(header).compare(0,NOFF.length(),NOFF)==0))
+       std::string(header).compare(0, OFF.length(), OFF)==0 ||
+       std::string(header).compare(0, COFF.length(), COFF)==0 ||
+       std::string(header).compare(0,NOFF.length(),NOFF)==0))
   {
     printf("Error: readOFF() first line should be OFF or NOFF or COFF, not %s...",header);
     fclose(off_file);
     return false;
   }
-  bool has_normals = string(header).compare(0,NOFF.length(),NOFF)==0;
-  bool has_vertexColors = string(header).compare(0,COFF.length(),COFF)==0;
+  bool has_normals = std::string(header).compare(0,NOFF.length(),NOFF)==0;
+  bool has_vertexColors = std::string(header).compare(0,COFF.length(),COFF)==0;
   // Second line is #vertices #faces #edges
   int number_of_vertices;
   int number_of_faces;

--- a/include/igl/readTGF.cpp
+++ b/include/igl/readTGF.cpp
@@ -18,7 +18,6 @@ IGL_INLINE bool igl::readTGF(
   std::vector<std::vector<int> > & CE,
   std::vector<std::vector<int> > & PE)
 {
-  using namespace std;
   // clear output
   C.clear();
   E.clear();
@@ -56,7 +55,7 @@ IGL_INLINE bool igl::readTGF(
     }else if(reading_vertices)
     {
       int index;
-      vector<double> position(3);
+      std::vector<double> position(3);
       int count = 
         sscanf(line,"%d %lg %lg %lg",
           &index,
@@ -73,7 +72,7 @@ IGL_INLINE bool igl::readTGF(
       C.push_back(position);
     }else if(reading_edges)
     {
-      vector<int> edge(2);
+      std::vector<int> edge(2);
       int is_BE = 0;
       int is_PE = 0;
       int is_CE = 0;

--- a/include/igl/readWRL.cpp
+++ b/include/igl/readWRL.cpp
@@ -14,7 +14,6 @@ IGL_INLINE bool igl::readWRL(
   std::vector<std::vector<Scalar > > & V,
   std::vector<std::vector<Index > > & F)
 {
-  using namespace std;
   FILE * wrl_file = fopen(wrl_file_name.c_str(),"r");
   if(NULL==wrl_file)
   {
@@ -30,14 +29,12 @@ IGL_INLINE bool igl::readWRL(
   std::vector<std::vector<Scalar > > & V,
   std::vector<std::vector<Index > > & F)
 {
-  using namespace std;
-
   char line[1000];
   // Read lines until seeing "point ["
   // treat other lines in file as "comments"
   bool still_comments = true;
-  string needle("point [");
-  string haystack;
+  std::string needle("point [");
+  std::string haystack;
   while(still_comments)
   {
     if(fgets(line,1000,wrl_file) == NULL)
@@ -46,8 +43,8 @@ IGL_INLINE bool igl::readWRL(
       fclose(wrl_file);
       return false;
     }
-    haystack = string(line);
-    still_comments = string::npos == haystack.find(needle);
+    haystack = std::string(line);
+    still_comments = std::string::npos == haystack.find(needle);
   }
 
   // read points in sets of 3
@@ -58,7 +55,7 @@ IGL_INLINE bool igl::readWRL(
     floats_read = fscanf(wrl_file," %lf %lf %lf,",&x,&y,&z);
     if(floats_read == 3)
     {
-      vector<Scalar > point;
+      std::vector<Scalar > point;
       point.resize(3);
       point[0] = x;
       point[1] = y;
@@ -74,19 +71,19 @@ IGL_INLINE bool igl::readWRL(
   // Read lines until seeing "coordIndex ["
   // treat other lines in file as "comments"
   still_comments = true;
-  needle = string("coordIndex [");
+  needle = std::string("coordIndex [");
   while(still_comments)
   {
     fgets(line,1000,wrl_file);
-    haystack = string(line);
-    still_comments = string::npos == haystack.find(needle);
+    haystack = std::string(line);
+    still_comments = std::string::npos == haystack.find(needle);
   }
   // read F
   int ints_read = 1;
   while(ints_read > 0)
   {
     // read new face indices (until hit -1)
-    vector<Index > face;
+    std::vector<Index > face;
     while(true)
     {
       // indices are 0-indexed

--- a/include/igl/read_triangle_mesh.cpp
+++ b/include/igl/read_triangle_mesh.cpp
@@ -30,14 +30,13 @@ IGL_INLINE bool igl::read_triangle_mesh(
   std::vector<std::vector<Scalar> > & V,
   std::vector<std::vector<Index> > & F)
 {
-  using namespace std;
   // dirname, basename, extension and filename
-  string d,b,e,f;
+  std::string d,b,e,f;
   pathinfo(str,d,b,e,f);
   // Convert extension to lower case
   std::transform(e.begin(), e.end(), e.begin(), ::tolower);
-  vector<vector<Scalar> > TC, N, C;
-  vector<vector<Index> > FTC, FN;
+  std::vector<std::vector<Scalar> > TC, N, C;
+  std::vector<std::vector<Index> > FTC, FN;
   if(e == "obj")
   {
     // Annoyingly obj can store 4 coordinates, truncate to xyz for this generic
@@ -52,8 +51,8 @@ IGL_INLINE bool igl::read_triangle_mesh(
   {
     return readOFF(str,V,F,N,C);
   }
-  cerr<<"Error: "<<__FUNCTION__<<": "<<
-    str<<" is not a recognized mesh file format."<<endl;
+  std::cerr<<"Error: "<<__FUNCTION__<<": "<<
+    str<<" is not a recognized mesh file format."<<std::endl;
   return false;
 }
 
@@ -78,7 +77,6 @@ IGL_INLINE bool igl::read_triangle_mesh(
   std::string & ext,
   std::string & name)
 {
-  using namespace std;
   using namespace Eigen;
 
   // dirname, basename, extension and filename
@@ -124,12 +122,11 @@ IGL_INLINE bool igl::read_triangle_mesh(
   Eigen::PlainObjectBase<DerivedV>& V,
   Eigen::PlainObjectBase<DerivedF>& F)
 {
-  using namespace std;
   using namespace Eigen;
   Eigen::MatrixXd N;
-  vector<vector<double > > vV,vN,vTC,vC;
-  vector<vector<int > > vF,vFTC,vFN;
-  vector<tuple<string, int, int>> FM;
+  std::vector<std::vector<double > > vV,vN,vTC,vC;
+  std::vector<std::vector<int > > vF,vFTC,vFN;
+  std::vector<std::tuple<std::string, int, int>> FM;
 
   if(ext == "mesh")
   {
@@ -179,7 +176,7 @@ IGL_INLINE bool igl::read_triangle_mesh(
     }
   }else
   {
-    cerr<<"Error: unknown extension: "<<ext<<endl;
+    std::cerr<<"Error: unknown extension: "<<ext<<std::endl;
     return false;
   }
   if(vV.size() > 0)

--- a/include/igl/read_triangle_mesh.cpp
+++ b/include/igl/read_triangle_mesh.cpp
@@ -77,8 +77,6 @@ IGL_INLINE bool igl::read_triangle_mesh(
   std::string & ext,
   std::string & name)
 {
-  using namespace Eigen;
-
   // dirname, basename, extension and filename
   pathinfo(filename,dir,base,ext,name);
   // Convert extension to lower case
@@ -122,7 +120,6 @@ IGL_INLINE bool igl::read_triangle_mesh(
   Eigen::PlainObjectBase<DerivedV>& V,
   Eigen::PlainObjectBase<DerivedF>& F)
 {
-  using namespace Eigen;
   Eigen::MatrixXd N;
   std::vector<std::vector<double > > vV,vN,vTC,vC;
   std::vector<std::vector<int > > vF,vFTC,vFN;
@@ -131,7 +128,7 @@ IGL_INLINE bool igl::read_triangle_mesh(
   if(ext == "mesh")
   {
     // Convert extension to lower case
-    MatrixXi T;
+    Eigen::MatrixXi T;
     if(!readMESH(fp,V,T,F))
     {
       return 1;

--- a/include/igl/redux.h
+++ b/include/igl/redux.h
@@ -20,7 +20,7 @@ namespace igl
   ///     to use this to count (implicit) zeros.
   ///  2. This redux is more powerful in the sense that A and B may have
   ///     different types. This makes it possible to count the number of
-  ///     non-zeros in a SparseMatrix<bool> A into a VectorXi B.
+  ///     non-zeros in a Eigen::SparseMatrix<bool> A into a Eigen::VectorXi B.
   ///
   /// @param[in] A  m by n sparse matrix
   /// @param[in] dim  dimension along which to sum (1 or 2)

--- a/include/igl/remove_duplicate_vertices.cpp
+++ b/include/igl/remove_duplicate_vertices.cpp
@@ -65,7 +65,6 @@ IGL_INLINE void igl::remove_duplicate_vertices(
     (DerivedSVJ::RowsAtCompileTime == 1 || DerivedSVJ::ColsAtCompileTime == 1),
     "SVI and SVJ need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
   using namespace Eigen;
-  using namespace std;
   remove_duplicate_vertices(V,epsilon,SV,SVI,SVJ);
   SF.resizeLike(F);
   for(int f = 0;f<F.rows();f++)

--- a/include/igl/remove_duplicate_vertices.cpp
+++ b/include/igl/remove_duplicate_vertices.cpp
@@ -64,7 +64,6 @@ IGL_INLINE void igl::remove_duplicate_vertices(
     (DerivedSVI::RowsAtCompileTime == 1 || DerivedSVI::ColsAtCompileTime == 1) &&
     (DerivedSVJ::RowsAtCompileTime == 1 || DerivedSVJ::ColsAtCompileTime == 1),
     "SVI and SVJ need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
-  using namespace Eigen;
   remove_duplicate_vertices(V,epsilon,SV,SVI,SVJ);
   SF.resizeLike(F);
   for(int f = 0;f<F.rows();f++)

--- a/include/igl/remove_unreferenced.cpp
+++ b/include/igl/remove_unreferenced.cpp
@@ -41,7 +41,6 @@ IGL_INLINE void igl::remove_unreferenced(
   Eigen::PlainObjectBase<DerivedI> &I,
   Eigen::PlainObjectBase<DerivedJ> &J)
 {
-  using namespace std;
   const size_t n = V.rows();
   remove_unreferenced(n,F,I,J);
   NF = F;

--- a/include/igl/repdiag.cpp
+++ b/include/igl/repdiag.cpp
@@ -14,11 +14,10 @@ IGL_INLINE void igl::repdiag(
   const int d,
   Eigen::SparseMatrix<T>& B)
 {
-  using namespace Eigen;
   int m = A.rows();
   int n = A.cols();
 #if false
-  vector<Triplet<T> > IJV;
+  vector<Eigen::Triplet<T> > IJV;
   IJV.reserve(A.nonZeros()*d);
   // Loop outer level
   for (int k=0; k<A.outerSize(); ++k)
@@ -28,7 +27,7 @@ IGL_INLINE void igl::repdiag(
     {
       for(int i = 0;i<d;i++)
       {
-        IJV.push_back(Triplet<T>(i*m+it.row(),i*n+it.col(),it.value()));
+        IJV.push_back(Eigen::Triplet<T>(i*m+it.row(),i*n+it.col(),it.value()));
       }
     }
   }

--- a/include/igl/repdiag.cpp
+++ b/include/igl/repdiag.cpp
@@ -14,7 +14,6 @@ IGL_INLINE void igl::repdiag(
   const int d,
   Eigen::SparseMatrix<T>& B)
 {
-  using namespace std;
   using namespace Eigen;
   int m = A.rows();
   int n = A.cols();

--- a/include/igl/sample_edges.cpp
+++ b/include/igl/sample_edges.cpp
@@ -13,7 +13,6 @@ IGL_INLINE void igl::sample_edges(
   const int k,
   Eigen::MatrixXd & S)
 {
-  using namespace Eigen;
   // Resize output
   S.resize(V.rows() + k * E.rows(),V.cols());
   // Copy V at front of S
@@ -22,8 +21,8 @@ IGL_INLINE void igl::sample_edges(
   // loop over edges
   for(int i = 0;i<E.rows();i++)
   {
-    VectorXd tip = V.row(E(i,0));
-    VectorXd tail = V.row(E(i,1));
+    Eigen::VectorXd tip = V.row(E(i,0));
+    Eigen::VectorXd tail = V.row(E(i,1));
     for(int s=0;s<k;s++)
     {
       double f = double(s+1)/double(k+1);

--- a/include/igl/setdiff.cpp
+++ b/include/igl/setdiff.cpp
@@ -22,7 +22,6 @@ IGL_INLINE void igl::setdiff(
   Eigen::PlainObjectBase<DerivedC> & C,
   Eigen::PlainObjectBase<DerivedIA> & IA)
 {
-  using namespace Eigen;
   // boring base cases
   if(A.size() == 0)
   {
@@ -32,8 +31,8 @@ IGL_INLINE void igl::setdiff(
   }
 
   // Get rid of any duplicates
-  typedef Matrix<typename DerivedA::Scalar,Dynamic,1> VectorA;
-  typedef Matrix<typename DerivedB::Scalar,Dynamic,1> VectorB;
+  typedef Eigen::Matrix<typename DerivedA::Scalar ,Eigen::Dynamic,1> VectorA;
+  typedef Eigen::Matrix<typename DerivedB::Scalar ,Eigen::Dynamic,1> VectorB;
   VectorA uA;
   VectorB uB;
   typedef DerivedIA IAType;

--- a/include/igl/setdiff.cpp
+++ b/include/igl/setdiff.cpp
@@ -23,7 +23,6 @@ IGL_INLINE void igl::setdiff(
   Eigen::PlainObjectBase<DerivedIA> & IA)
 {
   using namespace Eigen;
-  using namespace std;
   // boring base cases
   if(A.size() == 0)
   {
@@ -49,8 +48,8 @@ IGL_INLINE void igl::setdiff(
   sort(uA,1,true,sA,sIA);
   sort(uB,1,true,sB,sIB);
 
-  vector<typename DerivedB::Scalar> vC;
-  vector<typename DerivedIA::Scalar> vIA;
+  std::vector<typename DerivedB::Scalar> vC;
+  std::vector<typename DerivedIA::Scalar> vIA;
   int bi = 0;
   // loop over sA
   bool past = false;

--- a/include/igl/shape_diameter_function.cpp
+++ b/include/igl/shape_diameter_function.cpp
@@ -34,14 +34,13 @@ IGL_INLINE void igl::shape_diameter_function(
   const int num_samples,
   Eigen::PlainObjectBase<DerivedS> & S)
 {
-  using namespace Eigen;
   using Scalar = typename DerivedP::Scalar;
   using Vector3S = Eigen::Matrix<typename DerivedP::Scalar,3,1>;
   const int n = P.rows();
   // Resize output
   S.resize(n,1);
   // Embree seems to be parallel when constructing but not when tracing rays
-  const Matrix<Scalar,Eigen::Dynamic,3> D = random_dir_stratified(num_samples).cast<Scalar>();
+  const Eigen::Matrix<Scalar,Eigen::Dynamic,3> D = random_dir_stratified(num_samples).cast<Scalar>();
 
   const auto & inner = [&P,&N,&num_samples,&D,&S,&shoot_ray](const int p)
   {

--- a/include/igl/shapeup.cpp
+++ b/include/igl/shapeup.cpp
@@ -87,7 +87,6 @@ namespace igl
                                          const Eigen::MatrixBase<Derivedw>& wSmooth,
                                          ShapeupData & sudata)
   {
-      using namespace Eigen;
       sudata.P=P;
       sudata.SC=SC;
       sudata.S=S;
@@ -105,7 +104,7 @@ namespace igl
       sudata.DSmooth.conservativeResize(E.rows(), P.rows());  //smoothness matrix
         
       //Building shape matrix
-      std::vector<Triplet<Scalar> > DShapeTriplets;
+      std::vector<Eigen::Triplet<Scalar> > DShapeTriplets;
       int currRow=0;
       for (int i=0;i<S.rows();i++){
           Scalar avgCoeff=1.0/(Scalar)SC(i);
@@ -113,9 +112,9 @@ namespace igl
           for (int j=0;j<SC(i);j++){
             for (int k=0;k<SC(i);k++){
               if (j==k)
-                DShapeTriplets.push_back(Triplet<Scalar>(currRow+j, S(i,k), (1.0-avgCoeff)));
+                DShapeTriplets.push_back(Eigen::Triplet<Scalar>(currRow+j, S(i,k), (1.0-avgCoeff)));
               else
-                DShapeTriplets.push_back(Triplet<Scalar>(currRow+j, S(i,k), (-avgCoeff)));
+                DShapeTriplets.push_back(Eigen::Triplet<Scalar>(currRow+j, S(i,k), (-avgCoeff)));
             }
           }
         currRow+=SC(i);
@@ -125,39 +124,39 @@ namespace igl
       sudata.DShape.setFromTriplets(DShapeTriplets.begin(), DShapeTriplets.end());
 
       //Building closeness matrix
-      std::vector<Triplet<Scalar> > DCloseTriplets;
+      std::vector<Eigen::Triplet<Scalar> > DCloseTriplets;
       for (int i=0;i<b.size();i++)
-        DCloseTriplets.push_back(Triplet<Scalar>(i,b(i), 1.0));
+        DCloseTriplets.push_back(Eigen::Triplet<Scalar>(i,b(i), 1.0));
       
       sudata.DClose.setFromTriplets(DCloseTriplets.begin(), DCloseTriplets.end());
       
       //Building smoothness matrix
-      std::vector<Triplet<Scalar> > DSmoothTriplets;
+      std::vector<Eigen::Triplet<Scalar> > DSmoothTriplets;
       for (int i=0; i<E.rows(); i++) {
-        DSmoothTriplets.push_back(Triplet<Scalar>(i, E(i, 0), -1));
-        DSmoothTriplets.push_back(Triplet<Scalar>(i, E(i, 1), 1));
+        DSmoothTriplets.push_back(Eigen::Triplet<Scalar>(i, E(i, 0), -1));
+        DSmoothTriplets.push_back(Eigen::Triplet<Scalar>(i, E(i, 1), 1));
       }
         
-      SparseMatrix<Scalar> tempMat;
+      Eigen::SparseMatrix<Scalar> tempMat;
       igl::cat(1, sudata.DShape, sudata.DClose, tempMat);
       igl::cat(1, tempMat, sudata.DSmooth, sudata.A);
         
       //weight matrix
-      std::vector<Triplet<Scalar> > WTriplets;
+      std::vector<Eigen::Triplet<Scalar> > WTriplets;
         
       //one weight per set in S.
       currRow=0;
       for (int i=0;i<SC.rows();i++){
           for (int j=0;j<SC(i);j++)
-              WTriplets.push_back(Triplet<double>(currRow+j,currRow+j,sudata.shapeCoeff*wShape(i)));
+              WTriplets.push_back(Eigen::Triplet<double>(currRow+j,currRow+j,sudata.shapeCoeff*wShape(i)));
           currRow+=SC(i);
       }
         
       for (int i=0;i<b.size();i++)
-          WTriplets.push_back(Triplet<double>(SC.sum()+i, SC.sum()+i, sudata.closeCoeff));
+          WTriplets.push_back(Eigen::Triplet<double>(SC.sum()+i, SC.sum()+i, sudata.closeCoeff));
         
       for (int i=0;i<E.rows();i++)
-          WTriplets.push_back(Triplet<double>(SC.sum()+b.size()+i, SC.sum()+b.size()+i, sudata.smoothCoeff*wSmooth(i)));
+          WTriplets.push_back(Eigen::Triplet<double>(SC.sum()+b.size()+i, SC.sum()+b.size()+i, sudata.smoothCoeff*wSmooth(i)));
         
       sudata.W.conservativeResize(SC.sum()+b.size()+E.rows(), SC.sum()+b.size()+E.rows());
       sudata.W.setFromTriplets(WTriplets.begin(), WTriplets.end());
@@ -165,7 +164,7 @@ namespace igl
       sudata.At=sudata.A.transpose();  //for efficieny, as we use the transpose a lot in the iteration
       sudata.Q=sudata.At*sudata.W*sudata.A;
 
-      return min_quad_with_fixed_precompute(sudata.Q,VectorXi(),SparseMatrix<double>(),true,sudata.solver_data);
+      return min_quad_with_fixed_precompute(sudata.Q,Eigen::VectorXi(),Eigen::SparseMatrix<double>(),true,sudata.solver_data);
   }
 
 
@@ -180,14 +179,13 @@ namespace igl
                                 const bool quietIterations,
                                 Eigen::PlainObjectBase<DerivedP>& P)
   {
-    using namespace Eigen;
-    MatrixXd currP=P0;
-    MatrixXd prevP=P0;
-    MatrixXd projP;
+    Eigen::MatrixXd currP=P0;
+    Eigen::MatrixXd prevP=P0;
+    Eigen::MatrixXd projP;
     
     assert(bc.rows()==sudata.b.rows());
     
-		MatrixXd rhs(sudata.A.rows(), 3); rhs.setZero();
+		Eigen::MatrixXd rhs(sudata.A.rows(), 3); rhs.setZero();
     rhs.block(sudata.DShape.rows(), 0, sudata.b.rows(),3)=bc;  //this stays constant throughout the iterations
         
     if (!quietIterations){
@@ -206,10 +204,10 @@ namespace igl
           rhs.row(currRow++)=projP.block(i, 3*j, 1,3);
       
       DerivedP lsrhs=-sudata.At*sudata.W*rhs;
-      MatrixXd Y(0,3), Beq(0,3);  //We do not use the min_quad_solver fixed variables mechanism; they are treated with the closeness energy of ShapeUp.
+      Eigen::MatrixXd Y(0,3), Beq(0,3);  //We do not use the min_quad_solver fixed variables mechanism; they are treated with the closeness energy of ShapeUp.
       min_quad_with_fixed_solve(sudata.solver_data, lsrhs,Y,Beq,currP);
       
-      double currChange=(currP-prevP).lpNorm<Infinity>();
+      double currChange=(currP-prevP).lpNorm<Eigen::Infinity>();
       if (!quietIterations)
         std::cout << "Iteration "<<iter<<", integration Linf error: "<<currChange<< std::endl;
       prevP=currP;

--- a/include/igl/shapeup.cpp
+++ b/include/igl/shapeup.cpp
@@ -87,7 +87,6 @@ namespace igl
                                          const Eigen::MatrixBase<Derivedw>& wSmooth,
                                          ShapeupData & sudata)
   {
-      using namespace std;
       using namespace Eigen;
       sudata.P=P;
       sudata.SC=SC;
@@ -144,7 +143,7 @@ namespace igl
       igl::cat(1, tempMat, sudata.DSmooth, sudata.A);
         
       //weight matrix
-      vector<Triplet<Scalar> > WTriplets;
+      std::vector<Triplet<Scalar> > WTriplets;
         
       //one weight per set in S.
       currRow=0;
@@ -182,7 +181,6 @@ namespace igl
                                 Eigen::PlainObjectBase<DerivedP>& P)
   {
     using namespace Eigen;
-    using namespace std;
     MatrixXd currP=P0;
     MatrixXd prevP=P0;
     MatrixXd projP;
@@ -193,8 +191,8 @@ namespace igl
     rhs.block(sudata.DShape.rows(), 0, sudata.b.rows(),3)=bc;  //this stays constant throughout the iterations
         
     if (!quietIterations){
-        cout<<"Shapeup Iterations, "<<sudata.DShape.rows()<<" constraints, solution size "<<P0.size()<<endl;
-        cout<<"**********************************************************************************************"<<endl;
+        std::cout<<"Shapeup Iterations, "<<sudata.DShape.rows()<<" constraints, solution size "<<P0.size()<<std::endl;
+        std::cout<<"**********************************************************************************************"<<std::endl;
     }
     projP.conservativeResize(sudata.SC.rows(), 3*sudata.SC.maxCoeff());
     for (int iter=0;iter<sudata.maxIterations;iter++){
@@ -213,7 +211,7 @@ namespace igl
       
       double currChange=(currP-prevP).lpNorm<Infinity>();
       if (!quietIterations)
-        cout << "Iteration "<<iter<<", integration Linf error: "<<currChange<< endl;
+        std::cout << "Iteration "<<iter<<", integration Linf error: "<<currChange<< std::endl;
       prevP=currP;
       if (currChange<sudata.pTolerance){
         P=currP;

--- a/include/igl/signed_distance.cpp
+++ b/include/igl/signed_distance.cpp
@@ -542,7 +542,6 @@ IGL_INLINE void igl::signed_distance_pseudonormal(
     DerivedV::ColsAtCompileTime == 3 || DerivedV::ColsAtCompileTime == Eigen::Dynamic,
     "V should have 3 or Dynamic columns");
   using namespace Eigen;
-  using namespace std;
   //typedef Eigen::Matrix<typename DerivedV::Scalar,1,3> RowVector3S;
   // Alec: Why was this constructor around q necessary?
   //sqrd = tree.squared_distance(V,F,RowVector3S(q),i,(RowVector3S&)c);
@@ -578,7 +577,6 @@ IGL_INLINE void igl::signed_distance_pseudonormal(
     DerivedV::ColsAtCompileTime == 2 || DerivedV::ColsAtCompileTime == Eigen::Dynamic,
     "V should have 2 or Dynamic columns");
   using namespace Eigen;
-  using namespace std;
   typedef Eigen::Matrix<typename DerivedV::Scalar,1,2> RowVector2S;
   sqrd = tree.squared_distance(V,E,RowVector2S(q),i,(RowVector2S&)c);
   pseudonormal_test(V,E,EN,VN,q,i,c,s,n);
@@ -628,7 +626,6 @@ IGL_INLINE void igl::signed_distance_winding_number(
     DerivedV::ColsAtCompileTime == 3 || DerivedV::ColsAtCompileTime == Eigen::Dynamic,
     "V should have 3 or Dynamic columns");
   using namespace Eigen;
-  using namespace std;
   typedef Eigen::Matrix<typename DerivedV::Scalar,1,3> RowVector3S;
   sqrd = tree.squared_distance(V,F,RowVector3S(q),i,(RowVector3S&)c);
   const Scalar w = hier.winding_number(q.transpose());
@@ -655,7 +652,6 @@ IGL_INLINE void igl::signed_distance_winding_number(
     DerivedV::ColsAtCompileTime == 2 || DerivedV::ColsAtCompileTime == Eigen::Dynamic,
     "V should have 2 or Dynamic columns");
   using namespace Eigen;
-  using namespace std;
   typedef Eigen::Matrix<typename DerivedV::Scalar,1,2> RowVector2S;
   sqrd = tree.squared_distance(V,F,RowVector2S(q),i,(RowVector2S&)c);
   // TODO: using .data() like this is very dangerous... This is assuming

--- a/include/igl/signed_distance.cpp
+++ b/include/igl/signed_distance.cpp
@@ -491,7 +491,6 @@ IGL_INLINE void igl::signed_distance_pseudonormal(
   Eigen::PlainObjectBase<DerivedC> & C,
   Eigen::PlainObjectBase<DerivedN> & N)
 {
-  using namespace Eigen;
   const size_t np = P.rows();
   S.resize(np,1);
   I.resize(np,1);
@@ -541,7 +540,6 @@ IGL_INLINE void igl::signed_distance_pseudonormal(
   static_assert(
     DerivedV::ColsAtCompileTime == 3 || DerivedV::ColsAtCompileTime == Eigen::Dynamic,
     "V should have 3 or Dynamic columns");
-  using namespace Eigen;
   //typedef Eigen::Matrix<typename DerivedV::Scalar,1,3> RowVector3S;
   // Alec: Why was this constructor around q necessary?
   //sqrd = tree.squared_distance(V,F,RowVector3S(q),i,(RowVector3S&)c);
@@ -576,7 +574,6 @@ IGL_INLINE void igl::signed_distance_pseudonormal(
   static_assert(
     DerivedV::ColsAtCompileTime == 2 || DerivedV::ColsAtCompileTime == Eigen::Dynamic,
     "V should have 2 or Dynamic columns");
-  using namespace Eigen;
   typedef Eigen::Matrix<typename DerivedV::Scalar,1,2> RowVector2S;
   sqrd = tree.squared_distance(V,E,RowVector2S(q),i,(RowVector2S&)c);
   pseudonormal_test(V,E,EN,VN,q,i,c,s,n);
@@ -625,7 +622,6 @@ IGL_INLINE void igl::signed_distance_winding_number(
   static_assert(
     DerivedV::ColsAtCompileTime == 3 || DerivedV::ColsAtCompileTime == Eigen::Dynamic,
     "V should have 3 or Dynamic columns");
-  using namespace Eigen;
   typedef Eigen::Matrix<typename DerivedV::Scalar,1,3> RowVector3S;
   sqrd = tree.squared_distance(V,F,RowVector3S(q),i,(RowVector3S&)c);
   const Scalar w = hier.winding_number(q.transpose());
@@ -651,7 +647,6 @@ IGL_INLINE void igl::signed_distance_winding_number(
   static_assert(
     DerivedV::ColsAtCompileTime == 2 || DerivedV::ColsAtCompileTime == Eigen::Dynamic,
     "V should have 2 or Dynamic columns");
-  using namespace Eigen;
   typedef Eigen::Matrix<typename DerivedV::Scalar,1,2> RowVector2S;
   sqrd = tree.squared_distance(V,F,RowVector2S(q),i,(RowVector2S&)c);
   // TODO: using .data() like this is very dangerous... This is assuming

--- a/include/igl/signed_distance.h
+++ b/include/igl/signed_distance.h
@@ -260,9 +260,9 @@ namespace igl
   /// for sign.
   ///
   /// #### Usage:
-  ///     VectorXd S;  
-  ///     VectorXd V, P; //where V is mesh vertices, P are query points
-  ///     VectorXi F;  
+  ///     Eigen::VectorXd S;
+  ///     Eigen::VectorXd V, P; //where V is mesh vertices, P are query points
+  ///     Eigen::VectorXi F;
   ///     igl::FastWindingNumberBVH fwn_bvh;
   ///     igl::fast_winding_number(V.cast<float>(), F, 2, fwn_bvh);
   ///     igl::signed_distance_fast_winding_number(P,V,F,tree,fwn_bvh,S);

--- a/include/igl/slice.h
+++ b/include/igl/slice.h
@@ -102,7 +102,7 @@ namespace igl
     const Eigen::DenseBase<DerivedC> & C,
     Eigen::PlainObjectBase<DerivedY> & Y);
   /// \overload
-  /// \brief VectorXi Y = slice(X,R);
+  /// \brief Eigen::VectorXi Y = slice(X,R);
   /// This templating is bad because the return type might not have the same
   /// size as `DerivedX`. This will probably only work if DerivedX has Dynamic
   /// as it's non-trivial sizes or if the number of rows in R happens to equal

--- a/include/igl/slice_cached.h
+++ b/include/igl/slice_cached.h
@@ -29,13 +29,13 @@ namespace igl
   /// #### Example
   ///
   ///     // Construct and slice up Laplacian
-  ///     SparseMatrix<double> L,L_sliced;
+  ///     Eigen::SparseMatrix<double> L,L_sliced;
   ///     igl::cotmatrix(V,F,L);
   ///     // Normal igl::slice call
   ///     igl::slice(L,in,in,L_in_in);
   ///     …
   ///     // Fast version
-  ///     static VectorXi data; // static or saved in a global state
+  ///     static Eigen::VectorXi data; // static or saved in a global state
   ///     if (data.size() == 0)
   ///       igl::slice_cached_precompute(L,in,in,data,L_sliced);
   ///     else

--- a/include/igl/slim.cpp
+++ b/include/igl/slim.cpp
@@ -112,8 +112,6 @@ namespace igl
       Eigen::VectorXi & /*soft_b_p*/,
       Eigen::MatrixXd & /*soft_bc_p*/)
     {
-      using namespace Eigen;
-
       Eigen::SparseMatrix<double> L;
       build_linear_system(s,L);
 
@@ -125,14 +123,14 @@ namespace igl
 #ifndef CHOLMOD
       if (s.dim == 2)
       {
-        SimplicialLDLT<Eigen::SparseMatrix<double> > solver;
+        Eigen::SimplicialLDLT<Eigen::SparseMatrix<double> > solver;
         Uc = solver.compute(L).solve(s.rhs);
       }
       else
       { // seems like CG performs much worse for 2D and way better for 3D
         Eigen::VectorXd guess(uv.rows() * s.dim);
         for (int i = 0; i < s.v_num; i++) for (int j = 0; j < s.dim; j++) guess(uv.rows() * j + i) = uv(i, j); // flatten vector
-        ConjugateGradient<Eigen::SparseMatrix<double>, Lower | Upper> cg;
+        Eigen::ConjugateGradient<Eigen::SparseMatrix<double>, Eigen::Lower | Eigen::Upper> cg;
         cg.setTolerance(1e-8);
         cg.compute(L);
         Uc = cg.solveWithGuess(s.rhs, guess);

--- a/include/igl/snap_points.cpp
+++ b/include/igl/snap_points.cpp
@@ -42,7 +42,6 @@ IGL_INLINE void igl::snap_points(
   Eigen::PlainObjectBase<DerivedI > & I,
   Eigen::PlainObjectBase<DerivedminD > & minD)
 {
-  using namespace std;
   const int n = V.rows();
   const int m = C.rows();
   assert(V.cols() == C.cols() && "Dimensions should match");
@@ -52,7 +51,7 @@ IGL_INLINE void igl::snap_points(
   // reasonably distubed points.
   I.resize(m,1);
   typedef typename DerivedV::Scalar Scalar;
-  minD.setConstant(m,1,numeric_limits<Scalar>::max());
+  minD.setConstant(m,1,std::numeric_limits<Scalar>::max());
   for(int v = 0;v<n;v++)
   {
     for(int c = 0;c<m;c++)

--- a/include/igl/snap_to_fixed_up.cpp
+++ b/include/igl/snap_to_fixed_up.cpp
@@ -12,7 +12,6 @@ IGL_INLINE void igl::snap_to_fixed_up(
   const Eigen::Quaternion<Qtype> & q,
   Eigen::Quaternion<Qtype> & s)
 {
-  using namespace Eigen;
   typedef Eigen::Matrix<Qtype,3,1> Vector3Q;
   const Vector3Q up = q.matrix() * Vector3Q(0,1,0);
   Vector3Q proj_up(0,up(1),up(2));
@@ -21,8 +20,8 @@ IGL_INLINE void igl::snap_to_fixed_up(
     proj_up = Vector3Q(0,1,0);
   }
   proj_up.normalize();
-  Quaternion<Qtype> dq;
-  dq = Quaternion<Qtype>::FromTwoVectors(up,proj_up);
+  Eigen::Quaternion<Qtype> dq;
+  dq = Eigen::Quaternion<Qtype>::FromTwoVectors(up,proj_up);
   s = dq * q;
 }
 

--- a/include/igl/sort.cpp
+++ b/include/igl/sort.cpp
@@ -38,7 +38,6 @@ IGL_INLINE void igl::sort(
     case 3:
       return igl::sort3(X,dim,ascending,Y,IX);
   }
-  using namespace Eigen;
   // get number of columns (or rows)
   int num_outer = (dim == 1 ? X.cols() : X.rows() );
   // dim must be 2 or 1
@@ -112,7 +111,6 @@ IGL_INLINE void igl::sort_new(
     case 3:
       return igl::sort3(X,dim,ascending,Y,IX);
   }
-  using namespace Eigen;
   // get number of columns (or rows)
   int num_outer = (dim == 1 ? X.cols() : X.rows() );
   // dim must be 2 or 1
@@ -168,7 +166,6 @@ IGL_INLINE void igl::sort2(
   Eigen::PlainObjectBase<DerivedY>& Y,
   Eigen::PlainObjectBase<DerivedIX>& IX)
 {
-  using namespace Eigen;
   typedef typename DerivedY::Scalar YScalar;
   Y = X.derived().template cast<YScalar>();
 
@@ -212,7 +209,6 @@ IGL_INLINE void igl::sort3(
   Eigen::PlainObjectBase<DerivedY>& Y,
   Eigen::PlainObjectBase<DerivedIX>& IX)
 {
-  using namespace Eigen;
   typedef typename DerivedY::Scalar YScalar;
   Y = X.derived().template cast<YScalar>();
   Y.resizeLike(X);

--- a/include/igl/sort.cpp
+++ b/include/igl/sort.cpp
@@ -169,7 +169,6 @@ IGL_INLINE void igl::sort2(
   Eigen::PlainObjectBase<DerivedIX>& IX)
 {
   using namespace Eigen;
-  using namespace std;
   typedef typename DerivedY::Scalar YScalar;
   Y = X.derived().template cast<YScalar>();
 
@@ -214,7 +213,6 @@ IGL_INLINE void igl::sort3(
   Eigen::PlainObjectBase<DerivedIX>& IX)
 {
   using namespace Eigen;
-  using namespace std;
   typedef typename DerivedY::Scalar YScalar;
   Y = X.derived().template cast<YScalar>();
   Y.resizeLike(X);

--- a/include/igl/sort.h
+++ b/include/igl/sort.h
@@ -17,8 +17,8 @@ namespace igl
   /// Sort the elements of a matrix X along a given dimension like matlabs sort
   /// function
   ///
-  /// @tparam DerivedX derived scalar type, e.g. MatrixXi or MatrixXd
-  /// @tparam DerivedIX derived integer type, e.g. MatrixXi
+  /// @tparam DerivedX derived scalar type, e.g. Eigen::MatrixXi or Eigen::MatrixXd
+  /// @tparam DerivedIX derived integer type, e.g. Eigen::MatrixXi
   /// @param[in] X  m by n matrix whose entries are to be sorted
   /// @param[in] dim  dimensional along which to sort:
   ///     1  sort each column (matlab default)

--- a/include/igl/sort_triangles.cpp
+++ b/include/igl/sort_triangles.cpp
@@ -32,7 +32,6 @@ IGL_INLINE void igl::sort_triangles(
   Eigen::PlainObjectBase<DerivedI> & I)
 {
   using namespace Eigen;
-  using namespace std;
 
 
   typedef typename DerivedV::Scalar Scalar;

--- a/include/igl/sort_triangles.cpp
+++ b/include/igl/sort_triangles.cpp
@@ -31,9 +31,6 @@ IGL_INLINE void igl::sort_triangles(
   Eigen::PlainObjectBase<DerivedFF> & FF,
   Eigen::PlainObjectBase<DerivedI> & I)
 {
-  using namespace Eigen;
-
-
   typedef typename DerivedV::Scalar Scalar;
   // Barycenter, centroid
   Eigen::Matrix<Scalar, DerivedF::RowsAtCompileTime,1> D,sD;

--- a/include/igl/sortrows.cpp
+++ b/include/igl/sortrows.cpp
@@ -59,7 +59,6 @@ IGL_INLINE void igl::sortrows(
   // This is already 2x faster than matlab's builtin `sortrows`. I have tried
   // implementing a "multiple-pass" sort on each column, but see no performance
   // improvement.
-  using namespace std;
   using namespace Eigen;
   // Resize output
   const size_t num_rows = X.rows();

--- a/include/igl/sortrows.cpp
+++ b/include/igl/sortrows.cpp
@@ -24,7 +24,6 @@
 //  Eigen::PlainObjectBase<DerivedIX>& IX)
 //{
 //  using namespace std;
-//  using namespace Eigen;
 //  typedef Eigen::Matrix<typename DerivedX::Scalar, Eigen::Dynamic, 1> RowVector;
 //  vector<SortableRow<RowVector> > rows;
 //  rows.resize(X.rows());
@@ -59,7 +58,6 @@ IGL_INLINE void igl::sortrows(
   // This is already 2x faster than matlab's builtin `sortrows`. I have tried
   // implementing a "multiple-pass" sort on each column, but see no performance
   // improvement.
-  using namespace Eigen;
   // Resize output
   const size_t num_rows = X.rows();
   const size_t num_cols = X.cols();

--- a/include/igl/sortrows.h
+++ b/include/igl/sortrows.h
@@ -15,8 +15,8 @@ namespace igl
 {
   /// Act like matlab's [Y,I] = sortrows(X)
   ///
-  /// @tparam DerivedX derived scalar type, e.g. MatrixXi or MatrixXd
-  /// @tparam DerivedI derived integer type, e.g. MatrixXi
+  /// @tparam DerivedX derived scalar type, e.g. Eigen::MatrixXi or Eigen::MatrixXd
+  /// @tparam DerivedI derived integer type, e.g. Eigen::MatrixXi
   /// @param[in] X  m by n matrix whose entries are to be sorted
   /// @param[in] ascending  sort ascending (true, matlab default) or descending (false)
   /// @param[out] Y  m by n matrix whose entries are sorted (**should not** be same

--- a/include/igl/sparse.cpp
+++ b/include/igl/sparse.cpp
@@ -36,7 +36,6 @@ IGL_INLINE void igl::sparse(
   const size_t n,
   Eigen::SparseMatrix<T>& X)
 {
-  using namespace std;
   using namespace Eigen;
   assert((int)I.maxCoeff() < (int)m);
   assert((int)I.minCoeff() >= 0);
@@ -49,7 +48,7 @@ IGL_INLINE void igl::sparse(
   assert(J.rows() == V.rows());
   assert(I.cols() == J.cols());
   assert(J.cols() == V.cols());
-  vector<Triplet<T> > IJV;
+  std::vector<Triplet<T> > IJV;
   IJV.reserve(I.size());
   for(int x = 0;x<I.size();x++)
   {
@@ -65,9 +64,8 @@ IGL_INLINE void igl::sparse(
   Eigen::SparseMatrix<T>& X)
 {
   assert(false && "Obsolete. Just call D.sparseView() directly");
-  using namespace std;
   using namespace Eigen;
-  vector<Triplet<T> > DIJV;
+  std::vector<Triplet<T> > DIJV;
   const int m = D.rows();
   const int n = D.cols();
   for(int i = 0;i<m;i++)

--- a/include/igl/sparse.cpp
+++ b/include/igl/sparse.cpp
@@ -36,7 +36,6 @@ IGL_INLINE void igl::sparse(
   const size_t n,
   Eigen::SparseMatrix<T>& X)
 {
-  using namespace Eigen;
   assert((int)I.maxCoeff() < (int)m);
   assert((int)I.minCoeff() >= 0);
   assert((int)J.maxCoeff() < (int)n);
@@ -48,11 +47,11 @@ IGL_INLINE void igl::sparse(
   assert(J.rows() == V.rows());
   assert(I.cols() == J.cols());
   assert(J.cols() == V.cols());
-  std::vector<Triplet<T> > IJV;
+  std::vector<Eigen::Triplet<T> > IJV;
   IJV.reserve(I.size());
   for(int x = 0;x<I.size();x++)
   {
-    IJV.push_back(Triplet<T >(I(x),J(x),V(x)));
+    IJV.push_back(Eigen::Triplet<T >(I(x),J(x),V(x)));
   }
   X.resize(m,n);
   X.setFromTriplets(IJV.begin(),IJV.end());
@@ -64,8 +63,7 @@ IGL_INLINE void igl::sparse(
   Eigen::SparseMatrix<T>& X)
 {
   assert(false && "Obsolete. Just call D.sparseView() directly");
-  using namespace Eigen;
-  std::vector<Triplet<T> > DIJV;
+  std::vector<Eigen::Triplet<T> > DIJV;
   const int m = D.rows();
   const int n = D.cols();
   for(int i = 0;i<m;i++)
@@ -74,7 +72,7 @@ IGL_INLINE void igl::sparse(
     {
       if(D(i,j)!=0)
       {
-        DIJV.push_back(Triplet<T>(i,j,D(i,j)));
+        DIJV.push_back(Eigen::Triplet<T>(i,j,D(i,j)));
       }
     }
   }

--- a/include/igl/split_nonmanifold.cpp
+++ b/include/igl/split_nonmanifold.cpp
@@ -363,10 +363,10 @@ IGL_INLINE void igl::split_nonmanifold(
   // Consider each unique edge in the original mesh
 
   // number of faces incident on each unique edge
-  VectorXI D = uEC.tail(uEC.rows()-1)-uEC.head(uEC.rows()-1);
-  VectorXI uI;
+  Eigen::VectorXi D = uEC.tail(uEC.rows()-1)-uEC.head(uEC.rows()-1);
+  Eigen::VectorXi uI;
   {
-    VectorXI sD;
+    Eigen::VectorXi sD;
     igl::sort(D,1,true,sD,uI);
   }
 
@@ -430,7 +430,7 @@ IGL_INLINE void igl::split_nonmanifold(
   {
     SVI.resize(F.size());
     std::vector<bool> marked(F.size());
-    VectorXI J = VectorXI::Constant(F.size(),-1);
+    Eigen::VectorXi J = Eigen::VectorXi::Constant(F.size(),-1);
     SF.resize(F.rows(),F.cols());
     {
       int nv = 0;

--- a/include/igl/squared_edge_lengths.cpp
+++ b/include/igl/squared_edge_lengths.cpp
@@ -15,7 +15,6 @@ IGL_INLINE void igl::squared_edge_lengths(
   const Eigen::MatrixBase<DerivedF>& F,
   Eigen::PlainObjectBase<DerivedL>& L)
 {
-  using namespace std;
   const int m = F.rows();
   switch(F.cols())
   {

--- a/include/igl/squared_edge_lengths.h
+++ b/include/igl/squared_edge_lengths.h
@@ -16,9 +16,9 @@ namespace igl
   /// Constructs a list of squared lengths of edges opposite each index in a face
   /// (triangle/tet) list
   ///
-  /// @tparam DerivedV derived from vertex positions matrix type: i.e. MatrixXd
-  /// @tparam DerivedF derived from face indices matrix type: i.e. MatrixXi
-  /// @tparam DerivedL derived from edge lengths matrix type: i.e. MatrixXd
+  /// @tparam DerivedV derived from vertex positions matrix type: i.e. Eigen::MatrixXd
+  /// @tparam DerivedF derived from face indices matrix type: i.e. Eigen::MatrixXi
+  /// @tparam DerivedL derived from edge lengths matrix type: i.e. Eigen::MatrixXd
   /// @param[in] V  eigen matrix #V by 3
   /// @param[in] F  #F by (2|3|4) list of mesh edges, triangles or tets
   /// @param[out] L  #F by {1|3|6} list of edge lengths squared

--- a/include/igl/stb/write_image.cpp
+++ b/include/igl/stb/write_image.cpp
@@ -47,8 +47,7 @@ IGL_INLINE bool igl::stb::write_image(
 {
   const int comp = 4;                                  // 4 Channels Red, Green, Blue, Alpha
   const int stride_in_bytes = width*comp;           // Length of one row in bytes
-  using namespace std;
-  string d,b,e,f;
+  std::string d,b,e,f;
   pathinfo(image_file,d,b,e,f);
   if(e == "png")
   {

--- a/include/igl/straighten_seams.cpp
+++ b/include/igl/straighten_seams.cpp
@@ -46,47 +46,46 @@ IGL_INLINE void igl::straighten_seams(
   Eigen::PlainObjectBase<DerivedUT> & UT,
   Eigen::PlainObjectBase<DerivedOT> & OT)
 {
-  using namespace Eigen;
   // number of faces
   assert(FT.rows() == F.rows() && "#FT must == #F");
   assert(F.cols() == 3 && "F should contain triangles");
   assert(FT.cols() == 3 && "FT should contain triangles");
   const int m = F.rows();
   // Boundary edges of the texture map and 3d meshes
-  Array<bool,Dynamic,1> _;
-  Array<bool,Dynamic,3> BT,BF;
+  Eigen::Array<bool ,Eigen::Dynamic,1> _;
+  Eigen::Array<bool ,Eigen::Dynamic,3> BT,BF;
   on_boundary(FT,_,BT);
   on_boundary(F,_,BF);
   assert((!((BF && (BT!=true)).any())) && 
     "Not dealing with boundaries of mesh that get 'stitched' in texture mesh");
-  typedef Matrix<typename DerivedF::Scalar,Dynamic,2> MatrixX2I; 
+  typedef Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,2> MatrixX2I;
   const MatrixX2I ET = (MatrixX2I(FT.rows()*3,2)
     <<FT.col(1),FT.col(2),FT.col(2),FT.col(0),FT.col(0),FT.col(1)).finished();
   // "half"-edges with indices into 3D-mesh
   const MatrixX2I EF = (MatrixX2I(F.rows()*3,2)
     <<F.col(1),F.col(2),F.col(2),F.col(0),F.col(0),F.col(1)).finished();
   // Find unique (undirected) edges in F
-  VectorXi EFMAP;
+  Eigen::VectorXi EFMAP;
   {
     MatrixX2I _1;
-    VectorXi _2;
+    Eigen::VectorXi _2;
     unique_simplices(EF,_1,_2,EFMAP);
   }
-  Array<bool,Dynamic,1>vBT = Map<Array<bool,Dynamic,1> >(BT.data(),BT.size(),1);
-  Array<bool,Dynamic,1>vBF = Map<Array<bool,Dynamic,1> >(BF.data(),BF.size(),1);
+  Eigen::Array<bool ,Eigen::Dynamic,1>vBT = Eigen::Map<Eigen::Array<bool ,Eigen::Dynamic,1> >(BT.data(),BT.size(),1);
+  Eigen::Array<bool ,Eigen::Dynamic,1>vBF = Eigen::Map<Eigen::Array<bool ,Eigen::Dynamic,1> >(BF.data(),BF.size(),1);
   const auto vBT_i = igl::find(vBT);
   MatrixX2I OF = EF(vBT_i,igl::placeholders::all);
   OT = EF(vBT_i,igl::placeholders::all);
-  VectorXi OFMAP = EFMAP(vBT_i);
+  Eigen::VectorXi OFMAP = EFMAP(vBT_i);
   // Two boundary edges on the texture-mapping are "equivalent" to each other on
   // the 3D-mesh if their 3D-mesh vertex indices match
-  SparseMatrix<bool> OEQ;
+  Eigen::SparseMatrix<bool> OEQ;
   {
-    SparseMatrix<bool> OEQR;
+    Eigen::SparseMatrix<bool> OEQR;
     sparse(
-      igl::LinSpaced<VectorXi >(OT.rows(),0,OT.rows()-1),
+      igl::LinSpaced<Eigen::VectorXi >(OT.rows(),0,OT.rows()-1),
       OFMAP,
-      Array<bool,Dynamic,1>::Ones(OT.rows(),1),
+      Eigen::Array<bool ,Eigen::Dynamic,1>::Ones(OT.rows(),1),
       OT.rows(),
       m*3,
       OEQR);
@@ -99,31 +98,31 @@ IGL_INLINE void igl::straighten_seams(
   // mapping to this endpoint.
   //
   // Adjacency matrix between 3d-vertices and texture-vertices
-  SparseMatrix<bool> V2VT;
+  Eigen::SparseMatrix<bool> V2VT;
   sparse(
     F,
     FT,
-    Array<bool,Dynamic,3>::Ones(F.rows(),F.cols()), 
+    Eigen::Array<bool ,Eigen::Dynamic,3>::Ones(F.rows(),F.cols()),
     V.rows(),
     VT.rows(),
     V2VT);
   // For each 3d-vertex count how many different texture-coordinates its getting
   // from different incident corners
-  VectorXi DV;
+  Eigen::VectorXi DV;
   count(V2VT,2,DV);
-  VectorXi M,I;
+  Eigen::VectorXi M,I;
   max(V2VT,1,M,I);
   assert( (M.array() == 1).all() );
-  VectorXi DT;
+  Eigen::VectorXi DT;
   // Map counts onto texture-vertices
   DT = DV(I,igl::placeholders::all);
   // Boundary in 3D && UV
-  Array<bool,Dynamic,1> BTF = vBF(igl::find(vBT));
+  Eigen::Array<bool ,Eigen::Dynamic,1> BTF = vBF(igl::find(vBT));
 
   // Texture-vertex is "sharp" if incident on "half-"edge that is not a
   // boundary in the 3D mesh but is a boundary in the texture-mesh AND is not
   // "cut cleanly" (the vertex is mapped to exactly 2 locations)
-  Array<bool,Dynamic,1> SV = Array<bool,Dynamic,1>::Zero(VT.rows(),1);
+  Eigen::Array<bool ,Eigen::Dynamic,1> SV = Eigen::Array<bool ,Eigen::Dynamic,1>::Zero(VT.rows(),1);
   //std::cout<<"#SV: "<<SV.count()<<std::endl;
   assert(BTF.size() == OT.rows());
   for(int h = 0;h<BTF.size();h++)
@@ -135,19 +134,19 @@ IGL_INLINE void igl::straighten_seams(
     }
   }
   //std::cout<<"#SV: "<<SV.count()<<std::endl;
-  Array<bool,Dynamic,1> CL = DT.array()==2;
-  SparseMatrix<bool> VTOT;
+  Eigen::Array<bool ,Eigen::Dynamic,1> CL = DT.array()==2;
+  Eigen::SparseMatrix<bool> VTOT;
   {
     Eigen::MatrixXi I = 
-      igl::LinSpaced<VectorXi >(OT.rows(),0,OT.rows()-1).replicate(1,2);
+      igl::LinSpaced<Eigen::VectorXi >(OT.rows(),0,OT.rows()-1).replicate(1,2);
     sparse(
       OT,
       I,
-      Array<bool,Dynamic,2>::Ones(OT.rows(),OT.cols()),
+      Eigen::Array<bool ,Eigen::Dynamic,2>::Ones(OT.rows(),OT.cols()),
       VT.rows(),
       OT.rows(),
       VTOT);
-    Array<int,Dynamic,1> cuts;
+    Eigen::Array<int ,Eigen::Dynamic,1> cuts;
     count( (VTOT*OEQ).eval(), 2, cuts);
     CL = (CL && (cuts.array() == 2)).eval();
   }
@@ -161,18 +160,18 @@ IGL_INLINE void igl::straighten_seams(
     // vertices at the corner of ears are declared to be sharp. This is
     // conservative: for example, if the ear is strictly convex and stays
     // strictly convex then the ear won't be flipped.
-    VectorXi ear,ear_opp;
+    Eigen::VectorXi ear,ear_opp;
     ears(FT,ear,ear_opp);
     //std::cout<<"#ear: "<<ear.size()<<std::endl;
     // There might be an ear on one copy, so mark vertices on other copies, too
     // ears as they live on the 3D mesh
-    Array<bool,Dynamic,1> earT = Array<bool,Dynamic,1>::Zero(VT.rows(),1);
+    Eigen::Array<bool ,Eigen::Dynamic,1> earT = Eigen::Array<bool ,Eigen::Dynamic,1>::Zero(VT.rows(),1);
     for(int e = 0;e<ear.size();e++) earT(FT(ear(e),ear_opp(e))) = 1;
     //std::cout<<"#earT: "<<earT.count()<<std::endl;
     // Even if ear-vertices are marked as sharp if it changes, e.g., from
     // convex to concave then it will _force_ a flip of the ear triangle. So,
     // declare that neighbors of ears are also sharp.
-    SparseMatrix<bool> A;
+    Eigen::SparseMatrix<bool> A;
     adjacency_matrix(FT,A);
     earT = (earT || (A*earT.matrix()).array()).eval();
     //std::cout<<"#earT: "<<earT.count()<<std::endl;
@@ -182,22 +181,22 @@ IGL_INLINE void igl::straighten_seams(
   }
 
   {
-    SparseMatrix<bool> V2VTSV,V2VTC;
+    Eigen::SparseMatrix<bool> V2VTSV,V2VTC;
     slice_mask(V2VT,SV,2,V2VTSV);
-    Array<bool,Dynamic,1> Cb;
+    Eigen::Array<bool ,Eigen::Dynamic,1> Cb;
     any(V2VTSV,2,Cb);
     slice_mask(V2VT,Cb,1,V2VTC);
     any(V2VTC,1,SV);
   }
   //std::cout<<"#SV: "<<SV.count()<<std::endl;
 
-  SparseMatrix<bool> OTVT = VTOT.transpose();
+  Eigen::SparseMatrix<bool> OTVT = VTOT.transpose();
   int nc;
-  ArrayXi C;
+  Eigen::ArrayXi C;
   {
     // Doesn't Compile on older Eigen:
     //SparseMatrix<bool> A = OTVT * (!SV).matrix().asDiagonal() * VTOT;
-    SparseMatrix<bool> A = OTVT * (SV!=true).matrix().asDiagonal() * VTOT;
+    Eigen::SparseMatrix<bool> A = OTVT * (SV!=true).matrix().asDiagonal() * VTOT;
     vertex_components(A,C);
     nc = C.maxCoeff()+1;
   }
@@ -222,7 +221,7 @@ IGL_INLINE void igl::straighten_seams(
     {
       continue;
     }
-    SparseMatrix<bool> OEQIc;
+    Eigen::SparseMatrix<bool> OEQIc;
     slice(OEQ,Ic,1,OEQIc);
     Eigen::VectorXi N;
     sum(OEQIc,2,N);
@@ -238,7 +237,7 @@ IGL_INLINE void igl::straighten_seams(
         {
           MatrixX2I OTIc = OT(Ic,igl::placeholders::all);
           edges_to_path(OTIc,vpath,epath,eend);
-          Array<bool,Dynamic,1> SVvpath = SV(vpath);
+          Eigen::Array<bool ,Eigen::Dynamic,1> SVvpath = SV(vpath);
           assert(
             (vpath(0) != vpath(vpath.size()-1) || !SVvpath.any()) && 
             "Not dealing with 1-loops touching 'sharp' corners");
@@ -252,7 +251,7 @@ IGL_INLINE void igl::straighten_seams(
           const bool is_closed = PI(0) == PI(PI.size()-1);
           assert(!is_closed ||  vpath.size() >= 4);
           Scalar eff_tol = std::min(tol,2.);
-          VectorXi UIc;
+          Eigen::VectorXi UIc;
           while(true)
           {
             MatrixX2S UPI,UTvpath;
@@ -277,15 +276,15 @@ IGL_INLINE void igl::straighten_seams(
       case 2:
         {
           // Find copies
-          VectorXi Icc;
+          Eigen::VectorXi Icc;
           {
-            VectorXi II;
-            Array<bool,Dynamic,1> IV;
-            SparseMatrix<bool> OEQIcT = OEQIc.transpose().eval();
+            Eigen::VectorXi II;
+            Eigen::Array<bool ,Eigen::Dynamic,1> IV;
+            Eigen::SparseMatrix<bool> OEQIcT = OEQIc.transpose().eval();
             find(OEQIcT,Icc,II,IV);
             assert(II.size() == Ic.size() && 
               (II.array() ==
-              igl::LinSpaced<VectorXi >(Ic.size(),0,Ic.size()-1).array()).all());
+              igl::LinSpaced<Eigen::VectorXi >(Ic.size(),0,Ic.size()-1).array()).all());
             assert(Icc.size() == Ic.size());
             const int cc = C(Icc(0));
             Eigen::VectorXi CIcc = C(Icc);
@@ -293,7 +292,7 @@ IGL_INLINE void igl::straighten_seams(
             assert(!done[cc]);
             done[cc] = true;
           }
-          Array<bool,Dynamic,1> flipped;
+          Eigen::Array<bool ,Eigen::Dynamic,1> flipped;
           {
             MatrixX2I OFIc = OF(Ic,igl::placeholders::all);
             MatrixX2I OFIcc = OF(Icc,igl::placeholders::all);
@@ -314,7 +313,7 @@ IGL_INLINE void igl::straighten_seams(
             edges_to_path(OTIc,vpath,epath,eend);
             // Flip endpoints if needed
             for(int e = 0;e<eend.size();e++)if(flipped(e))eend(e)=1-eend(e);
-            VectorXi vpathc(epath.size()+1);
+            Eigen::VectorXi vpathc(epath.size()+1);
             for(int e = 0;e<epath.size();e++)
             {
               vpathc(e) = OT(Icc(epath(e)),eend(e));
@@ -322,7 +321,7 @@ IGL_INLINE void igl::straighten_seams(
             vpathc(epath.size()) =
               OT(Icc(epath(epath.size()-1)),1-eend(eend.size()-1));
             assert(vpath.size() == vpathc.size());
-            Matrix<Scalar,Dynamic,Dynamic> PI(vpath.size(),VT.cols()*2);
+            Eigen::Matrix<Scalar ,Eigen::Dynamic ,Eigen::Dynamic> PI(vpath.size(),VT.cols()*2);
             for(int p = 0;p<PI.rows();p++)
             {
               for(int d = 0;d<VT.cols();d++)
@@ -333,8 +332,8 @@ IGL_INLINE void igl::straighten_seams(
             }
             const Scalar bbd = 
               (PI.colwise().maxCoeff() - PI.colwise().minCoeff()).norm();
-            Matrix<Scalar,Dynamic,Dynamic> UPI,SI;
-            VectorXi UIc;
+            Eigen::Matrix<Scalar ,Eigen::Dynamic ,Eigen::Dynamic> UPI,SI;
+            Eigen::VectorXi UIc;
             ramer_douglas_peucker(PI,tol*bbd,UPI,UIc,SI);
             UT(vpath,igl::placeholders::all) = SI.leftCols (VT.cols());
             UT(vpathc,igl::placeholders::all) = SI.rightCols(VT.cols());

--- a/include/igl/swept_volume.cpp
+++ b/include/igl/swept_volume.cpp
@@ -15,16 +15,15 @@ IGL_INLINE void igl::swept_volume(
   Eigen::MatrixXd & SV,
   Eigen::MatrixXi & SF)
 {
-  using namespace Eigen;
   using namespace igl;
 
   const auto & Vtransform = 
-    [&V,&transform](const size_t vi,const double t)->RowVector3d
+    [&V,&transform](const size_t vi,const double t)->Eigen::RowVector3d
   {
-    Vector3d Vvi = V.row(vi).transpose();
+    Eigen::Vector3d Vvi = V.row(vi).transpose();
     return (transform(t)*Vvi).transpose();
   };
-  AlignedBox3d Mbox;
+  Eigen::AlignedBox3d Mbox;
   swept_volume_bounding_box(V.rows(),Vtransform,steps,Mbox);
 
   // Amount of padding: pad*h should be >= isolevel
@@ -35,12 +34,12 @@ IGL_INLINE void igl::swept_volume(
   const double isolevel = isolevel_grid*h;
 
   // create grid
-  RowVector3i res;
-  MatrixXd GV;
+  Eigen::RowVector3i res;
+  Eigen::MatrixXd GV;
   voxel_grid(Mbox,s,pad,GV,res);
 
   // compute values
-  VectorXd S;
+  Eigen::VectorXd S;
   swept_volume_signed_distance(V,F,transform,steps,GV,res,h,isolevel,S);
   S.array()-=isolevel;
   marching_cubes(S,GV,res(0),res(1),res(2),0,SV,SF);

--- a/include/igl/swept_volume.cpp
+++ b/include/igl/swept_volume.cpp
@@ -15,7 +15,6 @@ IGL_INLINE void igl::swept_volume(
   Eigen::MatrixXd & SV,
   Eigen::MatrixXi & SF)
 {
-  using namespace std;
   using namespace Eigen;
   using namespace igl;
 

--- a/include/igl/swept_volume_bounding_box.cpp
+++ b/include/igl/swept_volume_bounding_box.cpp
@@ -14,9 +14,8 @@ IGL_INLINE void igl::swept_volume_bounding_box(
   const size_t & steps,
   Eigen::AlignedBox3d & box)
 {
-  using namespace Eigen;
   box.setEmpty();
-  const VectorXd t = igl::LinSpaced<VectorXd >(steps,0,1);
+  const Eigen::VectorXd t = igl::LinSpaced<Eigen::VectorXd >(steps,0,1);
   // Find extent over all time steps
   for(int ti = 0;ti<t.size();ti++)
   {

--- a/include/igl/swept_volume_signed_distance.cpp
+++ b/include/igl/swept_volume_signed_distance.cpp
@@ -30,7 +30,6 @@ IGL_INLINE void igl::swept_volume_signed_distance(
   const Eigen::VectorXd & S0,
   Eigen::VectorXd & S)
 {
-  using namespace std;
   using namespace igl;
   using namespace Eigen;
   S = S0;
@@ -74,7 +73,7 @@ IGL_INLINE void igl::swept_volume_signed_distance(
       const double min_sqrd = 
         finite_iso ? 
         pow(sqrt(3.)*h+isolevel,2) : 
-        numeric_limits<double>::infinity();
+        std::numeric_limits<double>::infinity();
       sqrd = tree.squared_distance(V,F,gv,min_sqrd,i,c);
       if(sqrd<min_sqrd)
       {
@@ -113,10 +112,9 @@ IGL_INLINE void igl::swept_volume_signed_distance(
   const double isolevel,
   Eigen::VectorXd & S)
 {
-  using namespace std;
   using namespace igl;
   using namespace Eigen;
-  S = VectorXd::Constant(GV.rows(),1,numeric_limits<double>::quiet_NaN());
+  S = VectorXd::Constant(GV.rows(),1,std::numeric_limits<double>::quiet_NaN());
   return 
     swept_volume_signed_distance(V,F,transform,steps,GV,res,h,isolevel,S,S);
 }

--- a/include/igl/swept_volume_signed_distance.cpp
+++ b/include/igl/swept_volume_signed_distance.cpp
@@ -31,9 +31,8 @@ IGL_INLINE void igl::swept_volume_signed_distance(
   Eigen::VectorXd & S)
 {
   using namespace igl;
-  using namespace Eigen;
   S = S0;
-  const VectorXd t = igl::LinSpaced<VectorXd >(steps,0,1);
+  const Eigen::VectorXd t = igl::LinSpaced<Eigen::VectorXd >(steps,0,1);
   const bool finite_iso = isfinite(isolevel);
   const double extension = (finite_iso ? isolevel : 0) + sqrt(3.0)*h;
   Eigen::AlignedBox3d box(
@@ -47,11 +46,11 @@ IGL_INLINE void igl::swept_volume_signed_distance(
   per_vertex_normals(V,F,PER_VERTEX_NORMALS_WEIGHTING_TYPE_ANGLE,FN,VN);
   per_edge_normals(
     V,F,PER_EDGE_NORMALS_WEIGHTING_TYPE_UNIFORM,FN,EN,E,EMAP);
-  AABB<MatrixXd,3> tree;
+  AABB<Eigen::MatrixXd,3> tree;
   tree.init(V,F);
   for(int ti = 0;ti<t.size();ti++)
   {
-    const Affine3d At = transform(t(ti));
+    const Eigen::Affine3d At = transform(t(ti));
     for(int g = 0;g<GV.rows();g++)
     {
       // Don't bother finding out how deep inside points are.
@@ -59,14 +58,14 @@ IGL_INLINE void igl::swept_volume_signed_distance(
       {
         continue;
       }
-      const RowVector3d gv = 
+      const Eigen::RowVector3d gv =
         (GV.row(g) - At.translation().transpose())*At.linear();
       // If outside of extended box, then consider it "far away enough"
       if(finite_iso && !box.contains(gv.transpose()))
       {
         continue;
       }
-      RowVector3d c,n;
+      Eigen::RowVector3d c,n;
       int i;
       double sqrd,s;
       //signed_distance_pseudonormal(tree,V,F,FN,VN,EN,EMAP,gv,s,sqrd,i,c,n);
@@ -113,8 +112,7 @@ IGL_INLINE void igl::swept_volume_signed_distance(
   Eigen::VectorXd & S)
 {
   using namespace igl;
-  using namespace Eigen;
-  S = VectorXd::Constant(GV.rows(),1,std::numeric_limits<double>::quiet_NaN());
+  S = Eigen::VectorXd::Constant(GV.rows(),1,std::numeric_limits<double>::quiet_NaN());
   return 
     swept_volume_signed_distance(V,F,transform,steps,GV,res,h,isolevel,S,S);
 }

--- a/include/igl/trackball.cpp
+++ b/include/igl/trackball.cpp
@@ -22,7 +22,6 @@
 template <typename Q_type>
 static IGL_INLINE Q_type _QuatD(double w, double h)
 {
-  using namespace std;
   return (Q_type)(std::abs(w) < std::abs(h) ? std::abs(w) : std::abs(h)) - 4;
 }
 template <typename Q_type>
@@ -144,7 +143,6 @@ IGL_INLINE void igl::trackball(
   const double mouse_y,
   Eigen::Quaternion<Scalarquat> & quat)
 {
-  using namespace std;
   return trackball(
     w,
     h,

--- a/include/igl/triangle/refine.cpp
+++ b/include/igl/triangle/refine.cpp
@@ -22,15 +22,13 @@ IGL_INLINE void igl::triangle::refine(
   Eigen::PlainObjectBase<DerivedV2> & V2,
   Eigen::PlainObjectBase<DerivedF2> & F2)
 {
-  using namespace Eigen;
-  using namespace Eigen;
   assert(V.cols() == 2);
   assert(F.cols() == 3);
   // Prepare the flags
   std::string full_flags = flags + "rzB" + (E.size()?"p":"");
 
-  typedef Map< Matrix<double,Dynamic,Dynamic,RowMajor> > MapXdr;
-  typedef Map< Matrix<int,Dynamic,Dynamic,RowMajor> > MapXir;
+  typedef Map< Eigen::Matrix<double ,Eigen::Dynamic ,Eigen::Dynamic,RowMajor> > MapXdr;
+  typedef Map< Eigen::Matrix<int ,Eigen::Dynamic ,Eigen::Dynamic,RowMajor> > MapXir;
  
   // To-do: reduce duplicate code with triangulate.cpp
   // Prepare the input struct

--- a/include/igl/triangle/refine.cpp
+++ b/include/igl/triangle/refine.cpp
@@ -27,8 +27,8 @@ IGL_INLINE void igl::triangle::refine(
   // Prepare the flags
   std::string full_flags = flags + "rzB" + (E.size()?"p":"");
 
-  typedef Map< Eigen::Matrix<double ,Eigen::Dynamic ,Eigen::Dynamic,RowMajor> > MapXdr;
-  typedef Map< Eigen::Matrix<int ,Eigen::Dynamic ,Eigen::Dynamic,RowMajor> > MapXir;
+  typedef Eigen::Map< Eigen::Matrix<double ,Eigen::Dynamic ,Eigen::Dynamic,Eigen::RowMajor> > MapXdr;
+  typedef Eigen::Map< Eigen::Matrix<int ,Eigen::Dynamic ,Eigen::Dynamic,Eigen::RowMajor> > MapXir;
  
   // To-do: reduce duplicate code with triangulate.cpp
   // Prepare the input struct

--- a/include/igl/triangle/scaf.cpp
+++ b/include/igl/triangle/scaf.cpp
@@ -252,7 +252,6 @@ IGL_INLINE void add_new_patch(igl::triangle::SCAFData &s, const Eigen::MatrixXd 
                    const Eigen::RowVectorXd &/*center*/,
                    const Eigen::MatrixXd &uv_init)
 {
-  using namespace std;
   using namespace Eigen;
 
   assert(uv_init.rows() != 0);
@@ -400,8 +399,6 @@ IGL_INLINE void get_complement(const Eigen::VectorXi &bnd_ids, int v_n, Eigen::A
 IGL_INLINE void build_surface_linear_system(const SCAFData &s, Eigen::SparseMatrix<double> &L, Eigen::VectorXd &rhs)
 {
   using namespace Eigen;
-  using namespace std;
-
   const int v_n = s.v_num - (s.frame_ids.size());
   const int dim = s.dim;
   const int f_n = s.mf_num;
@@ -556,7 +553,6 @@ IGL_INLINE void build_weighted_arap_system(SCAFData &s, Eigen::SparseMatrix<doub
 IGL_INLINE void solve_weighted_arap(SCAFData &s, Eigen::MatrixXd &uv)
 {
   using namespace Eigen;
-  using namespace std;
   int dim = s.dim;
   igl::Timer timer;
   timer.start();
@@ -681,7 +677,6 @@ IGL_INLINE void igl::triangle::scaf_precompute(
 
 IGL_INLINE Eigen::MatrixXd igl::triangle::scaf_solve(const int iter_num, igl::triangle::SCAFData &s)
 {
-  using namespace std;
   using namespace Eigen;
   s.energy = igl::triangle::scaf::compute_energy(s, s.w_uv, false) / s.mesh_measure;
 

--- a/include/igl/triangle/scaf.cpp
+++ b/include/igl/triangle/scaf.cpp
@@ -150,7 +150,7 @@ IGL_INLINE void mesh_improve(igl::triangle::SCAFData &s)
 
   if (s.rect_frame_V.size() == 0)
   {
-    Matrix2d ob; // = rect_corners;
+    Eigen::Matrix2d ob; // = rect_corners;
     {
       Eigen::VectorXd uv_max = m_uv.colwise().maxCoeff();
       Eigen::VectorXd uv_min = m_uv.colwise().minCoeff();
@@ -160,7 +160,7 @@ IGL_INLINE void mesh_improve(igl::triangle::SCAFData &s)
       ob.row(0) = uv_mid.array() + scaf_range * ((uv_min - uv_mid).array());
       ob.row(1) = uv_mid.array() + scaf_range * ((uv_max - uv_mid).array());
     }
-    Vector2d rect_len;
+    Eigen::Vector2d rect_len;
     rect_len << ob(1, 0) - ob(0, 0), ob(1, 1) - ob(0, 1);
     int frame_points = 5;
 
@@ -272,7 +272,7 @@ IGL_INLINE void add_new_patch(igl::triangle::SCAFData &s, const Eigen::MatrixXd 
   for (auto cur_bnd : all_bnds)
   {
     s.internal_bnd.conservativeResize(s.internal_bnd.size() + cur_bnd.size());
-    s.internal_bnd.bottomRows(cur_bnd.size()) = Map<ArrayXi>(cur_bnd.data(), cur_bnd.size()) + s.mv_num;
+    s.internal_bnd.bottomRows(cur_bnd.size()) = Eigen::Map<Eigen::ArrayXi>(cur_bnd.data(), cur_bnd.size()) + s.mv_num;
     s.bnd_sizes.push_back(cur_bnd.size());
   }
 
@@ -428,8 +428,8 @@ IGL_INLINE void build_surface_linear_system(const SCAFData &s, Eigen::SparseMatr
   {
     Eigen::MatrixXd bnd_pos = s.w_uv(bnd_ids, igl::placeholders::all);
 
-    ArrayXi known_ids(bnd_ids.size() * dim);
-    ArrayXi unknown_ids((v_n - bnd_ids.rows()) * dim);
+    Eigen::ArrayXi known_ids(bnd_ids.size() * dim);
+    Eigen::ArrayXi unknown_ids((v_n - bnd_ids.rows()) * dim);
     get_complement(bnd_ids, v_n, unknown_ids);
     Eigen::VectorXd known_pos(bnd_ids.size() * dim);
     for (int d = 0; d < dim; d++)
@@ -487,8 +487,8 @@ IGL_INLINE void build_scaffold_linear_system(const SCAFData &s, Eigen::SparseMat
   IGL_ASSERT(bnd_n > 0);
   Eigen::MatrixXd bnd_pos = s.w_uv(bnd_ids, igl::placeholders::all);
 
-  ArrayXi known_ids(bnd_ids.size() * dim);
-  ArrayXi unknown_ids((v_n - bnd_ids.rows()) * dim);
+  Eigen::ArrayXi known_ids(bnd_ids.size() * dim);
+  Eigen::ArrayXi unknown_ids((v_n - bnd_ids.rows()) * dim);
 
   get_complement(bnd_ids, v_n, unknown_ids);
 
@@ -556,8 +556,8 @@ IGL_INLINE void solve_weighted_arap(SCAFData &s, Eigen::MatrixXd &uv)
   assert(bnd_n > 0);
   Eigen::MatrixXd bnd_pos = s.w_uv(bnd_ids, igl::placeholders::all);
 
-  ArrayXi known_ids(bnd_n * dim);
-  ArrayXi unknown_ids((v_n - bnd_n) * dim);
+  Eigen::ArrayXi known_ids(bnd_n * dim);
+  Eigen::ArrayXi unknown_ids((v_n - bnd_n) * dim);
 
   get_complement(bnd_ids, v_n, unknown_ids);
 
@@ -577,12 +577,12 @@ IGL_INLINE void solve_weighted_arap(SCAFData &s, Eigen::MatrixXd &uv)
 
   Eigen::VectorXd unknown_Uc((v_n - s.frame_ids.size() - s.fixed_ids.size()) * dim), Uc(dim * v_n);
 
-  SimplicialLDLT<Eigen::SparseMatrix<double>> solver;
+  Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> solver;
   unknown_Uc = solver.compute(L).solve(rhs);
   Uc(unknown_ids) = unknown_Uc;
   Uc(known_ids) = known_pos;
 
-  uv = Map<Matrix<double, -1, -1, Eigen::ColMajor>>(Uc.data(), v_n, dim);
+  uv = Eigen::Map<Eigen::Matrix<double, -1, -1, Eigen::ColMajor>>(Uc.data(), v_n, dim);
 }
 
 IGL_INLINE double perform_iteration(SCAFData &s)

--- a/include/igl/triangle/scaf.cpp
+++ b/include/igl/triangle/scaf.cpp
@@ -100,11 +100,10 @@ IGL_INLINE void compute_scaffold_gradient_matrix(SCAFData &s,
                                       Eigen::SparseMatrix<double> &D1,
                                       Eigen::SparseMatrix<double> &D2)
 {
-  using namespace Eigen;
   Eigen::SparseMatrix<double> G;
-  MatrixXi F_s = s.s_T;
+  Eigen::MatrixXi F_s = s.s_T;
   int vn = s.v_num;
-  MatrixXd V = MatrixXd::Zero(vn, 3);
+  Eigen::MatrixXd V = Eigen::MatrixXd::Zero(vn, 3);
   V.leftCols(2) = s.w_uv;
 
   double min_bnd_edge_len = INFINITY;
@@ -131,7 +130,7 @@ IGL_INLINE void compute_scaffold_gradient_matrix(SCAFData &s,
   Eigen::SparseMatrix<double> Dx, Dy, Dz;
   adjusted_grad(V, F_s, area_threshold, Dx, Dy, Dz);
 
-  MatrixXd F1, F2, F3;
+  Eigen::MatrixXd F1, F2, F3;
   igl::local_basis(V, F_s, F1, F2, F3);
   D1 = F1.col(0).asDiagonal() * Dx + F1.col(1).asDiagonal() * Dy +
        F1.col(2).asDiagonal() * Dz;
@@ -141,9 +140,8 @@ IGL_INLINE void compute_scaffold_gradient_matrix(SCAFData &s,
 
 IGL_INLINE void mesh_improve(igl::triangle::SCAFData &s)
 {
-  using namespace Eigen;
-  MatrixXd m_uv = s.w_uv.topRows(s.mv_num);
-  MatrixXd V_bnd;
+  Eigen::MatrixXd m_uv = s.w_uv.topRows(s.mv_num);
+  Eigen::MatrixXd V_bnd;
   V_bnd.resize(s.internal_bnd.size(), 2);
   for (int i = 0; i < s.internal_bnd.size(); i++) // redoing step 1.
   {
@@ -154,9 +152,9 @@ IGL_INLINE void mesh_improve(igl::triangle::SCAFData &s)
   {
     Matrix2d ob; // = rect_corners;
     {
-      VectorXd uv_max = m_uv.colwise().maxCoeff();
-      VectorXd uv_min = m_uv.colwise().minCoeff();
-      VectorXd uv_mid = (uv_max + uv_min) / 2.;
+      Eigen::VectorXd uv_max = m_uv.colwise().maxCoeff();
+      Eigen::VectorXd uv_min = m_uv.colwise().minCoeff();
+      Eigen::VectorXd uv_mid = (uv_max + uv_min) / 2.;
 
       Eigen::Array2d scaf_range(3, 3);
       ob.row(0) = uv_mid.array() + scaf_range * ((uv_min - uv_mid).array());
@@ -187,8 +185,8 @@ IGL_INLINE void mesh_improve(igl::triangle::SCAFData &s)
   }
 
   // Concatenate Vert and Edge
-  MatrixXd V;
-  MatrixXi E;
+  Eigen::MatrixXd V;
+  Eigen::MatrixXi E;
   igl::cat(1, V_bnd, s.rect_frame_V, V);
   E.resize(V.rows(), 2);
   for (int i = 0; i < E.rows(); i++)
@@ -202,7 +200,7 @@ IGL_INLINE void mesh_improve(igl::triangle::SCAFData &s)
   E(V.rows() - 1, 1) = acc_bs;
   assert(acc_bs == s.internal_bnd.size());
 
-  MatrixXd H = MatrixXd::Zero(s.component_sizes.size(), 2);
+  Eigen::MatrixXd H = Eigen::MatrixXd::Zero(s.component_sizes.size(), 2);
   {
     int hole_f = 0;
     int hole_i = 0;
@@ -216,7 +214,7 @@ IGL_INLINE void mesh_improve(igl::triangle::SCAFData &s)
   }
   H /= 3.;
 
-  MatrixXd uv2;
+  Eigen::MatrixXd uv2;
   igl::triangle::triangulate(V, E, H, std::basic_string<char>("qYYQ"), uv2, s.s_T);
   auto bnd_n = s.internal_bnd.size();
 
@@ -242,7 +240,7 @@ IGL_INLINE void mesh_improve(igl::triangle::SCAFData &s)
   s.Dx_s.makeCompressed();
   s.Dy_s.makeCompressed();
   s.Dz_s.makeCompressed();
-  s.Ri_s = MatrixXd::Zero(s.Dx_s.rows(), s.dim * s.dim);
+  s.Ri_s = Eigen::MatrixXd::Zero(s.Dx_s.rows(), s.dim * s.dim);
   s.Ji_s.resize(s.Dx_s.rows(), s.dim * s.dim);
   s.W_s.resize(s.Dx_s.rows(), s.dim * s.dim);
 }
@@ -252,8 +250,6 @@ IGL_INLINE void add_new_patch(igl::triangle::SCAFData &s, const Eigen::MatrixXd 
                    const Eigen::RowVectorXd &/*center*/,
                    const Eigen::MatrixXd &uv_init)
 {
-  using namespace Eigen;
-
   assert(uv_init.rows() != 0);
   Eigen::VectorXd M;
   igl::doublearea(V_ref, F_ref, M);
@@ -267,7 +263,7 @@ IGL_INLINE void add_new_patch(igl::triangle::SCAFData &s, const Eigen::MatrixXd 
 
   s.component_sizes.push_back(F_ref.rows());
 
-  MatrixXd m_uv = s.w_uv.topRows(s.mv_num);
+  Eigen::MatrixXd m_uv = s.w_uv.topRows(s.mv_num);
   igl::cat(1, m_uv, uv_init, s.w_uv);
 
   s.m_M.conservativeResize(s.mf_num + M.size());
@@ -288,7 +284,7 @@ IGL_INLINE void add_new_patch(igl::triangle::SCAFData &s, const Eigen::MatrixXd 
   s.m_V.bottomRows(V_ref.rows()) = V_ref;
   s.mv_num += V_ref.rows();
 
-  s.rect_frame_V = MatrixXd();
+  s.rect_frame_V = Eigen::MatrixXd();
 
   mesh_improve(s);
 }
@@ -398,7 +394,6 @@ IGL_INLINE void get_complement(const Eigen::VectorXi &bnd_ids, int v_n, Eigen::A
 
 IGL_INLINE void build_surface_linear_system(const SCAFData &s, Eigen::SparseMatrix<double> &L, Eigen::VectorXd &rhs)
 {
-  using namespace Eigen;
   const int v_n = s.v_num - (s.frame_ids.size());
   const int dim = s.dim;
   const int f_n = s.mf_num;
@@ -412,7 +407,7 @@ IGL_INLINE void build_surface_linear_system(const SCAFData &s, Eigen::SparseMatr
   decoy_Dy_m.conservativeResize(s.W_m.rows(), v_n);
   buildAm(sqrtM, decoy_Dx_m, decoy_Dy_m, s.W_m, A);
 
-  const VectorXi &bnd_ids = s.fixed_ids;
+  const Eigen::VectorXi &bnd_ids = s.fixed_ids;
   auto bnd_n = bnd_ids.size();
   if (bnd_n == 0)
   {
@@ -431,12 +426,12 @@ IGL_INLINE void build_surface_linear_system(const SCAFData &s, Eigen::SparseMatr
   }
   else
   {
-    MatrixXd bnd_pos = s.w_uv(bnd_ids, igl::placeholders::all);
+    Eigen::MatrixXd bnd_pos = s.w_uv(bnd_ids, igl::placeholders::all);
 
     ArrayXi known_ids(bnd_ids.size() * dim);
     ArrayXi unknown_ids((v_n - bnd_ids.rows()) * dim);
     get_complement(bnd_ids, v_n, unknown_ids);
-    VectorXd known_pos(bnd_ids.size() * dim);
+    Eigen::VectorXd known_pos(bnd_ids.size() * dim);
     for (int d = 0; d < dim; d++)
     {
       auto n_b = bnd_ids.rows();
@@ -477,8 +472,6 @@ IGL_INLINE void build_surface_linear_system(const SCAFData &s, Eigen::SparseMatr
 
 IGL_INLINE void build_scaffold_linear_system(const SCAFData &s, Eigen::SparseMatrix<double> &L, Eigen::VectorXd &rhs)
 {
-  using namespace Eigen;
-
   const int f_n = s.W_s.rows();
   const int v_n = s.Dx_s.cols();
   const int dim = s.dim;
@@ -487,19 +480,19 @@ IGL_INLINE void build_scaffold_linear_system(const SCAFData &s, Eigen::SparseMat
   Eigen::SparseMatrix<double> A(dim * dim * f_n, dim * v_n);
   buildAm(sqrtM, s.Dx_s, s.Dy_s, s.W_s, A);
 
-  VectorXi bnd_ids;
+  Eigen::VectorXi bnd_ids;
   igl::cat(1, s.fixed_ids, s.frame_ids, bnd_ids);
 
   auto bnd_n = bnd_ids.size();
   IGL_ASSERT(bnd_n > 0);
-  MatrixXd bnd_pos = s.w_uv(bnd_ids, igl::placeholders::all);
+  Eigen::MatrixXd bnd_pos = s.w_uv(bnd_ids, igl::placeholders::all);
 
   ArrayXi known_ids(bnd_ids.size() * dim);
   ArrayXi unknown_ids((v_n - bnd_ids.rows()) * dim);
 
   get_complement(bnd_ids, v_n, unknown_ids);
 
-  VectorXd known_pos(bnd_ids.size() * dim);
+  Eigen::VectorXd known_pos(bnd_ids.size() * dim);
   for (int d = 0; d < dim; d++)
   {
     auto n_b = bnd_ids.rows();
@@ -552,24 +545,23 @@ IGL_INLINE void build_weighted_arap_system(SCAFData &s, Eigen::SparseMatrix<doub
 
 IGL_INLINE void solve_weighted_arap(SCAFData &s, Eigen::MatrixXd &uv)
 {
-  using namespace Eigen;
   int dim = s.dim;
   igl::Timer timer;
   timer.start();
 
-  VectorXi bnd_ids;
+  Eigen::VectorXi bnd_ids;
   igl::cat(1, s.fixed_ids, s.frame_ids, bnd_ids);
   const auto v_n = s.v_num;
   const auto bnd_n = bnd_ids.size();
   assert(bnd_n > 0);
-  MatrixXd bnd_pos = s.w_uv(bnd_ids, igl::placeholders::all);
+  Eigen::MatrixXd bnd_pos = s.w_uv(bnd_ids, igl::placeholders::all);
 
   ArrayXi known_ids(bnd_n * dim);
   ArrayXi unknown_ids((v_n - bnd_n) * dim);
 
   get_complement(bnd_ids, v_n, unknown_ids);
 
-  VectorXd known_pos(bnd_ids.size() * dim);
+  Eigen::VectorXd known_pos(bnd_ids.size() * dim);
   for (int d = 0; d < dim; d++)
   {
     auto n_b = bnd_ids.rows();
@@ -677,7 +669,6 @@ IGL_INLINE void igl::triangle::scaf_precompute(
 
 IGL_INLINE Eigen::MatrixXd igl::triangle::scaf_solve(const int iter_num, igl::triangle::SCAFData &s)
 {
-  using namespace Eigen;
   s.energy = igl::triangle::scaf::compute_energy(s, s.w_uv, false) / s.mesh_measure;
 
   for (int it = 0; it < iter_num; it++)

--- a/include/igl/triangle/triangulate.cpp
+++ b/include/igl/triangle/triangulate.cpp
@@ -52,8 +52,6 @@ IGL_INLINE void igl::triangle::triangulate(
   Eigen::PlainObjectBase<DerivedE2> & E2,
   Eigen::PlainObjectBase<DerivedEM2> & EM2)
 {
-  using namespace Eigen;
-
   assert( (VM.size() == 0 || V.rows() == VM.size()) &&
     "Vertex markers must be empty or same size as V");
   assert( (EM.size() == 0 || E.rows() == EM.size()) &&
@@ -65,8 +63,8 @@ IGL_INLINE void igl::triangle::triangulate(
   // Prepare the flags
   std::string full_flags = flags + "pz" + (EM.size() || VM.size() ? "" : "B");
 
-  typedef Map< Matrix<double,Dynamic,Dynamic,RowMajor> > MapXdr;
-  typedef Map< Matrix<int,Dynamic,Dynamic,RowMajor> > MapXir;
+  typedef Map< Eigen::Matrix<double ,Eigen::Dynamic ,Eigen::Dynamic,RowMajor> > MapXdr;
+  typedef Map< Eigen::Matrix<int ,Eigen::Dynamic ,Eigen::Dynamic,RowMajor> > MapXir;
 
   // Prepare the input struct
   triangulateio in;

--- a/include/igl/triangle/triangulate.cpp
+++ b/include/igl/triangle/triangulate.cpp
@@ -63,8 +63,8 @@ IGL_INLINE void igl::triangle::triangulate(
   // Prepare the flags
   std::string full_flags = flags + "pz" + (EM.size() || VM.size() ? "" : "B");
 
-  typedef Map< Eigen::Matrix<double ,Eigen::Dynamic ,Eigen::Dynamic,RowMajor> > MapXdr;
-  typedef Map< Eigen::Matrix<int ,Eigen::Dynamic ,Eigen::Dynamic,RowMajor> > MapXir;
+  typedef Eigen::Map< Eigen::Matrix<double ,Eigen::Dynamic ,Eigen::Dynamic,Eigen::RowMajor> > MapXdr;
+  typedef Eigen::Map< Eigen::Matrix<int ,Eigen::Dynamic ,Eigen::Dynamic,Eigen::RowMajor> > MapXir;
 
   // Prepare the input struct
   triangulateio in;

--- a/include/igl/triangle/triangulate.cpp
+++ b/include/igl/triangle/triangulate.cpp
@@ -52,7 +52,6 @@ IGL_INLINE void igl::triangle::triangulate(
   Eigen::PlainObjectBase<DerivedE2> & E2,
   Eigen::PlainObjectBase<DerivedEM2> & EM2)
 {
-  using namespace std;
   using namespace Eigen;
 
   assert( (VM.size() == 0 || V.rows() == VM.size()) &&
@@ -64,7 +63,7 @@ IGL_INLINE void igl::triangle::triangulate(
   assert(H.size() == 0 || H.cols() == 2);
 
   // Prepare the flags
-  string full_flags = flags + "pz" + (EM.size() || VM.size() ? "" : "B");
+  std::string full_flags = flags + "pz" + (EM.size() || VM.size() ? "" : "B");
 
   typedef Map< Matrix<double,Dynamic,Dynamic,RowMajor> > MapXdr;
   typedef Map< Matrix<int,Dynamic,Dynamic,RowMajor> > MapXir;

--- a/include/igl/triangle_fan.cpp
+++ b/include/igl/triangle_fan.cpp
@@ -14,8 +14,6 @@ IGL_INLINE void igl::triangle_fan(
   const Eigen::MatrixBase<DerivedE> & E,
   Eigen::PlainObjectBase<Derivedcap> & cap)
 {
-  using namespace Eigen;
-
   // Handle lame base case
   if(E.size() == 0)
   {

--- a/include/igl/triangle_fan.cpp
+++ b/include/igl/triangle_fan.cpp
@@ -14,7 +14,6 @@ IGL_INLINE void igl::triangle_fan(
   const Eigen::MatrixBase<DerivedE> & E,
   Eigen::PlainObjectBase<Derivedcap> & cap)
 {
-  using namespace std;
   using namespace Eigen;
 
   // Handle lame base case
@@ -30,7 +29,7 @@ IGL_INLINE void igl::triangle_fan(
   // Arbitrary starting vertex
   //int s = E(int(((double)rand() / RAND_MAX)*E.rows()),0);
   int s = E(rand()%E.rows(),0);
-  vector<vector<int> >  lcap;
+  std::vector<std::vector<int> >  lcap;
   for(int i = 0;i<E.rows();i++)
   {
     // Skip edges incident on s (they would be zero-area)
@@ -38,7 +37,7 @@ IGL_INLINE void igl::triangle_fan(
     {
       continue;
     }
-    vector<int> e(3);
+    std::vector<int> e(3);
     e[0] = s;
     e[1] = E(i,0);
     e[2] = E(i,1);

--- a/include/igl/triangle_triangle_adjacency.cpp
+++ b/include/igl/triangle_triangle_adjacency.cpp
@@ -177,7 +177,6 @@ template <
     std::vector<std::vector<std::vector<TTiIndex> > > & TTi)
 {
   using namespace Eigen;
-  using namespace std;
   assert(F.cols() == 3 && "Faces must be triangles");
   // number of faces
   typedef typename DerivedF::Index Index;
@@ -185,7 +184,7 @@ template <
   typedef Matrix<typename DerivedF::Index,Dynamic,1> VectorXI;
   MatrixX2I E,uE;
   VectorXI EMAP;
-  vector<vector<Index> > uE2E;
+  std::vector<std::vector<Index> > uE2E;
   unique_edge_map(F,E,uE,EMAP,uE2E);
   return triangle_triangle_adjacency(E,EMAP,uE2E,construct_TTi,TT,TTi);
 }
@@ -204,17 +203,16 @@ template <
     std::vector<std::vector<std::vector<TTIndex> > > & TT,
     std::vector<std::vector<std::vector<TTiIndex> > > & TTi)
 {
-  using namespace std;
   using namespace Eigen;
   typedef typename DerivedE::Index Index;
   const size_t m = E.rows()/3;
   assert((size_t)E.rows() == m*3 && "E should come from list of triangles.");
   // E2E[i] --> {j,k,...} means face edge i corresponds to other faces edges j
   // and k
-  TT.resize (m,vector<vector<TTIndex> >(3));
+  TT.resize (m,std::vector<std::vector<TTIndex> >(3));
   if(construct_TTi)
   {
-    TTi.resize(m,vector<vector<TTiIndex> >(3));
+    TTi.resize(m,std::vector<std::vector<TTiIndex> >(3));
   }
 
   // No race conditions because TT*[f][c]'s are in bijection with e's
@@ -229,7 +227,7 @@ template <
       {
         const Index e = f + m*c;
         //const Index c = e/m;
-        const vector<uE2EType> & N = uE2E[EMAP(e)];
+        const std::vector<uE2EType> & N = uE2E[EMAP(e)];
         for(const auto & ne : N)
         {
           const Index nf = ne%m;
@@ -263,17 +261,16 @@ template <
     std::vector<std::vector<std::vector<TTIndex> > > & TT,
     std::vector<std::vector<std::vector<TTiIndex> > > & TTi)
 {
-  using namespace std;
   using namespace Eigen;
   typedef Eigen::Index Index;
   const size_t m = EMAP.rows()/3;
   assert((size_t)EMAP.rows() == m*3 && "EMAP should come from list of triangles.");
   // E2E[i] --> {j,k,...} means face edge i corresponds to other faces edges j
   // and k
-  TT.resize (m,vector<vector<TTIndex> >(3));
+  TT.resize (m,std::vector<std::vector<TTIndex> >(3));
   if(construct_TTi)
   {
-    TTi.resize(m,vector<vector<TTiIndex> >(3));
+    TTi.resize(m,std::vector<std::vector<TTiIndex> >(3));
   }
 
   // No race conditions because TT*[f][c]'s are in bijection with e's

--- a/include/igl/triangle_triangle_adjacency.cpp
+++ b/include/igl/triangle_triangle_adjacency.cpp
@@ -176,12 +176,11 @@ template <
     std::vector<std::vector<std::vector<TTIndex> > > & TT,
     std::vector<std::vector<std::vector<TTiIndex> > > & TTi)
 {
-  using namespace Eigen;
   assert(F.cols() == 3 && "Faces must be triangles");
   // number of faces
   typedef typename DerivedF::Index Index;
-  typedef Matrix<typename DerivedF::Scalar,Dynamic,2> MatrixX2I;
-  typedef Matrix<typename DerivedF::Index,Dynamic,1> VectorXI;
+  typedef Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,2> MatrixX2I;
+  typedef Eigen::Matrix<typename DerivedF::Index ,Eigen::Dynamic,1> VectorXI;
   MatrixX2I E,uE;
   VectorXI EMAP;
   std::vector<std::vector<Index> > uE2E;
@@ -203,7 +202,6 @@ template <
     std::vector<std::vector<std::vector<TTIndex> > > & TT,
     std::vector<std::vector<std::vector<TTiIndex> > > & TTi)
 {
-  using namespace Eigen;
   typedef typename DerivedE::Index Index;
   const size_t m = E.rows()/3;
   assert((size_t)E.rows() == m*3 && "E should come from list of triangles.");
@@ -261,7 +259,6 @@ template <
     std::vector<std::vector<std::vector<TTIndex> > > & TT,
     std::vector<std::vector<std::vector<TTiIndex> > > & TTi)
 {
-  using namespace Eigen;
   typedef Eigen::Index Index;
   const size_t m = EMAP.rows()/3;
   assert((size_t)EMAP.rows() == m*3 && "EMAP should come from list of triangles.");

--- a/include/igl/triangles_from_strip.cpp
+++ b/include/igl/triangles_from_strip.cpp
@@ -13,7 +13,6 @@ IGL_INLINE void igl::triangles_from_strip(
   const Eigen::MatrixBase<DerivedS>& S,
   Eigen::PlainObjectBase<DerivedF>& F)
 {
-  using namespace std;
   F.resize(S.size()-2,3);
   for(int s = 0;s < S.size()-2;s++)
   {

--- a/include/igl/triangulated_grid.cpp
+++ b/include/igl/triangulated_grid.cpp
@@ -20,7 +20,6 @@ IGL_INLINE void igl::triangulated_grid(
   Eigen::PlainObjectBase<DerivedGV> & GV,
   Eigen::PlainObjectBase<DerivedGF> & GF)
 {
-  using namespace Eigen;
   Eigen::Matrix<XType,2,1> res(nx,ny);
   igl::grid(res,GV);
   return igl::triangulated_grid(nx,ny,GF);

--- a/include/igl/uniformly_sample_two_manifold.cpp
+++ b/include/igl/uniformly_sample_two_manifold.cpp
@@ -27,8 +27,6 @@ IGL_INLINE void igl::uniformly_sample_two_manifold(
   const double push,
   Eigen::MatrixXd & WS)
 {
-  using namespace Eigen;
-
   // Euclidean distance between two points on a mesh given as barycentric
   // coordinates
   // Inputs:
@@ -62,12 +60,12 @@ IGL_INLINE void igl::uniformly_sample_two_manifold(
   if(F.cols() == 4)
   {
     verbose("uniform_sample.h: sampling tet mesh\n");
-    MatrixXi T0 = F.col(0);
-    MatrixXi T1 = F.col(1);
-    MatrixXi T2 = F.col(2);
-    MatrixXi T3 = F.col(3);
+    Eigen::MatrixXi T0 = F.col(0);
+    Eigen::MatrixXi T1 = F.col(1);
+    Eigen::MatrixXi T2 = F.col(2);
+    Eigen::MatrixXi T3 = F.col(3);
     // Faces from tets
-    MatrixXi TF =
+    Eigen::MatrixXi TF =
       cat(1,
         cat(1,
           cat(2,T0, cat(2,T1,T2)),
@@ -84,7 +82,7 @@ IGL_INLINE void igl::uniformly_sample_two_manifold(
 
   double start = get_seconds();
 
-  VectorXi S;
+  Eigen::VectorXi S;
   // First get sampling as best as possible on mesh
   uniformly_sample_two_manifold_at_vertices(W,k,push,S);
   verbose("Lap: %g\n",get_seconds()-start);
@@ -108,10 +106,10 @@ IGL_INLINE void igl::uniformly_sample_two_manifold(
   std::vector<int> cur_maxmin; cur_maxmin.resize(k);
   // List of distance matrices, D(i)(s,j) reveals distance from i's sth sample
   // to jth seed if j<k or (j-k)th "pushed" corner
-  std::vector<MatrixXd> D; D.resize(k);
+  std::vector<Eigen::MatrixXd> D; D.resize(k);
 
   // Precompute an W.cols() by W.cols() identity matrix
-  MatrixXd I(MatrixXd::Identity(W.cols(),W.cols()));
+  Eigen::MatrixXd I(Eigen::MatrixXd::Identity(W.cols(),W.cols()));
 
   // Describe each seed as a face index and barycentric coordinates
   for(int i = 0;i < k;i++)
@@ -163,7 +161,7 @@ IGL_INLINE void igl::uniformly_sample_two_manifold(
       sample_barys[i].push_back(bary);
       sample_faces[i].push_back(face_i);
       // Current seed location in weight space
-      VectorXd seed =
+      Eigen::VectorXd seed =
         bary(0)*W.row(F(face_i,0)) +
         bary(1)*W.row(F(face_i,1)) +
         bary(2)*W.row(F(face_i,2));
@@ -288,7 +286,7 @@ IGL_INLINE void igl::uniformly_sample_two_manifold(
       for(int i = 0;i < k;i++)
       {
         // for each sample look at distance to closest seed/corner
-        VectorXd minD = D[i].rowwise().minCoeff();
+        Eigen::VectorXd minD = D[i].rowwise().minCoeff();
         assert(minD.size() == (int)sample_faces[i].size());
         // find random sample with maximum minimum distance to other seeds
         int old_cur_maxmin = cur_maxmin[i];
@@ -347,19 +345,18 @@ IGL_INLINE void igl::uniformly_sample_two_manifold_at_vertices(
   const double push,
   Eigen::VectorXi & S)
 {
-  using namespace Eigen;
   // Copy weights and faces
-  const MatrixXd & W = OW;
-  /*const MatrixXi & F = OF;*/
+  const Eigen::MatrixXd & W = OW;
+  /*const Eigen::MatrixXi & F = OF;*/
 
   // Initialize seeds
-  VectorXi G;
-  Matrix<double,Dynamic,1>  ignore;
+  Eigen::VectorXi G;
+  Eigen::Matrix<double ,Eigen::Dynamic,1>  ignore;
   partition(W,k+W.cols(),G,S,ignore);
   // Remove corners, which better be at top
   S = S.segment(W.cols(),k).eval();
 
-  MatrixXd WS = W(S,igl::placeholders::all);
+  Eigen::MatrixXd WS = W(S,igl::placeholders::all);
   //cout<<"WSpartition=["<<endl<<WS<<endl<<"];"<<endl;
 
   // number of vertices
@@ -367,12 +364,12 @@ IGL_INLINE void igl::uniformly_sample_two_manifold_at_vertices(
   // number of dimensions in weight space
   int m = W.cols();
   // Corners of weight space
-  MatrixXd I = MatrixXd::Identity(m,m);
+  Eigen::MatrixXd I = Eigen::MatrixXd::Identity(m,m);
   // append corners to bottom of weights
-  MatrixXd WI(n+m,m);
+  Eigen::MatrixXd WI(n+m,m);
   WI << W,I;
   // Weights at seeds and corners
-  MatrixXd WSC(k+m,m);
+  Eigen::MatrixXd WSC(k+m,m);
   for(int i = 0;i<k;i++)
   {
     WSC.row(i) = W.row(S(i));
@@ -382,7 +379,7 @@ IGL_INLINE void igl::uniformly_sample_two_manifold_at_vertices(
     WSC.row(i+k) = WI.row(n+i);
   }
   // initialize all pairs sqaured distances
-  MatrixXd sqrD;
+  Eigen::MatrixXd sqrD;
   all_pairs_distances(WI,WSC,true,sqrD);
   // bring in corners by push factor (squared because distances are squared)
   sqrD.block(0,k,sqrD.rows(),m) /= push*push;
@@ -400,11 +397,11 @@ IGL_INLINE void igl::uniformly_sample_two_manifold_at_vertices(
       sqrD.col(i).setZero();
       sqrD.col(i).array() += 10;
       // find vertex farthers from all other seeds
-      MatrixXd minsqrD = sqrD.rowwise().minCoeff();
-      MatrixXd::Index si,PHONY;
+      Eigen::MatrixXd minsqrD = sqrD.rowwise().minCoeff();
+      Eigen::MatrixXd::Index si,PHONY;
       minsqrD.maxCoeff(&si,&PHONY);
-      MatrixXd Wsi = W.row(si);
-      MatrixXd sqrDi;
+      Eigen::MatrixXd Wsi = W.row(si);
+      Eigen::MatrixXd sqrDi;
       all_pairs_distances(WI,Wsi,true,sqrDi);
       sqrD.col(i) = sqrDi;
       S(i) = si;

--- a/include/igl/uniformly_sample_two_manifold.cpp
+++ b/include/igl/uniformly_sample_two_manifold.cpp
@@ -28,7 +28,6 @@ IGL_INLINE void igl::uniformly_sample_two_manifold(
   Eigen::MatrixXd & WS)
 {
   using namespace Eigen;
-  using namespace std;
 
   // Euclidean distance between two points on a mesh given as barycentric
   // coordinates
@@ -97,19 +96,19 @@ IGL_INLINE void igl::uniformly_sample_two_manifold(
 //#endif
 
   // Build map from vertices to list of incident faces
-  vector<vector<int> > VF,VFi;
+  std::vector<std::vector<int> > VF,VFi;
   vertex_triangle_adjacency(W,F,VF,VFi);
 
   // List of list of face indices, for each sample gives index to face it is on
-  vector<vector<int> > sample_faces; sample_faces.resize(k);
+  std::vector<std::vector<int> > sample_faces; sample_faces.resize(k);
   // List of list of barycentric coordinates, for each sample gives b-coords in
   // face its on
-  vector<vector<Eigen::Vector3d> > sample_barys; sample_barys.resize(k);
+  std::vector<std::vector<Eigen::Vector3d> > sample_barys; sample_barys.resize(k);
   // List of current maxmins amongst samples
-  vector<int> cur_maxmin; cur_maxmin.resize(k);
+  std::vector<int> cur_maxmin; cur_maxmin.resize(k);
   // List of distance matrices, D(i)(s,j) reveals distance from i's sth sample
   // to jth seed if j<k or (j-k)th "pushed" corner
-  vector<MatrixXd> D; D.resize(k);
+  std::vector<MatrixXd> D; D.resize(k);
 
   // Precompute an W.cols() by W.cols() identity matrix
   MatrixXd I(MatrixXd::Identity(W.cols(),W.cols()));
@@ -155,7 +154,7 @@ IGL_INLINE void igl::uniformly_sample_two_manifold(
       // find closest mesh vertex
       int vertex_i = F(face_i,index_in_face);
       // incident triangles
-      vector<int> incident_F = VF[vertex_i];
+      std::vector<int> incident_F = VF[vertex_i];
       // We're going to try to place num_rand_samples_per_triangle samples on
       // each sample *after* this location
       sample_barys[i].clear();
@@ -349,8 +348,6 @@ IGL_INLINE void igl::uniformly_sample_two_manifold_at_vertices(
   Eigen::VectorXi & S)
 {
   using namespace Eigen;
-  using namespace std;
-
   // Copy weights and faces
   const MatrixXd & W = OW;
   /*const MatrixXi & F = OF;*/

--- a/include/igl/unique.cpp
+++ b/include/igl/unique.cpp
@@ -24,7 +24,6 @@ IGL_INLINE void igl::unique(
   std::vector<size_t> & IA,
   std::vector<size_t> & IC)
 {
-  using namespace std;
   std::vector<size_t> IM;
   std::vector<T> sortA;
   igl::sort(A,true,sortA,IM);
@@ -82,11 +81,10 @@ IGL_INLINE void igl::unique(
     Eigen::PlainObjectBase<DerivedIA> & IA,
     Eigen::PlainObjectBase<DerivedIC> & IC)
 {
-  using namespace std;
   using namespace Eigen;
-  vector<typename DerivedA::Scalar > vA;
-  vector<typename DerivedC::Scalar > vC;
-  vector<size_t> vIA,vIC;
+  std::vector<typename DerivedA::Scalar > vA;
+  std::vector<typename DerivedC::Scalar > vC;
+  std::vector<size_t> vIA,vIC;
   matrix_to_list(A,vA);
   unique(vA,vC,vIA,vIC);
   list_to_matrix(vC,C);
@@ -102,11 +100,10 @@ IGL_INLINE void igl::unique(
     const Eigen::MatrixBase<DerivedA> & A,
     Eigen::PlainObjectBase<DerivedC> & C)
 {
-  using namespace std;
   using namespace Eigen;
-  vector<typename DerivedA::Scalar > vA;
-  vector<typename DerivedC::Scalar > vC;
-  vector<size_t> vIA,vIC;
+  std::vector<typename DerivedA::Scalar > vA;
+  std::vector<typename DerivedC::Scalar > vC;
+  std::vector<size_t> vIA,vIC;
   matrix_to_list(A,vA);
   unique(vA,vC,vIA,vIC);
   list_to_matrix(vC,C);

--- a/include/igl/unique.cpp
+++ b/include/igl/unique.cpp
@@ -81,7 +81,6 @@ IGL_INLINE void igl::unique(
     Eigen::PlainObjectBase<DerivedIA> & IA,
     Eigen::PlainObjectBase<DerivedIC> & IC)
 {
-  using namespace Eigen;
   std::vector<typename DerivedA::Scalar > vA;
   std::vector<typename DerivedC::Scalar > vC;
   std::vector<size_t> vIA,vIC;
@@ -100,7 +99,6 @@ IGL_INLINE void igl::unique(
     const Eigen::MatrixBase<DerivedA> & A,
     Eigen::PlainObjectBase<DerivedC> & C)
 {
-  using namespace Eigen;
   std::vector<typename DerivedA::Scalar > vA;
   std::vector<typename DerivedC::Scalar > vC;
   std::vector<size_t> vIA,vIC;

--- a/include/igl/unique_edge_map.cpp
+++ b/include/igl/unique_edge_map.cpp
@@ -30,11 +30,10 @@ IGL_INLINE void igl::unique_edge_map(
     (DerivedEMAP::RowsAtCompileTime == 1 || DerivedEMAP::ColsAtCompileTime == 1) ,
     "EMAP need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
   using namespace Eigen;
-  using namespace std;
   unique_edge_map(F,E,uE,EMAP);
   uE2E.resize(uE.rows());
   // This does help a little
-  for_each(uE2E.begin(),uE2E.end(),[](vector<uE2EType > & v){v.reserve(2);});
+  for_each(uE2E.begin(),uE2E.end(),[](std::vector<uE2EType > & v){v.reserve(2);});
   const size_t ne = E.rows();
   IGL_ASSERT((size_t)EMAP.size() == ne);
   for(uE2EType e = 0;e<(uE2EType)ne;e++)
@@ -55,7 +54,6 @@ IGL_INLINE void igl::unique_edge_map(
   Eigen::PlainObjectBase<DerivedEMAP> & EMAP)
 {
   using namespace Eigen;
-  using namespace std;
   // All occurrences of directed edges
   oriented_facets(F,E);
   const size_t ne = E.rows();

--- a/include/igl/unique_edge_map.cpp
+++ b/include/igl/unique_edge_map.cpp
@@ -29,7 +29,6 @@ IGL_INLINE void igl::unique_edge_map(
   static_assert(
     (DerivedEMAP::RowsAtCompileTime == 1 || DerivedEMAP::ColsAtCompileTime == 1) ,
     "EMAP need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
-  using namespace Eigen;
   unique_edge_map(F,E,uE,EMAP);
   uE2E.resize(uE.rows());
   // This does help a little
@@ -53,14 +52,13 @@ IGL_INLINE void igl::unique_edge_map(
   Eigen::PlainObjectBase<DeriveduE> & uE,
   Eigen::PlainObjectBase<DerivedEMAP> & EMAP)
 {
-  using namespace Eigen;
   // All occurrences of directed edges
   oriented_facets(F,E);
   const size_t ne = E.rows();
   // This is 2x faster to create than a map from pairs to lists of edges and 5x
   // faster to access (actually access is probably assympotically faster O(1)
   // vs. O(log m)
-  Matrix<typename DerivedEMAP::Scalar,Dynamic,1> IA;
+  Eigen::Matrix<typename DerivedEMAP::Scalar ,Eigen::Dynamic,1> IA;
   unique_simplices(E,uE,IA,EMAP);
   IGL_ASSERT((size_t)EMAP.size() == ne);
 }
@@ -92,7 +90,7 @@ IGL_INLINE void igl::unique_edge_map(
   igl::cumsum(uEK,1,true,uEC);
   IGL_ASSERT(uEK.rows()+1 == uEC.rows());
   // running inner offset in uEE
-  VectorXI uEO = VectorXI::Zero(uE.rows(),1);
+  Eigen::VectorXi uEO = Eigen::VectorXi::Zero(uE.rows(),1);
   // flat array of faces incide on each uE
   uEE.resize(EMAP.rows(),1);
   for(Eigen::Index e = 0;e<EMAP.rows();e++)

--- a/include/igl/unique_rows.cpp
+++ b/include/igl/unique_rows.cpp
@@ -25,7 +25,6 @@ IGL_INLINE void igl::unique_rows(
     (DerivedIA::RowsAtCompileTime == 1 || DerivedIA::ColsAtCompileTime == 1) &&
     (DerivedIC::RowsAtCompileTime == 1 || DerivedIC::ColsAtCompileTime == 1),
     "IA and IC need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
-  using namespace std;
   using namespace Eigen;
   VectorXi IM;
   Eigen::Matrix<typename DerivedA::Scalar, DerivedA::RowsAtCompileTime, DerivedA::ColsAtCompileTime> sortA;
@@ -34,7 +33,7 @@ IGL_INLINE void igl::unique_rows(
 
   const int num_rows = sortA.rows();
   const int num_cols = sortA.cols();
-  vector<int> vIA(num_rows);
+  std::vector<int> vIA(num_rows);
   for(int i=0;i<num_rows;i++)
   {
     vIA[i] = i;

--- a/include/igl/unique_rows.cpp
+++ b/include/igl/unique_rows.cpp
@@ -25,8 +25,7 @@ IGL_INLINE void igl::unique_rows(
     (DerivedIA::RowsAtCompileTime == 1 || DerivedIA::ColsAtCompileTime == 1) &&
     (DerivedIC::RowsAtCompileTime == 1 || DerivedIC::ColsAtCompileTime == 1),
     "IA and IC need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
-  using namespace Eigen;
-  VectorXi IM;
+  Eigen::VectorXi IM;
   Eigen::Matrix<typename DerivedA::Scalar, DerivedA::RowsAtCompileTime, DerivedA::ColsAtCompileTime> sortA;
   sortrows(A,true,sortA,IM);
 

--- a/include/igl/unique_rows.h
+++ b/include/igl/unique_rows.h
@@ -15,9 +15,9 @@ namespace igl
 {
   /// Act like matlab's [C,IA,IC] = unique(X,'rows')
   ///
-  /// @tparam  DerivedA derived scalar type, e.g. MatrixXi or MatrixXd
-  /// @tparam  DerivedIA derived integer type, e.g. MatrixXi
-  /// @tparam  DerivedIC derived integer type, e.g. MatrixXi
+  /// @tparam  DerivedA derived scalar type, e.g. Eigen::MatrixXi or Eigen::MatrixXd
+  /// @tparam  DerivedIA derived integer type, e.g. Eigen::MatrixXi
+  /// @tparam  DerivedIC derived integer type, e.g. Eigen::MatrixXi
   /// @param[in] A  m by n matrix whose entries are to unique'd according to rows
   /// @param[out] C  #C vector of unique rows in A
   /// @param[out] IA  #C index vector so that C = A(IA,:);

--- a/include/igl/unique_simplices.cpp
+++ b/include/igl/unique_simplices.cpp
@@ -26,7 +26,6 @@ IGL_INLINE void igl::unique_simplices(
     (DerivedIA::RowsAtCompileTime == 1 || DerivedIA::ColsAtCompileTime == 1) &&
     (DerivedIC::RowsAtCompileTime == 1 || DerivedIC::ColsAtCompileTime == 1),
     "IA and IC need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
-  using namespace Eigen;
   typedef Eigen::Matrix<typename DerivedF::Scalar,Eigen::Dynamic,Eigen::Dynamic>
     MatrixXI;
   // Sort each face

--- a/include/igl/unique_simplices.cpp
+++ b/include/igl/unique_simplices.cpp
@@ -27,7 +27,6 @@ IGL_INLINE void igl::unique_simplices(
     (DerivedIC::RowsAtCompileTime == 1 || DerivedIC::ColsAtCompileTime == 1),
     "IA and IC need to have RowsAtCompileTime == 1 or ColsAtCompileTime == 1");
   using namespace Eigen;
-  using namespace std;
   typedef Eigen::Matrix<typename DerivedF::Scalar,Eigen::Dynamic,Eigen::Dynamic>
     MatrixXI;
   // Sort each face

--- a/include/igl/unproject_in_mesh.cpp
+++ b/include/igl/unproject_in_mesh.cpp
@@ -24,7 +24,6 @@ template < typename Derivedobj>
       Eigen::PlainObjectBase<Derivedobj> & obj,
       std::vector<igl::Hit<float> > & hits)
 {
-  using namespace std;
   using namespace Eigen;
   Vector3f s,dir;
   unproject_ray(pos,model,proj,viewport,s,dir);
@@ -64,7 +63,6 @@ template < typename DerivedV, typename DerivedF, typename Derivedobj>
       Eigen::PlainObjectBase<Derivedobj> & obj,
       std::vector<igl::Hit<float> > & hits)
 {
-  using namespace std;
   using namespace Eigen;
   const auto Vf = V.template cast<float>().eval();
   const auto & shoot_ray = [&Vf,&F](

--- a/include/igl/unproject_in_mesh.cpp
+++ b/include/igl/unproject_in_mesh.cpp
@@ -24,8 +24,7 @@ template < typename Derivedobj>
       Eigen::PlainObjectBase<Derivedobj> & obj,
       std::vector<igl::Hit<float> > & hits)
 {
-  using namespace Eigen;
-  Vector3f s,dir;
+  Eigen::Vector3f s,dir;
   unproject_ray(pos,model,proj,viewport,s,dir);
   shoot_ray(s,dir,hits);
   switch(hits.size())
@@ -63,7 +62,6 @@ template < typename DerivedV, typename DerivedF, typename Derivedobj>
       Eigen::PlainObjectBase<Derivedobj> & obj,
       std::vector<igl::Hit<float> > & hits)
 {
-  using namespace Eigen;
   const auto Vf = V.template cast<float>().eval();
   const auto & shoot_ray = [&Vf,&F](
     const Eigen::Vector3f& s,

--- a/include/igl/unproject_on_line.cpp
+++ b/include/igl/unproject_on_line.cpp
@@ -15,20 +15,19 @@ void igl::unproject_on_line(
   const Eigen::MatrixBase<Deriveddir> & dir,
   typename DerivedUV::Scalar & t)
 {
-  using namespace Eigen;
   typedef typename DerivedUV::Scalar Scalar;
-  Matrix<Scalar,2,3> A;
-  Matrix<Scalar,2,1> B;
+  Eigen::Matrix<Scalar,2,3> A;
+  Eigen::Matrix<Scalar,2,1> B;
   projection_constraint(UV,M,VP,A,B);
   // min_z,t ‖Az - B‖²  subject to z = origin + t*dir
   // min_t  ‖A(origin + t*dir) - B‖²
   // min_t  ‖A*t*dir + A*origin - B‖²
   // min_t  ‖D*t + C‖²
   // t = -(D'D)\(D'*C)
-  Matrix<Scalar,2,1> C = A*origin.template cast<Scalar>() - B;
-  Matrix<Scalar,2,1> D =    A*dir.template cast<Scalar>();
+  Eigen::Matrix<Scalar,2,1> C = A*origin.template cast<Scalar>() - B;
+  Eigen::Matrix<Scalar,2,1> D =    A*dir.template cast<Scalar>();
   // Solve least squares system directly
-  const Matrix<Scalar,1,1> t_mat = D.jacobiSvd(ComputeFullU | ComputeFullV).solve(-C);
+  const Eigen::Matrix<Scalar,1,1> t_mat = D.jacobiSvd(Eigen::ComputeFullU | Eigen::ComputeFullV).solve(-C);
   t = t_mat(0,0);
 }
 

--- a/include/igl/unproject_on_plane.cpp
+++ b/include/igl/unproject_on_plane.cpp
@@ -15,15 +15,14 @@ void igl::unproject_on_plane(
   const Eigen::MatrixBase<DerivedP> & P,
   Eigen::PlainObjectBase<DerivedZ> & Z)
 {
-  using namespace Eigen;
   typedef typename DerivedZ::Scalar Scalar;
-  Matrix<Scalar,2,3> A;
-  Matrix<Scalar,2,1> B;
+  Eigen::Matrix<Scalar,2,3> A;
+  Eigen::Matrix<Scalar,2,1> B;
   projection_constraint(UV,M,VP,A,B);
-  Matrix<Scalar,3,3> AA;
+  Eigen::Matrix<Scalar,3,3> AA;
   AA.topRows(2) = A.template cast<Scalar>();
   AA.row(2) = P.head(3).template cast<Scalar>();
-  Matrix<Scalar,3,1> BB;
+  Eigen::Matrix<Scalar,3,1> BB;
   BB.head(2) = B.template cast<Scalar>();
   BB(2) = -P(3);
   Z = AA.fullPivHouseholderQr().solve(BB);

--- a/include/igl/unproject_onto_mesh.cpp
+++ b/include/igl/unproject_onto_mesh.cpp
@@ -22,7 +22,6 @@ IGL_INLINE bool igl::unproject_onto_mesh(
   int & fid,
   Eigen::PlainObjectBase<Derivedbc> & bc)
 {
-  using namespace std;
   using namespace Eigen;
   const auto Vf = V.template cast<float>().eval();
   const auto & shoot_ray = [&Vf,&F](
@@ -56,7 +55,6 @@ IGL_INLINE bool igl::unproject_onto_mesh(
   int & fid,
   Eigen::PlainObjectBase<Derivedbc> & bc)
 {
-  using namespace std;
   using namespace Eigen;
   Vector3f s,dir;
   unproject_ray(pos,model,proj,viewport,s,dir);

--- a/include/igl/unproject_onto_mesh.cpp
+++ b/include/igl/unproject_onto_mesh.cpp
@@ -22,7 +22,6 @@ IGL_INLINE bool igl::unproject_onto_mesh(
   int & fid,
   Eigen::PlainObjectBase<Derivedbc> & bc)
 {
-  using namespace Eigen;
   const auto Vf = V.template cast<float>().eval();
   const auto & shoot_ray = [&Vf,&F](
     const Eigen::Vector3f& s,
@@ -55,8 +54,7 @@ IGL_INLINE bool igl::unproject_onto_mesh(
   int & fid,
   Eigen::PlainObjectBase<Derivedbc> & bc)
 {
-  using namespace Eigen;
-  Vector3f s,dir;
+  Eigen::Vector3f s,dir;
   unproject_ray(pos,model,proj,viewport,s,dir);
   Hit<float> hit;
   if(!shoot_ray(s,dir,hit))

--- a/include/igl/unproject_ray.cpp
+++ b/include/igl/unproject_ray.cpp
@@ -23,7 +23,6 @@ IGL_INLINE void igl::unproject_ray(
   Eigen::PlainObjectBase<Deriveds> & s,
   Eigen::PlainObjectBase<Deriveddir> & dir)
 {
-  using namespace std;
   using namespace Eigen;
   // Source and direction on screen
   typedef Eigen::Matrix<typename Deriveds::Scalar,3,1> Vec3;

--- a/include/igl/unproject_ray.cpp
+++ b/include/igl/unproject_ray.cpp
@@ -23,7 +23,6 @@ IGL_INLINE void igl::unproject_ray(
   Eigen::PlainObjectBase<Deriveds> & s,
   Eigen::PlainObjectBase<Deriveddir> & dir)
 {
-  using namespace Eigen;
   // Source and direction on screen
   typedef Eigen::Matrix<typename Deriveds::Scalar,3,1> Vec3;
   Vec3 win_s(pos(0, 0),pos(1, 0),0);

--- a/include/igl/upsample.cpp
+++ b/include/igl/upsample.cpp
@@ -20,8 +20,6 @@ IGL_INLINE void igl::upsample(
   Eigen::SparseMatrix<SType>& S,
   Eigen::PlainObjectBase<DerivedNF>& NF)
 {
-  using namespace Eigen;
-
   typedef Eigen::Triplet<SType> Triplet_t;
 
   Eigen::Matrix< typename DerivedF::Scalar,Eigen::Dynamic,Eigen::Dynamic>

--- a/include/igl/upsample.cpp
+++ b/include/igl/upsample.cpp
@@ -20,7 +20,6 @@ IGL_INLINE void igl::upsample(
   Eigen::SparseMatrix<SType>& S,
   Eigen::PlainObjectBase<DerivedNF>& NF)
 {
-  using namespace std;
   using namespace Eigen;
 
   typedef Eigen::Triplet<SType> Triplet_t;

--- a/include/igl/upsample.h
+++ b/include/igl/upsample.h
@@ -36,8 +36,8 @@ namespace igl
   /// Subdivide a mesh without moving vertices: loop subdivision but odd
   /// vertices stay put and even vertices are just edge midpoints
   ///
-  /// @tparam MatV  matrix for vertex positions, e.g. MatrixXd
-  /// @tparam MatF  matrix for vertex positions, e.g. MatrixXi
+  /// @tparam MatV  matrix for vertex positions, e.g. Eigen::MatrixXd
+  /// @tparam MatF  matrix for vertex positions, e.g. Eigen::MatrixXi
   /// @param[in] V  #V by dim  mesh vertices
   /// @param[in] F  #F by 3  mesh triangles
   /// @param[out] NV new vertex positions, V is guaranteed to be at top

--- a/include/igl/vector_area_matrix.cpp
+++ b/include/igl/vector_area_matrix.cpp
@@ -18,27 +18,25 @@ IGL_INLINE void igl::vector_area_matrix(
   const Eigen::MatrixBase<DerivedF> & F,
   Eigen::SparseMatrix<Scalar>& A)
 {
-  using namespace Eigen;
-
   // number of vertices
   const int n = F.maxCoeff()+1;
 
   assert(F.cols() == 3);
-  MatrixXi E;
+  Eigen::MatrixXi E;
   boundary_facets(F,E);
 
   //Prepare a vector of triplets to set the matrix
-  std::vector<Triplet<Scalar> > tripletList;
+  std::vector<Eigen::Triplet<Scalar> > tripletList;
   tripletList.reserve(4*E.rows());
 
   for(int k = 0; k < E.rows(); k++)
   {
 		int i = E(k,0);
 		int j = E(k,1);
-        tripletList.push_back(Triplet<Scalar>(i+n, j, -0.25));
-        tripletList.push_back(Triplet<Scalar>(j, i+n, -0.25));
-        tripletList.push_back(Triplet<Scalar>(i, j+n, 0.25));
-        tripletList.push_back(Triplet<Scalar>(j+n, i, 0.25));
+        tripletList.push_back(Eigen::Triplet<Scalar>(i+n, j, -0.25));
+        tripletList.push_back(Eigen::Triplet<Scalar>(j, i+n, -0.25));
+        tripletList.push_back(Eigen::Triplet<Scalar>(i, j+n, 0.25));
+        tripletList.push_back(Eigen::Triplet<Scalar>(j+n, i, 0.25));
   }
 
   //Set A from triplets (Eigen will sum triplets with same coordinates)

--- a/include/igl/vector_area_matrix.cpp
+++ b/include/igl/vector_area_matrix.cpp
@@ -19,7 +19,6 @@ IGL_INLINE void igl::vector_area_matrix(
   Eigen::SparseMatrix<Scalar>& A)
 {
   using namespace Eigen;
-  using namespace std;
 
   // number of vertices
   const int n = F.maxCoeff()+1;
@@ -29,7 +28,7 @@ IGL_INLINE void igl::vector_area_matrix(
   boundary_facets(F,E);
 
   //Prepare a vector of triplets to set the matrix
-  vector<Triplet<Scalar> > tripletList;
+  std::vector<Triplet<Scalar> > tripletList;
   tripletList.reserve(4*E.rows());
 
   for(int k = 0; k < E.rows(); k++)

--- a/include/igl/vector_area_matrix.h
+++ b/include/igl/vector_area_matrix.h
@@ -18,9 +18,9 @@ namespace igl
   /// [V.col(0); V.col(1)] is the **vector area** of the mesh (V,F).
   ///
   /// @tparam DerivedV  derived type of eigen matrix for V (e.g. derived from
-  ///     MatrixXd)
+  ///     Eigen::MatrixXd)
   /// @tparam DerivedF  derived type of eigen matrix for F (e.g. derived from
-  ///     MatrixXi)
+  ///     Eigen::MatrixXi)
   /// @tparam Scalar  scalar type for eigen sparse matrix (e.g. double)
   /// @param[in] F  #F by 3 list of mesh faces (must be triangles)
   /// @param[out] A  #Vx2 by #Vx2 area matrix

--- a/include/igl/vertex_components.cpp
+++ b/include/igl/vertex_components.cpp
@@ -16,10 +16,9 @@ IGL_INLINE void igl::vertex_components(
   Eigen::PlainObjectBase<DerivedC> & C,
   Eigen::PlainObjectBase<Derivedcounts> & counts)
 {
-  using namespace Eigen;
   assert(A.rows() == A.cols() && "A should be square.");
   const size_t n = A.rows();
-  Array<bool,Dynamic,1> seen = Array<bool,Dynamic,1>::Zero(n,1);
+  Eigen::Array<bool ,Eigen::Dynamic,1> seen = Eigen::Array<bool ,Eigen::Dynamic,1>::Zero(n,1);
   C.resize(n,1);
   typename DerivedC::Scalar id = 0;
   std::vector<typename Derivedcounts::Scalar> vcounts;

--- a/include/igl/vertex_components.cpp
+++ b/include/igl/vertex_components.cpp
@@ -17,13 +17,12 @@ IGL_INLINE void igl::vertex_components(
   Eigen::PlainObjectBase<Derivedcounts> & counts)
 {
   using namespace Eigen;
-  using namespace std;
   assert(A.rows() == A.cols() && "A should be square.");
   const size_t n = A.rows();
   Array<bool,Dynamic,1> seen = Array<bool,Dynamic,1>::Zero(n,1);
   C.resize(n,1);
   typename DerivedC::Scalar id = 0;
-  vector<typename Derivedcounts::Scalar> vcounts;
+  std::vector<typename Derivedcounts::Scalar> vcounts;
   // breadth first search
   for(int k=0; k<A.outerSize(); ++k)
   {
@@ -31,7 +30,7 @@ IGL_INLINE void igl::vertex_components(
     {
       continue;
     }
-    queue<int> Q;
+    std::queue<int> Q;
     Q.push(k);
     vcounts.push_back(0);
     while(!Q.empty())

--- a/include/igl/vertex_triangle_adjacency.cpp
+++ b/include/igl/vertex_triangle_adjacency.cpp
@@ -56,7 +56,7 @@ IGL_INLINE void igl::vertex_triangle_adjacency(
   typedef Eigen::Matrix<typename DerivedVF::Scalar,Eigen::Dynamic,1> VectorXI;
   // vfd  #V list so that vfd(i) contains the vertex-face degree (number of
   // faces incident on vertex i)
-  VectorXI vfd = VectorXI::Zero(n);
+   VectorXI vfd = VectorXI::Zero(n);
   for (int i = 0; i < F.rows(); i++)
   {
     for (int j = 0; j < 3; j++)

--- a/include/igl/volume.cpp
+++ b/include/igl/volume.cpp
@@ -17,7 +17,6 @@ IGL_INLINE void igl::volume(
   const Eigen::MatrixBase<DerivedT>& T,
   Eigen::PlainObjectBase<Derivedvol>& vol)
 {
-  using namespace Eigen;
   const int m = T.rows();
   vol.resize(m,1);
   for(int t = 0;t<m;t++)
@@ -75,7 +74,6 @@ IGL_INLINE void igl::volume(
   const Eigen::MatrixBase<DerivedL>& L,
   Eigen::PlainObjectBase<Derivedvol>& vol)
 {
-  using namespace Eigen;
   const int m = L.rows();
   typedef typename Derivedvol::Scalar ScalarS;
   vol.resize(m,1);

--- a/include/igl/voxel_grid.cpp
+++ b/include/igl/voxel_grid.cpp
@@ -19,7 +19,6 @@ IGL_INLINE void igl::voxel_grid(
   Eigen::PlainObjectBase<DerivedGV> & GV,
   Eigen::PlainObjectBase<Derivedside> & side)
 {
-  using namespace Eigen;
   typename DerivedGV::Index si = -1;
   side.resize(3);
   box.diagonal().maxCoeff(&si);
@@ -45,17 +44,17 @@ IGL_INLINE void igl::voxel_grid(
   // A * (1-p/s) - A * p/s = max-min
   // A * (1-2p/s) = max-min
   // A  = (max-min)/(1-2p/s)
-  const Array<Scalar,3,1> ps=
+  const Eigen::Array<Scalar,3,1> ps=
     (Scalar)(pad_count)/(side.transpose().template cast<Scalar>().array()-1.);
-  const Array<Scalar,3,1> A = box.diagonal().array()/(1.0-2.*ps);
+  const Eigen::Array<Scalar,3,1> A = box.diagonal().array()/(1.0-2.*ps);
   //// This would result in an "anamorphic", but perfectly fit grid:
   //const Array<Scalar,3,1> B = box.min().array() - A.array()*ps;
   //GV.array().rowwise() *= A.transpose();
   //GV.array().rowwise() += B.transpose();
   // Instead scale by largest factor and move to match center
-  typename Array<Scalar,3,1>::Index ai = -1;
+  typename Eigen::Array<Scalar,3,1>::Index ai = -1;
   Scalar a = A.maxCoeff(&ai);
-  const Array<Scalar,1,3> ratio =
+  const Eigen::Array<Scalar,1,3> ratio =
     a*(side.template cast<Scalar>().array()-1.0)/(Scalar)(side(ai)-1.0);
   GV.array().rowwise() *= ratio;
   const Eigen::Matrix<Scalar,1,3> offset = (box.center().transpose()-GV.colwise().mean()).eval();

--- a/include/igl/voxel_grid.cpp
+++ b/include/igl/voxel_grid.cpp
@@ -20,7 +20,6 @@ IGL_INLINE void igl::voxel_grid(
   Eigen::PlainObjectBase<Derivedside> & side)
 {
   using namespace Eigen;
-  using namespace std;
   typename DerivedGV::Index si = -1;
   side.resize(3);
   box.diagonal().maxCoeff(&si);

--- a/include/igl/winding_number.cpp
+++ b/include/igl/winding_number.cpp
@@ -25,7 +25,6 @@ IGL_INLINE void igl::winding_number(
   const Eigen::MatrixBase<DerivedO> & O,
   Eigen::PlainObjectBase<DerivedW> & W)
 {
-  using namespace Eigen;
   // make room for output
   W.resize(O.rows(),1);
   switch(F.cols())

--- a/include/igl/writeBF.cpp
+++ b/include/igl/writeBF.cpp
@@ -19,7 +19,6 @@ IGL_INLINE bool igl::writeBF(
   const Eigen::MatrixBase<DerivedO> & O)
 {
   using namespace Eigen;
-  using namespace std;
   const int n = WI.rows();
   assert(n == WI.rows() && "WI must have n rows");
   assert(n == P.rows()  && "P must have n rows");
@@ -33,7 +32,7 @@ IGL_INLINE bool igl::writeBF(
     WIPO(i,2+1) = O(i,1);
     WIPO(i,2+2) = O(i,2);
   }
-  ofstream s(filename);
+  std::ofstream s(filename);
   if(!s.is_open())
   {
     fprintf(stderr,"IOError: writeBF() could not open %s\n",filename.c_str());

--- a/include/igl/writeBF.cpp
+++ b/include/igl/writeBF.cpp
@@ -18,12 +18,11 @@ IGL_INLINE bool igl::writeBF(
   const Eigen::MatrixBase<DerivedP> & P,
   const Eigen::MatrixBase<DerivedO> & O)
 {
-  using namespace Eigen;
   const int n = WI.rows();
   assert(n == WI.rows() && "WI must have n rows");
   assert(n == P.rows()  && "P must have n rows");
   assert(n == O.rows()  && "O must have n rows");
-  MatrixXd WIPO(n,1+1+3);
+  Eigen::MatrixXd WIPO(n,1+1+3);
   for(int i = 0;i<n;i++)
   {
     WIPO(i,0) = WI(i);
@@ -39,7 +38,7 @@ IGL_INLINE bool igl::writeBF(
     return false;
   }
   s<<
-    WIPO.format(IOFormat(FullPrecision,DontAlignCols," ","\n","","","","\n"));
+    WIPO.format(Eigen::IOFormat(Eigen::FullPrecision,Eigen::DontAlignCols," ","\n","","","","\n"));
   return true;
 }
 

--- a/include/igl/writeMESH.cpp
+++ b/include/igl/writeMESH.cpp
@@ -51,7 +51,6 @@ IGL_INLINE bool igl::writeMESH(
   const Eigen::MatrixBase<DerivedT> & T,
   const Eigen::MatrixBase<DerivedF> & F)
 {
-  using namespace std;
   using namespace Eigen;
 
   //// This is (surprisingly) slower than the C-ish code below

--- a/include/igl/writeMESH.cpp
+++ b/include/igl/writeMESH.cpp
@@ -51,8 +51,6 @@ IGL_INLINE bool igl::writeMESH(
   const Eigen::MatrixBase<DerivedT> & T,
   const Eigen::MatrixBase<DerivedF> & F)
 {
-  using namespace Eigen;
-
   //// This is (surprisingly) slower than the C-ish code below
   //ofstream mesh_file;
   //mesh_file.open(str.c_str());

--- a/include/igl/writeMESH.h
+++ b/include/igl/writeMESH.h
@@ -34,9 +34,9 @@ namespace igl
     const std::vector<std::vector<Index > > & F);
   /// save a tetrahedral volume mesh to a .mesh file
   ///
-  /// @tparam DerivedV  real-value: i.e. from MatrixXd
-  /// @tparam DerivedT  integer-value: i.e. from MatrixXi
-  /// @tparam DerivedF  integer-value: i.e. from MatrixXi
+  /// @tparam DerivedV  real-value: i.e. from Eigen::MatrixXd
+  /// @tparam DerivedT  integer-value: i.e. from Eigen::MatrixXi
+  /// @tparam DerivedF  integer-value: i.e. from Eigen::MatrixXi
   /// @param[in] mesh_file_name  path of .mesh file
   /// @param[in] V  eigen double matrix #V by 3
   /// @param[in] T  eigen int matrix #T by 4

--- a/include/igl/writeOBJ.cpp
+++ b/include/igl/writeOBJ.cpp
@@ -103,10 +103,9 @@ IGL_INLINE bool igl::writeOBJ(
   const Eigen::MatrixBase<DerivedV>& V,
   const Eigen::MatrixBase<DerivedF>& F)
 {
-  using namespace std;
   using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
-  ofstream s(str);
+  std::ofstream s(str);
   if(!s.is_open())
   {
     fprintf(stderr,"IOError: writeOBJ() could not open %s\n",str.c_str());
@@ -124,10 +123,9 @@ IGL_INLINE bool igl::writeOBJ(
   const Eigen::MatrixBase<DerivedV>& V,
   const std::vector<std::vector<T> >& F)
 {
-  using namespace std;
   using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
-  ofstream s(str);
+  std::ofstream s(str);
   if(!s.is_open())
   {
     fprintf(stderr,"IOError: writeOBJ() could not open %s\n",str.c_str());

--- a/include/igl/writeOBJ.cpp
+++ b/include/igl/writeOBJ.cpp
@@ -103,7 +103,6 @@ IGL_INLINE bool igl::writeOBJ(
   const Eigen::MatrixBase<DerivedV>& V,
   const Eigen::MatrixBase<DerivedF>& F)
 {
-  using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
   std::ofstream s(str);
   if(!s.is_open())
@@ -112,8 +111,8 @@ IGL_INLINE bool igl::writeOBJ(
     return false;
   }
   s<<
-    V.format(IOFormat(FullPrecision,DontAlignCols," ","\n","v ","","","\n"))<<
-    (F.array()+1).format(IOFormat(FullPrecision,DontAlignCols," ","\n","f ","","","\n"));
+    V.format(Eigen::IOFormat(Eigen::FullPrecision,Eigen::DontAlignCols," ","\n","v ","","","\n"))<<
+    (F.array()+1).format(Eigen::IOFormat(Eigen::FullPrecision,Eigen::DontAlignCols," ","\n","f ","","","\n"));
   return true;
 }
 
@@ -123,7 +122,6 @@ IGL_INLINE bool igl::writeOBJ(
   const Eigen::MatrixBase<DerivedV>& V,
   const std::vector<std::vector<T> >& F)
 {
-  using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
   std::ofstream s(str);
   if(!s.is_open())
@@ -131,7 +129,7 @@ IGL_INLINE bool igl::writeOBJ(
     fprintf(stderr,"IOError: writeOBJ() could not open %s\n",str.c_str());
     return false;
   }
-  s<<V.format(IOFormat(FullPrecision,DontAlignCols," ","\n","v ","","","\n"));
+  s<<V.format(Eigen::IOFormat(Eigen::FullPrecision,Eigen::DontAlignCols," ","\n","v ","","","\n"));
   
   for(const auto& face : F)
   {

--- a/include/igl/writeOFF.cpp
+++ b/include/igl/writeOFF.cpp
@@ -16,7 +16,6 @@ IGL_INLINE bool igl::writeOFF(
   const Eigen::MatrixBase<DerivedV>& V,
   const Eigen::MatrixBase<DerivedF>& F)
 {
-  using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
   std::ofstream s(fname);
   if(!s.is_open())
@@ -27,8 +26,8 @@ IGL_INLINE bool igl::writeOFF(
 
   s<<
     "OFF\n"<<V.rows()<<" "<<F.rows()<<" 0\n"<<
-    V.format(IOFormat(FullPrecision,DontAlignCols," ","\n","","","","\n"))<<
-    (F.array()).format(IOFormat(FullPrecision,DontAlignCols," ","\n",std::to_string(F.cols()) + " ","","","\n"));
+    V.format(Eigen::IOFormat(Eigen::FullPrecision,Eigen::DontAlignCols," ","\n","","","","\n"))<<
+    (F.array()).format(Eigen::IOFormat(Eigen::FullPrecision,Eigen::DontAlignCols," ","\n",std::to_string(F.cols()) + " ","","","\n"));
   return true;
 }
 
@@ -40,7 +39,6 @@ IGL_INLINE bool igl::writeOFF(
   const Eigen::MatrixBase<DerivedF>& F,
   const Eigen::MatrixBase<DerivedC>& C)
 {
-  using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
   assert(C.cols() == 3 && "C should have 3 columns");
 
@@ -66,11 +64,11 @@ IGL_INLINE bool igl::writeOFF(
   s<< "COFF\n"<<V.rows()<<" "<<F.rows()<<" 0\n";
   for (unsigned i=0; i< V.rows(); i++)
   {
-    s <<V.row(i).format(IOFormat(FullPrecision,DontAlignCols," "," ","","",""," "));
+    s <<V.row(i).format(Eigen::IOFormat(Eigen::FullPrecision,Eigen::DontAlignCols," "," ","","",""," "));
     s << unsigned(RGB_Array(i,0)) << " " << unsigned(RGB_Array(i,1)) << " " << unsigned(RGB_Array(i,2)) << " 255\n";
   }
 
-  s<<(F.array()).format(IOFormat(FullPrecision,DontAlignCols," ","\n",std::to_string(F.cols()) + " ","","","\n"));
+  s<<(F.array()).format(Eigen::IOFormat(Eigen::FullPrecision,Eigen::DontAlignCols," ","\n",std::to_string(F.cols()) + " ","","","\n"));
   return true;
 }
 

--- a/include/igl/writeOFF.cpp
+++ b/include/igl/writeOFF.cpp
@@ -16,10 +16,9 @@ IGL_INLINE bool igl::writeOFF(
   const Eigen::MatrixBase<DerivedV>& V,
   const Eigen::MatrixBase<DerivedF>& F)
 {
-  using namespace std;
   using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
-  ofstream s(fname);
+  std::ofstream s(fname);
   if(!s.is_open())
   {
     fprintf(stderr,"IOError: writeOFF() could not open %s\n",fname.c_str());
@@ -41,7 +40,6 @@ IGL_INLINE bool igl::writeOFF(
   const Eigen::MatrixBase<DerivedF>& F,
   const Eigen::MatrixBase<DerivedC>& C)
 {
-  using namespace std;
   using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
   assert(C.cols() == 3 && "C should have 3 columns");
@@ -52,7 +50,7 @@ IGL_INLINE bool igl::writeOFF(
     return false;
   }
 
-  ofstream s(fname);
+  std::ofstream s(fname);
   if(!s.is_open())
   {
     fprintf(stderr,"IOError: writeOFF() could not open %s\n",fname.c_str());

--- a/include/igl/writeSTL.cpp
+++ b/include/igl/writeSTL.cpp
@@ -16,14 +16,13 @@ IGL_INLINE bool igl::writeSTL(
   const Eigen::MatrixBase<DerivedN> & N,
   FileEncoding encoding)
 {
-  using namespace std;
   assert(N.rows() == 0 || F.rows() == N.rows());
   if(encoding == FileEncoding::Ascii)
   {
     FILE * stl_file = fopen(filename.c_str(),"w");
     if(stl_file == NULL)
     {
-      cerr<<"IOError: "<<filename<<" could not be opened for writing."<<endl;
+      std::cerr<<"IOError: "<<filename<<" could not be opened for writing."<<std::endl;
       return false;
     }
     fprintf(stl_file,"solid %s\n",filename.c_str());
@@ -59,7 +58,7 @@ IGL_INLINE bool igl::writeSTL(
     FILE * stl_file = fopen(filename.c_str(),"wb");
     if(stl_file == NULL)
     {
-      cerr<<"IOError: "<<filename<<" could not be opened for writing."<<endl;
+      std::cerr<<"IOError: "<<filename<<" could not be opened for writing."<<std::endl;
       return false;
     }
     // Write unused 80-char header
@@ -74,7 +73,7 @@ IGL_INLINE bool igl::writeSTL(
     // Write each triangle
     for(int f = 0;f<F.rows();f++)
     {
-      vector<float> n(3,0);
+      std::vector<float> n(3,0);
       if(N.rows() > 0)
       {
         n[0] = N(f,0);
@@ -84,7 +83,7 @@ IGL_INLINE bool igl::writeSTL(
       fwrite(&n[0],sizeof(float),3,stl_file);
       for(int c = 0;c<3;c++)
       {
-        vector<float> v(3);
+        std::vector<float> v(3);
         v[0] = V(F(f,c),0);
         v[1] = V(F(f,c),1);
         v[2] = V(F(f,c),2);

--- a/include/igl/writeTGF.cpp
+++ b/include/igl/writeTGF.cpp
@@ -63,9 +63,8 @@ IGL_INLINE bool igl::writeTGF(
   const Eigen::MatrixXd & C,
   const Eigen::MatrixXi & E)
 {
-  using namespace std;
-  vector<vector<double> > vC;
-  vector<vector<int> > vE;
+  std::vector<std::vector<double> > vC;
+  std::vector<std::vector<int> > vE;
   matrix_to_list(C,vC);
   matrix_to_list(E,vE);
   return writeTGF(tgf_filename,vC,vE);

--- a/include/igl/writeWRL.cpp
+++ b/include/igl/writeWRL.cpp
@@ -14,14 +14,13 @@ IGL_INLINE bool igl::writeWRL(
   const Eigen::MatrixBase<DerivedV> & V,
   const Eigen::MatrixBase<DerivedF> & F)
 {
-  using namespace std;
   using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
   assert(F.cols() == 3 && "F should have 3 columns");
-  ofstream s(str);
+  std::ofstream s(str);
   if(!s.is_open())
   {
-    cerr<<"IOError: writeWRL() could not open "<<str<<endl;
+    std::cerr<<"IOError: writeWRL() could not open "<<str<<std::endl;
     return false;
   }
   // Append column of -1 to F
@@ -61,14 +60,13 @@ IGL_INLINE bool igl::writeWRL(
   const Eigen::MatrixBase<DerivedF> & F,
   const Eigen::MatrixBase<DerivedC> & C)
 {
-  using namespace std;
   using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
   assert(F.cols() == 3 && "F should have 3 columns");
-  ofstream s(str);
+  std::ofstream s(str);
   if(!s.is_open())
   {
-    cerr<<"IOError: writeWRL() could not open "<<str<<endl;
+    std::cerr<<"IOError: writeWRL() could not open "<<str<<std::endl;
     return false;
   }
   // Append column of -1 to F

--- a/include/igl/writeWRL.cpp
+++ b/include/igl/writeWRL.cpp
@@ -14,7 +14,6 @@ IGL_INLINE bool igl::writeWRL(
   const Eigen::MatrixBase<DerivedV> & V,
   const Eigen::MatrixBase<DerivedF> & F)
 {
-  using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
   assert(F.cols() == 3 && "F should have 3 columns");
   std::ofstream s(str);
@@ -24,7 +23,7 @@ IGL_INLINE bool igl::writeWRL(
     return false;
   }
   // Append column of -1 to F
-  Matrix<typename DerivedF::Scalar,Dynamic,4> FF(F.rows(),4);
+  Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,4> FF(F.rows(),4);
   FF.leftCols(3) = F;
   FF.col(3).setConstant(-1);
 
@@ -37,15 +36,15 @@ geometry DEF default-FACES IndexedFaceSet {
 ccw TRUE
 )"<<
     V.format(
-      IOFormat(
-        FullPrecision,
-        DontAlignCols,
+      Eigen::IOFormat(
+        Eigen::FullPrecision,
+        Eigen::DontAlignCols,
         " ",",\n","","",
         "coord DEF default-COORD Coordinate { point [ \n","]\n}\n"))<<
     FF.format(
-      IOFormat(
-        FullPrecision,
-        DontAlignCols,
+      Eigen::IOFormat(
+        Eigen::FullPrecision,
+        Eigen::DontAlignCols,
         ",","\n","","",
         "coordIndex [ \n"," ]\n"))<<
     "}\n}\n]\n}\n";
@@ -60,7 +59,6 @@ IGL_INLINE bool igl::writeWRL(
   const Eigen::MatrixBase<DerivedF> & F,
   const Eigen::MatrixBase<DerivedC> & C)
 {
-  using namespace Eigen;
   assert(V.cols() == 3 && "V should have 3 columns");
   assert(F.cols() == 3 && "F should have 3 columns");
   std::ofstream s(str);
@@ -70,7 +68,7 @@ IGL_INLINE bool igl::writeWRL(
     return false;
   }
   // Append column of -1 to F
-  Matrix<typename DerivedF::Scalar,Dynamic,4> FF(F.rows(),4);
+  Eigen::Matrix<typename DerivedF::Scalar ,Eigen::Dynamic,4> FF(F.rows(),4);
   FF.leftCols(3) = F;
   FF.col(3).setConstant(-1);
 
@@ -88,21 +86,21 @@ geometry DEF default-FACES IndexedFaceSet {
 ccw TRUE
 )"<<
     V.format(
-      IOFormat(
-        FullPrecision,
-        DontAlignCols,
+      Eigen::IOFormat(
+        Eigen::FullPrecision,
+        Eigen::DontAlignCols,
         " ",",\n","","",
         "coord DEF default-COORD Coordinate { point [ \n","]\n}\n"))<<
     FF.format(
-      IOFormat(
-        FullPrecision,
-        DontAlignCols,
+      Eigen::IOFormat(
+        Eigen::FullPrecision,
+        Eigen::DontAlignCols,
         ",","\n","","",
         "coordIndex [ \n"," ]\n"))<<
     RGB.format(
-      IOFormat(
-        FullPrecision,
-        DontAlignCols,
+      Eigen::IOFormat(
+        Eigen::FullPrecision,
+        Eigen::DontAlignCols,
         ",","\n","","",
         "colorPerVertex TRUE\ncolor Color { color [ \n"," ] }\n"))<<
     "}\n}\n]\n}\n";

--- a/include/igl/write_triangle_mesh.cpp
+++ b/include/igl/write_triangle_mesh.cpp
@@ -23,9 +23,8 @@ IGL_INLINE bool igl::write_triangle_mesh(
   const Eigen::MatrixBase<DerivedF>& F,
   FileEncoding encoding)
 {
-  using namespace std;
   // dirname, basename, extension and filename
-  string d,b,e,f;
+  std::string d,b,e,f;
   pathinfo(str,d,b,e,f);
   // Convert extension to lower case
   std::transform(e.begin(), e.end(), e.begin(), ::tolower);
@@ -51,7 +50,7 @@ IGL_INLINE bool igl::write_triangle_mesh(
   }else
   {
     assert("Unsupported file format");
-    cerr<<"Unsupported file format: ."<<e<<endl;
+    std::cerr<<"Unsupported file format: ."<<e<<std::endl;
     return false;
   }
 }

--- a/include/igl/xml/writeDAE.cpp
+++ b/include/igl/xml/writeDAE.cpp
@@ -17,7 +17,6 @@ IGL_INLINE bool igl::xml::writeDAE(
   const Eigen::MatrixBase<DerivedV> & V,
   const Eigen::MatrixBase<DerivedF> & F)
 {
-  using namespace std;
   using namespace Eigen;
 
   tinyxml2::XMLDocument* doc = new tinyxml2::XMLDocument();

--- a/include/igl/xml/writeDAE.cpp
+++ b/include/igl/xml/writeDAE.cpp
@@ -17,8 +17,6 @@ IGL_INLINE bool igl::xml::writeDAE(
   const Eigen::MatrixBase<DerivedV> & V,
   const Eigen::MatrixBase<DerivedF> & F)
 {
-  using namespace Eigen;
-
   tinyxml2::XMLDocument* doc = new tinyxml2::XMLDocument();
 
   const auto & ele = [&doc](

--- a/include/igl/xml/write_triangle_mesh.cpp
+++ b/include/igl/xml/write_triangle_mesh.cpp
@@ -17,9 +17,8 @@ IGL_INLINE bool igl::xml::write_triangle_mesh(
   const Eigen::MatrixBase<DerivedF>& F,
   const FileEncoding fe)
 {
-  using namespace std;
   // dirname, basename, extension and filename
-  string d,b,e,f;
+  std::string d,b,e,f;
   pathinfo(str,d,b,e,f);
   // Convert extension to lower case
   std::transform(e.begin(), e.end(), e.begin(), ::tolower);


### PR DESCRIPTION
Previously from #2481

> While `using namespace std;` and `using namespace Eigen;`  was limited to function scope in libigl there have been a few issues where third-parties did not play nice with it.
> I'm on par with @jdumas that's it's primarily the third-parties fault, however these issues keep popping up e.g.
> - https://github.com/libigl/libigl/issues/2480
> - https://github.com/libigl/libigl/issues/2132
> - https://github.com/libigl/libigl/issues/1282
> 
> Herby I propose to avoid `using namespace std;` and `using namespace Eigen;` completely in the sources of libigl.
> For quality of live I did not touch tests or tutorials.
