### PR TITLE
Fix: make `igl::sortrows` permutation vector match MATLAB `sortrows`

### DIFF
--- a/include/igl/sortrows.cpp
+++ b/include/igl/sortrows.cpp
@@ -75,7 +75,7 @@ IGL_INLINE void igl::sortrows(
       }
       return false;
     };
-      std::sort(
+      std::stable_sort(
         IX.data(),
         IX.data()+IX.size(),
         index_less_than
@@ -88,7 +88,7 @@ IGL_INLINE void igl::sortrows(
       }
       return false;
     };
-      std::sort(
+      std::stable_sort(
         IX.data(),
         IX.data()+IX.size(),
         index_greater_than


### PR DESCRIPTION
**Summary**
There’s a mismatch between `igl::sortrows` and MATLAB’s `sortrows`.
Specifically, the permutation index vector returned by `igl::sortrows` does not match the one produced by MATLAB for the same input.

**Reproduction**

1. Compile the attached MEX functions.
2. Run the attached script.
3. Compare the permutation index vectors returned by `igl::sortrows` and MATLAB’s `sortrows`.


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [x] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.

#### Files

main.m
```
clear all;
clc;

addpath("./build/Release");

N = 100;
m = 10;
A = rand(N,3);
i = randi(N);
inds = randi(N,[m,1]);

A(inds,:) = repmat(A(i,:),m,1);

[B0,index0] = sortrows(A);
[B1,index1] = mex_sortrows(A);
[B2,index2] = mex_stable_sortrows(A);

fprintf("B0 == B1 : %d \n", isequal(B0,B1));
fprintf("B0 == B2 : %d \n", isequal(B0,B2));
fprintf("index0 == index1 : %d \n", isequal(index0,index1+1));
fprintf("index0 == index2 : %d \n", isequal(index0,index2+1));
```

mex_sortrows.cpp
```
#include "mex.hpp"
#include "mexAdapter.hpp"

#include "Eigen/Dense"

template <typename DerivedX, typename DerivedY, typename DerivedIX>
void sortrows(const Eigen::DenseBase<DerivedX> &X, const bool ascending,
              Eigen::PlainObjectBase<DerivedY> &Y,
              Eigen::PlainObjectBase<DerivedIX> &IX) {
  // This is already 2x faster than matlab's builtin `sortrows`. I have tried
  // implementing a "multiple-pass" sort on each column, but see no performance
  // improvement.
  // Resize output
  const size_t num_rows = X.rows();
  const size_t num_cols = X.cols();
  Y.resize(num_rows, num_cols);
  IX.resize(num_rows, 1);
  for (int i = 0; i < num_rows; i++) {
    IX(i) = i;
  }
  if (ascending) {
    auto index_less_than = [&X, num_cols](size_t i, size_t j) {
      for (size_t c = 0; c < num_cols; c++) {
        if (X.coeff(i, c) < X.coeff(j, c))
          return true;
        else if (X.coeff(j, c) < X.coeff(i, c))
          return false;
      }
      return false;
    };
    std::sort(IX.data(), IX.data() + IX.size(), index_less_than);
  } else {
    auto index_greater_than = [&X, num_cols](size_t i, size_t j) {
      for (size_t c = 0; c < num_cols; c++) {
        if (X.coeff(i, c) > X.coeff(j, c))
          return true;
        else if (X.coeff(j, c) > X.coeff(i, c))
          return false;
      }
      return false;
    };
    std::sort(IX.data(), IX.data() + IX.size(), index_greater_than);
  }
  for (size_t j = 0; j < num_cols; j++) {
    for (int i = 0; i < num_rows; i++) {
      Y(i, j) = X(IX(i), j);
    }
  }
}

class MexFunction : public matlab::mex::Function {
public:
  void operator()(matlab::mex::ArgumentList outputs,
                  matlab::mex::ArgumentList inputs) override {
    std::shared_ptr<matlab::engine::MATLABEngine> matlabPtr;
    matlab::data::ArrayFactory factory;

    const matlab::data::TypedArray<double> input = inputs[0];
    const auto d = input.getDimensions();
    const size_t num_rows = d[0];
    const size_t num_cols = d[1];
    const double *data = &(*input.cbegin());
    const Eigen::Map<const Eigen::MatrixX<double>> A(data, num_rows, num_cols);

    Eigen::MatrixXd B;
    Eigen::VectorXi index;

    sortrows(A, true, B, index);

    const size_t Br = B.rows();
    const size_t Bc = B.cols();
    matlab::data::TypedArray<double> out_B =
        factory.createArray<double>({Br, Bc});
    {
      auto it = out_B.begin();
      for (int i = 0; i < B.size(); ++i) {
        *it = B(i);
        ++it;
      }
    }
    const size_t n_index = index.size();
    matlab::data::TypedArray<double> out_index =
        factory.createArray<double>({n_index, 1});
    {
      auto it = out_index.begin();
      for (int i = 0; i < index.size(); ++i) {
        *it = index(i);
        ++it;
      }
    }
    outputs[0] = out_B;
    outputs[1] = out_index;
  }
};
```

mex_stable_sortrows.cpp
```
#include "mex.hpp"
#include "mexAdapter.hpp"

#include "Eigen/Dense"

template <typename DerivedX, typename DerivedY, typename DerivedIX>
void sortrows(const Eigen::DenseBase<DerivedX> &X, const bool ascending,
              Eigen::PlainObjectBase<DerivedY> &Y,
              Eigen::PlainObjectBase<DerivedIX> &IX) {
  // This is already 2x faster than matlab's builtin `sortrows`. I have tried
  // implementing a "multiple-pass" sort on each column, but see no performance
  // improvement.
  // Resize output
  const size_t num_rows = X.rows();
  const size_t num_cols = X.cols();
  Y.resize(num_rows, num_cols);
  IX.resize(num_rows, 1);
  for (int i = 0; i < num_rows; i++) {
    IX(i) = i;
  }
  if (ascending) {
    auto index_less_than = [&X, num_cols](size_t i, size_t j) {
      for (size_t c = 0; c < num_cols; c++) {
        if (X.coeff(i, c) < X.coeff(j, c))
          return true;
        else if (X.coeff(j, c) < X.coeff(i, c))
          return false;
      }
      return false;
    };
    std::stable_sort(IX.data(), IX.data() + IX.size(), index_less_than);
  } else {
    auto index_greater_than = [&X, num_cols](size_t i, size_t j) {
      for (size_t c = 0; c < num_cols; c++) {
        if (X.coeff(i, c) > X.coeff(j, c))
          return true;
        else if (X.coeff(j, c) > X.coeff(i, c))
          return false;
      }
      return false;
    };
    std::stable_sort(IX.data(), IX.data() + IX.size(), index_greater_than);
  }
  for (size_t j = 0; j < num_cols; j++) {
    for (int i = 0; i < num_rows; i++) {
      Y(i, j) = X(IX(i), j);
    }
  }
}

class MexFunction : public matlab::mex::Function {
public:
  void operator()(matlab::mex::ArgumentList outputs,
                  matlab::mex::ArgumentList inputs) override {
    std::shared_ptr<matlab::engine::MATLABEngine> matlabPtr;
    matlab::data::ArrayFactory factory;

    const matlab::data::TypedArray<double> input = inputs[0];
    const auto d = input.getDimensions();
    const size_t num_rows = d[0];
    const size_t num_cols = d[1];
    const double *data = &(*input.cbegin());
    const Eigen::Map<const Eigen::MatrixX<double>> A(data, num_rows, num_cols);

    Eigen::MatrixXd B;
    Eigen::VectorXi index;

    sortrows(A, true, B, index);

    const size_t Br = B.rows();
    const size_t Bc = B.cols();
    matlab::data::TypedArray<double> out_B =
        factory.createArray<double>({Br, Bc});
    {
      auto it = out_B.begin();
      for (int i = 0; i < B.size(); ++i) {
        *it = B(i);
        ++it;
      }
    }
    const size_t n_index = index.size();
    matlab::data::TypedArray<double> out_index =
        factory.createArray<double>({n_index, 1});
    {
      auto it = out_index.begin();
      for (int i = 0; i < index.size(); ++i) {
        *it = index(i);
        ++it;
      }
    }
    outputs[0] = out_B;
    outputs[1] = out_index;
  }
};
```
