### PR TITLE
Add missing #include <cassert>

### DIFF
--- a/include/igl/slice.cpp
+++ b/include/igl/slice.cpp
@@ -8,6 +8,7 @@
 #include "slice.h"
 #include "colon.h"
 
+#include <cassert>
 #include <vector>
 
 template <


### PR DESCRIPTION
Fixes build in latest `Apple clang version 17.0.0 (clang-1700.6.3.2)` when only using knn and octree.

```cpp
#include <igl/knn.h>
#include <igl/octree.h>
```

This repo builds fine with examples and tests enabled, but it fails on my project when only using those two files. I assume there's no test/example that only uses them?

<!-- Describe your changes and what you've already done to test it. -->


#### Checklist
<!-- Check all that apply (change to `[x]`) -->

- [ ] All changes meet [libigl style-guidelines](https://libigl.github.io/style-guidelines/).
- [ ] Adds new .cpp file.
- [ ] Adds corresponding unit test.
- [x] This is a minor change.
