### PR TITLE
Force codesign to sign binaries, even if they are already signed

### DIFF
--- a/cmake/igl/igl_add_tutorial.cmake
+++ b/cmake/igl/igl_add_tutorial.cmake
@@ -22,7 +22,7 @@ function(igl_add_tutorial name)
     # add_custom_command(TARGET your_target POST_BUILD COMMAND codesign -s - $<TARGET_FILE:your_target>
     if(APPLE)
       add_custom_command(TARGET ${name} POST_BUILD
-        COMMAND codesign -s - $<TARGET_FILE:${name}>
+        COMMAND codesign -f -s - $<TARGET_FILE:${name}>
         COMMENT "Codesigning ${name}"
       )
     endif()


### PR DESCRIPTION
For some reason, Apple binaries need to be signed, but sometimes are already signed.  This triggers an error in codesign unless the force (-f) flag is passed.

Fixes #2493 .

<!-- Describe your changes and what you've already done to test it. -->


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [ ] This is a minor change.
