### PR TITLE
Fix typos in header documentation comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ LibiglOptions.cmake
 dox/
 latex/
 scripts/
+CLAUDE.md

--- a/include/igl/FastWindingNumberForSoups.h
+++ b/include/igl/FastWindingNumberForSoups.h
@@ -281,7 +281,7 @@ static constexpr inline fpreal32 SYSmax(fpreal32 a, fpreal32 b)	{ return h_max(a
 static constexpr inline fpreal64 SYSmin(fpreal64 a, fpreal64 b)	{ return h_min(a,b); }
 static constexpr inline fpreal64 SYSmax(fpreal64 a, fpreal64 b)	{ return h_max(a,b); }
 
-// Some systems have size_t as a seperate type from uint.  Some don't.
+// Some systems have size_t as a separate type from uint.  Some don't.
 #if (defined(LINUX) && defined(IA64)) || defined(MBSD)
 static constexpr inline size_t SYSmin(size_t a, size_t b)		{ return h_min(a,b); }
 static constexpr inline size_t SYSmax(size_t a, size_t b)		{ return h_max(a,b); }
@@ -3758,7 +3758,7 @@ namespace UT_Thread { inline int getNumProcessors() {
 /////
 ///// Requirements for the Range functor are:
 /////   - the requirements of the tbb Range Concept
-/////   - UT_estimatorNumItems<Range> must return the the estimated number of work items
+/////   - UT_estimatorNumItems<Range> must return the estimated number of work items
 /////     for the range. When Range::size() is not the correct estimate, then a 
 /////     (partial) specialization of UT_estimatorNumItemsimatorRange must be provided
 /////     for the type Range.

--- a/include/igl/circulation.h
+++ b/include/igl/circulation.h
@@ -47,7 +47,7 @@ namespace igl
   ///     F(f,:) opposite the vth corner, where EI(e,0)=v. Similarly EF(e,1) "
   ///     e=(j->i)
   /// @param[in] EI  #E by 2 list of edge flap corners (see above).
-  /// @param[out] #vN list of of faces touched by circulation (in cyclically order).
+  /// @param[out] #vN list of faces touched by circulation (in cyclically order).
   ///   
   /// \see edge_flaps
   template <typename DerivedEMAP, typename DerivedEF, typename DerivedEI, typename DerivedvN>

--- a/include/igl/collapse_edge.h
+++ b/include/igl/collapse_edge.h
@@ -36,10 +36,10 @@ namespace igl
   ///     e=(j->i)
   /// @param[in,out] EI  #E by 2 list of edge flap corners (see above).
   /// [mesh inputs]
-  /// @param[out] e1  index into E of edge collpased on left
-  /// @param[out] e2  index into E of edge collpased on right
-  /// @param[out] f1  index into F of face collpased on left
-  /// @param[out] f2  index into F of face collpased on right
+  /// @param[out] e1  index into E of edge collapsed on left
+  /// @param[out] e2  index into E of edge collapsed on right
+  /// @param[out] f1  index into F of face collapsed on left
+  /// @param[out] f2  index into F of face collapsed on right
   /// @return true if edge was collapsed
   ///
   ///

--- a/include/igl/collapse_least_cost_edge.h
+++ b/include/igl/collapse_least_cost_edge.h
@@ -47,10 +47,10 @@ namespace igl
   /// @param[in] C  #E by dim list of stored placements
   /// @param[out] e  index into E of attempted collapsed edge. Set to -1 if Q is empty or
   ///               contains only infinite cost edges.
-  /// @param[out] e1  index into E of edge collpased on left.
-  /// @param[out] e2  index into E of edge collpased on right.
-  /// @param[out] f1  index into F of face collpased on left.
-  /// @param[out] f2  index into F of face collpased on right.
+  /// @param[out] e1  index into E of edge collapsed on left.
+  /// @param[out] e2  index into E of edge collapsed on right.
+  /// @param[out] f1  index into F of face collapsed on left.
+  /// @param[out] f2  index into F of face collapsed on right.
   ///
   /// \bug This function is not templated nicely and refactoring it and its
   /// dependencies to do so is non-trivial, see

--- a/include/igl/copyleft/cgal/trim_with_solid.h
+++ b/include/igl/copyleft/cgal/trim_with_solid.h
@@ -29,11 +29,11 @@ namespace igl
         /// output and strictly fewer FLOPS than CHECK_EACH_FACE. There will be
         /// many tiny patches along the intersection of A and B. 
         CHECK_EACH_PATCH = 2,
-        /// Merge A and B into the same mesh and resolve all self-itnersections.
+        /// Merge A and B into the same mesh and resolve all self-intersections.
         /// Then "undo" remeshing on faces of A not involved in intersections
-        /// with B (i.e., self-intersections in A). Then seperate into patches
+        /// with B (i.e., self-intersections in A). Then separate into patches
         /// based on connected faces --- where connected means sharing a
-        /// _manifold edge_ --- then label each aptch as inside or outside.
+        /// _manifold edge_ --- then label each patch as inside or outside.
         /// Results in fewer patches than CHECK_EACH_PATCH but finding, meshing and
         /// mesh-undoing self-intersections in A can be costly. This
         /// could result in different output from CHECK_EACH_PATCH because of

--- a/include/igl/decimate_callback_types.h
+++ b/include/igl/decimate_callback_types.h
@@ -64,10 +64,10 @@ namespace igl
   /// @param[in] C  #E by dim list of stored placements
   /// @param[in] e  index into E of attempted collapsed edge. Set to -1 if Q is empty or
   ///               contains only infinite cost edges.
-  /// @param[in] e1  index into E of edge collpased on left.
-  /// @param[in] e2  index into E of edge collpased on right.
-  /// @param[in] f1  index into F of face collpased on left.
-  /// @param[in] f2  index into F of face collpased on right.
+  /// @param[in] e1  index into E of edge collapsed on left.
+  /// @param[in] e2  index into E of edge collapsed on right.
+  /// @param[in] f1  index into F of face collapsed on left.
+  /// @param[in] f2  index into F of face collapsed on right.
   /// @return whether to stop
   using decimate_stopping_condition_callback = 
     std::function<bool(
@@ -139,10 +139,10 @@ namespace igl
   /// @param[in] C  #E by dim list of stored placements
   /// @param[in] e  index into E of attempted collapsed edge. Set to -1 if Q is empty or
   ///               contains only infinite cost edges.
-  /// @param[in] e1  index into E of edge collpased on left.
-  /// @param[in] e2  index into E of edge collpased on right.
-  /// @param[in] f1  index into F of face collpased on left.
-  /// @param[in] f2  index into F of face collpased on right.
+  /// @param[in] e1  index into E of edge collapsed on left.
+  /// @param[in] e2  index into E of edge collapsed on right.
+  /// @param[in] f1  index into F of face collapsed on left.
+  /// @param[in] f2  index into F of face collapsed on right.
   /// @param[in] collapsed whether collapse actual took place
   using decimate_post_collapse_callback = 
     std::function<void(

--- a/include/igl/seam_edges.h
+++ b/include/igl/seam_edges.h
@@ -15,7 +15,7 @@ namespace igl
   ///
   /// @param[in] V  #V by dim list of positions of the input mesh.
   /// @param[in] TC  #TC by 2 list of 2D texture coordinates of the input mesh
-  /// @param[in] F  #F by 3 list of triange indices into V representing a
+  /// @param[in] F  #F by 3 list of triangle indices into V representing a
   ///     manifold-with-boundary triangle mesh
   /// @param[in] FTC  #F by 3 list of indices into TC for each corner
   /// @param[out] seams  Edges where the forwards and backwards directions have different


### PR DESCRIPTION
This is an experiment in pushing changes that the Claude Code agent did. It's just editing headers (I guess I'm scared). It's interesting to dream of major refactors and other things that would be great for the health of libigl maintenance that claude could do. 

Maybe rewriting the very stale libigl website (http://libigl.github.io/) would be good next task.