### PR TITLE
swept volume overload

### DIFF
--- a/include/igl/swept_volume.cpp
+++ b/include/igl/swept_volume.cpp
@@ -44,3 +44,23 @@ IGL_INLINE void igl::swept_volume(
   S.array()-=isolevel;
   marching_cubes(S,GV,res(0),res(1),res(2),0,SV,SF);
 }
+
+
+IGL_INLINE void igl::swept_volume(
+  const Eigen::MatrixXd & V,
+  const Eigen::MatrixXi & F,
+  const std::vector<
+    Eigen::Affine3d,Eigen::aligned_allocator<Eigen::Affine3d> > & transforms,
+  const size_t grid_res,
+  const size_t isolevel,
+  Eigen::MatrixXd & SV,
+  Eigen::MatrixXi & SF)
+{
+  auto transform = [&transforms](const double t)->Eigen::Affine3d
+  {
+    const size_t steps = transforms.size();
+    const size_t i = std::min((size_t)(t*(steps-1)+0.5),steps-1);
+    return transforms[i];
+  };
+  return swept_volume(V,F,transform,transforms.size(),grid_res,isolevel,SV,SF);
+}

--- a/include/igl/swept_volume.cpp
+++ b/include/igl/swept_volume.cpp
@@ -3,64 +3,86 @@
 #include "swept_volume_signed_distance.h"
 #include "voxel_grid.h"
 #include "marching_cubes.h"
-#include <iostream>
+#include <algorithm>
+#include <cmath>
 
+template <
+  typename DerivedV,
+  typename DerivedF,
+  typename TScalar,
+  typename TAlloc,
+  typename DerivedSV,
+  typename DerivedSF>
 IGL_INLINE void igl::swept_volume(
-  const Eigen::MatrixXd & V,
-  const Eigen::MatrixXi & F,
-  const std::function<Eigen::Affine3d(const double t)> & transform,
-  const size_t steps,
+  const Eigen::MatrixBase<DerivedV> & V,
+  const Eigen::MatrixBase<DerivedF> & F,
+  const std::vector<Eigen::Transform<TScalar,3,Eigen::Affine>,TAlloc> &
+    transforms,
+  const SignedDistanceType sign_type,
   const size_t grid_res,
-  const size_t isolevel_grid,
-  Eigen::MatrixXd & SV,
-  Eigen::MatrixXi & SF)
+  const typename DerivedV::Scalar isolevel,
+  Eigen::PlainObjectBase<DerivedSV> & SV,
+  Eigen::PlainObjectBase<DerivedSF> & SF)
 {
   using namespace igl;
 
-  const auto & Vtransform = 
-    [&V,&transform](const size_t vi,const double t)->Eigen::RowVector3d
-  {
-    Eigen::Vector3d Vvi = V.row(vi).transpose();
-    return (transform(t)*Vvi).transpose();
-  };
-  Eigen::AlignedBox3d Mbox;
-  swept_volume_bounding_box(V.rows(),Vtransform,steps,Mbox);
+  Eigen::AlignedBox<TScalar,3> Mbox;
+  swept_volume_bounding_box(V,transforms,Mbox);
 
+  // Grid spacing is determined by the longest side of the motion's bounding
+  // box; padding does not affect it.
+  const TScalar h = Mbox.diagonal().maxCoeff()/(TScalar)(grid_res-1);
   // Amount of padding: pad*h should be >= isolevel
-  const int pad = isolevel_grid+1;
+  const int pad = std::max((int)std::ceil(isolevel/h),0)+1;
   // number of vertices on the largest side
   const int s = grid_res+2*pad;
-  const double h = Mbox.diagonal().maxCoeff()/(double)(s-2.*pad-1.);
-  const double isolevel = isolevel_grid*h;
 
   // create grid
-  Eigen::RowVector3i res;
-  Eigen::MatrixXd GV;
+  Eigen::Matrix<int,1,3> res;
+  Eigen::Matrix<TScalar,Eigen::Dynamic,Eigen::Dynamic> GV;
   voxel_grid(Mbox,s,pad,GV,res);
 
   // compute values
-  Eigen::VectorXd S;
-  swept_volume_signed_distance(V,F,transform,steps,GV,res,h,isolevel,S);
+  Eigen::Matrix<TScalar,Eigen::Dynamic,1> S;
+  swept_volume_signed_distance(
+    V,F,transforms,sign_type,GV,res,h,isolevel,S);
   S.array()-=isolevel;
   marching_cubes(S,GV,res(0),res(1),res(2),0,SV,SF);
 }
 
-
-IGL_INLINE void igl::swept_volume(
-  const Eigen::MatrixXd & V,
-  const Eigen::MatrixXi & F,
-  const std::vector<
-    Eigen::Affine3d,Eigen::aligned_allocator<Eigen::Affine3d> > & transforms,
-  const size_t grid_res,
-  const size_t isolevel,
-  Eigen::MatrixXd & SV,
-  Eigen::MatrixXi & SF)
-{
-  auto transform = [&transforms](const double t)->Eigen::Affine3d
-  {
-    const size_t steps = transforms.size();
-    const size_t i = std::min((size_t)(t*(steps-1)+0.5),steps-1);
-    return transforms[i];
-  };
-  return swept_volume(V,F,transform,transforms.size(),grid_res,isolevel,SV,SF);
-}
+#ifdef IGL_STATIC_LIBRARY
+// Explicit template instantiation
+typedef Eigen::Transform<double,3,Eigen::Affine> Affine3dT;
+typedef Eigen::aligned_allocator<Affine3dT> Affine3dAlignedAlloc;
+typedef std::allocator<Affine3dT> Affine3dAlloc;
+template void igl::swept_volume<
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,-1,-1,0,-1,-1>,
+  double,
+  Affine3dAlignedAlloc,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,-1,-1,0,-1,-1> >(
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  Eigen::MatrixBase<Eigen::Matrix<int,-1,-1,0,-1,-1> > const &,
+  std::vector<Affine3dT,Affine3dAlignedAlloc> const &,
+  igl::SignedDistanceType,
+  size_t,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>::Scalar,
+  Eigen::PlainObjectBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > &,
+  Eigen::PlainObjectBase<Eigen::Matrix<int,-1,-1,0,-1,-1> > &);
+template void igl::swept_volume<
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,-1,-1,0,-1,-1>,
+  double,
+  Affine3dAlloc,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,-1,-1,0,-1,-1> >(
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  Eigen::MatrixBase<Eigen::Matrix<int,-1,-1,0,-1,-1> > const &,
+  std::vector<Affine3dT,Affine3dAlloc> const &,
+  igl::SignedDistanceType,
+  size_t,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>::Scalar,
+  Eigen::PlainObjectBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > &,
+  Eigen::PlainObjectBase<Eigen::Matrix<int,-1,-1,0,-1,-1> > &);
+#endif

--- a/include/igl/swept_volume.h
+++ b/include/igl/swept_volume.h
@@ -27,6 +27,24 @@ namespace igl
     const size_t isolevel,
     Eigen::MatrixXd & SV,
     Eigen::MatrixXi & SF);
+  /// \brief Pass stepped transforms directly. Passed to the function above with
+  /// piecewise constant interpolation. So that, if steps=3, then [0,0.25) →
+  /// transforms[0], [0.25,0.75) → transforms[1], [0.75,1] → transforms[2]. In
+  /// other words,
+  ///
+  /// transform(t) = transforms[std::min( (size_t)(t*(steps-1) + 0.5), steps-1)]
+  ///
+  /// @param[in] transforms  #steps list of rigid transformations at each time
+  /// step
+  IGL_INLINE void swept_volume(
+    const Eigen::MatrixXd & V,
+    const Eigen::MatrixXi & F,
+    const std::vector<
+      Eigen::Affine3d,Eigen::aligned_allocator<Eigen::Affine3d> > & transforms,
+    const size_t grid_res,
+    const size_t isolevel,
+    Eigen::MatrixXd & SV,
+    Eigen::MatrixXi & SF);
   
 }
 

--- a/include/igl/swept_volume.h
+++ b/include/igl/swept_volume.h
@@ -1,8 +1,10 @@
 #ifndef IGL_SWEPT_VOLUME_H
 #define IGL_SWEPT_VOLUME_H
 #include "igl_inline.h"
+#include "signed_distance.h"
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <vector>
 namespace igl
 {
   /// Compute the surface of the swept volume of a solid object with surface
@@ -10,41 +12,33 @@ namespace igl
   /// 
   /// @param[in] V  #V by 3 list of mesh positions in reference pose
   /// @param[in] F  #F by 3 list of mesh indices into V
-  /// @param[in] transform  function handle so that transform(t) returns the rigid
-  ///     transformation at time t∈[0,1]
-  /// @param[in] steps  number of time steps: steps=3 --> t∈{0,0.5,1}
+  /// @param[in] transforms  #transforms list of rigid transformations, one per
+  ///     time step
+  /// @param[in] sign_type  method for computing distance _sign_
   /// @param[in] grid_res  number of grid cells on the longest side containing the
-  ///     motion (isolevel+1 cells will also be added on each side as padding)
-  /// @param[in] isolevel  distance level to be contoured as swept volume
+  ///     motion (enough cells to cover isolevel, plus one, will also be added
+  ///     on each side as padding)
+  /// @param[in] isolevel  distance level to be contoured as swept volume (in
+  ///     the same units as V)
   /// @param[out] SV  #SV by 3 list of mesh positions of the swept surface
   /// @param[out] SF  #SF by 3 list of mesh faces into SV
+  template <
+    typename DerivedV,
+    typename DerivedF,
+    typename TScalar,
+    typename TAlloc,
+    typename DerivedSV,
+    typename DerivedSF>
   IGL_INLINE void swept_volume(
-    const Eigen::MatrixXd & V,
-    const Eigen::MatrixXi & F,
-    const std::function<Eigen::Affine3d(const double t)> & transform,
-    const size_t steps,
+    const Eigen::MatrixBase<DerivedV> & V,
+    const Eigen::MatrixBase<DerivedF> & F,
+    const std::vector<Eigen::Transform<TScalar,3,Eigen::Affine>,TAlloc> &
+      transforms,
+    const SignedDistanceType sign_type,
     const size_t grid_res,
-    const size_t isolevel,
-    Eigen::MatrixXd & SV,
-    Eigen::MatrixXi & SF);
-  /// \brief Pass stepped transforms directly. Passed to the function above with
-  /// piecewise constant interpolation. So that, if steps=3, then [0,0.25) →
-  /// transforms[0], [0.25,0.75) → transforms[1], [0.75,1] → transforms[2]. In
-  /// other words,
-  ///
-  /// transform(t) = transforms[std::min( (size_t)(t*(steps-1) + 0.5), steps-1)]
-  ///
-  /// @param[in] transforms  #steps list of rigid transformations at each time
-  /// step
-  IGL_INLINE void swept_volume(
-    const Eigen::MatrixXd & V,
-    const Eigen::MatrixXi & F,
-    const std::vector<
-      Eigen::Affine3d,Eigen::aligned_allocator<Eigen::Affine3d> > & transforms,
-    const size_t grid_res,
-    const size_t isolevel,
-    Eigen::MatrixXd & SV,
-    Eigen::MatrixXi & SF);
+    const typename DerivedV::Scalar isolevel,
+    Eigen::PlainObjectBase<DerivedSV> & SV,
+    Eigen::PlainObjectBase<DerivedSF> & SF);
   
 }
 

--- a/include/igl/swept_volume_bounding_box.cpp
+++ b/include/igl/swept_volume_bounding_box.cpp
@@ -6,22 +6,48 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can 
 // obtain one at http://mozilla.org/MPL/2.0/.
 #include "swept_volume_bounding_box.h"
-#include "LinSpaced.h"
 
+template <
+  typename DerivedV,
+  typename TScalar,
+  typename TAlloc>
 IGL_INLINE void igl::swept_volume_bounding_box(
-  const size_t & n,
-  const std::function<Eigen::RowVector3d(const size_t vi, const double t)> & V,
-  const size_t & steps,
-  Eigen::AlignedBox3d & box)
+  const Eigen::MatrixBase<DerivedV> & V,
+  const std::vector<Eigen::Transform<TScalar,3,Eigen::Affine>,TAlloc> &
+    transforms,
+  Eigen::AlignedBox<TScalar,3> & box)
 {
   box.setEmpty();
-  const Eigen::VectorXd t = igl::LinSpaced<Eigen::VectorXd >(steps,0,1);
   // Find extent over all time steps
-  for(int ti = 0;ti<t.size();ti++)
+  for(const Eigen::Transform<TScalar,3,Eigen::Affine> & T : transforms)
   {
-    for(size_t vi = 0;vi<n;vi++)
+    for(int vi = 0;vi<V.rows();vi++)
     {
-      box.extend(V(vi,t(ti)).transpose());
+      const Eigen::Matrix<TScalar,3,1> v =
+        V.row(vi).transpose().template cast<TScalar>();
+      box.extend(T*v);
     }
   }
 }
+
+#ifdef IGL_STATIC_LIBRARY
+// Explicit template instantiation
+template void igl::swept_volume_bounding_box<
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  double,
+  Eigen::aligned_allocator<Eigen::Transform<double,3,Eigen::Affine> > >(
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  std::vector<
+    Eigen::Transform<double,3,Eigen::Affine>,
+    Eigen::aligned_allocator<Eigen::Transform<double,3,Eigen::Affine> > > const &,
+  Eigen::AlignedBox<double,3> &);
+template void igl::swept_volume_bounding_box<
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  double,
+  std::allocator<Eigen::Transform<double,3,Eigen::Affine> > >(
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  std::vector<
+    Eigen::Transform<double,3,Eigen::Affine>,
+    std::allocator<Eigen::Transform<double,3,Eigen::Affine> > > const &,
+  Eigen::AlignedBox<double,3> &);
+#endif

--- a/include/igl/swept_volume_bounding_box.h
+++ b/include/igl/swept_volume_bounding_box.h
@@ -10,23 +10,25 @@
 #include "igl_inline.h"
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <functional>
+#include <vector>
 namespace igl
 {
   /// Construct an axis-aligned bounding box containing a shape undergoing a
-  /// motion sampled at `steps` discrete momements.
+  /// motion sampled at a list of discrete rigid transformations.
   ///
-  /// @param[in] n  number of mesh vertices
-  /// @param[in] V  function handle so that V(i,t) returns the 3d position of vertex
-  ///     i at time t, for t∈[0,1]
-  /// @param[in] steps  number of time steps: steps=3 --> t∈{0,0.5,1}
+  /// @param[in] V  #V by 3 list of mesh positions in reference pose
+  /// @param[in] transforms  #transforms list of rigid transformations, one per
+  ///     time step
   /// @param[out] box  box containing mesh under motion
+  template <
+    typename DerivedV,
+    typename TScalar,
+    typename TAlloc>
   IGL_INLINE void swept_volume_bounding_box(
-    const size_t & n,
-    const std::function<
-      Eigen::RowVector3d(const size_t vi, const double t)> & V,
-    const size_t & steps,
-    Eigen::AlignedBox3d & box);
+    const Eigen::MatrixBase<DerivedV> & V,
+    const std::vector<Eigen::Transform<TScalar,3,Eigen::Affine>,TAlloc> &
+      transforms,
+    Eigen::AlignedBox<TScalar,3> & box);
 }
 
 #ifndef IGL_STATIC_LIBRARY

--- a/include/igl/swept_volume_signed_distance.cpp
+++ b/include/igl/swept_volume_signed_distance.cpp
@@ -6,10 +6,11 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can 
 // obtain one at http://mozilla.org/MPL/2.0/.
 #include "swept_volume_signed_distance.h"
-#include "LinSpaced.h"
 #include "flood_fill.h"
 #include "signed_distance.h"
+#include "fast_winding_number.h"
 #include "AABB.h"
+#include "WindingNumberAABB.h"
 #include "pseudonormal_test.h"
 #include "per_face_normals.h"
 #include "per_vertex_normals.h"
@@ -18,71 +19,130 @@
 #include <cmath>
 #include <algorithm>
 
+template <
+  typename DerivedV,
+  typename DerivedF,
+  typename TScalar,
+  typename TAlloc,
+  typename DerivedGV,
+  typename Derivedres,
+  typename DerivedS0,
+  typename DerivedS>
 IGL_INLINE void igl::swept_volume_signed_distance(
-  const Eigen::MatrixXd & V,
-  const Eigen::MatrixXi & F,
-  const std::function<Eigen::Affine3d(const double t)> & transform,
-  const size_t & steps,
-  const Eigen::MatrixXd & GV,
-  const Eigen::RowVector3i & res,
-  const double h,
-  const double isolevel,
-  const Eigen::VectorXd & S0,
-  Eigen::VectorXd & S)
+  const Eigen::MatrixBase<DerivedV> & V,
+  const Eigen::MatrixBase<DerivedF> & F,
+  const std::vector<Eigen::Transform<TScalar,3,Eigen::Affine>,TAlloc> &
+    transforms,
+  const SignedDistanceType sign_type,
+  const Eigen::MatrixBase<DerivedGV> & GV,
+  const Eigen::MatrixBase<Derivedres> & res,
+  const typename DerivedGV::Scalar h,
+  const typename DerivedGV::Scalar isolevel,
+  const Eigen::MatrixBase<DerivedS0> & S0,
+  Eigen::PlainObjectBase<DerivedS> & S)
 {
   using namespace igl;
-  S = S0;
-  const Eigen::VectorXd t = igl::LinSpaced<Eigen::VectorXd >(steps,0,1);
-  const bool finite_iso = isfinite(isolevel);
-  const double extension = (finite_iso ? isolevel : 0) + sqrt(3.0)*h;
-  Eigen::AlignedBox3d box(
+  typedef typename DerivedV::Scalar Scalar;
+  typedef typename DerivedF::Scalar Index;
+  typedef typename DerivedS::Scalar SScalar;
+  typedef Eigen::Matrix<Scalar,1,3> RowVector3S;
+  S = S0.template cast<SScalar>();
+  const bool finite_iso = std::isfinite(isolevel);
+  const Scalar h_ = h;
+  const Scalar isolevel_ = finite_iso ? (Scalar)isolevel : 
+    std::numeric_limits<Scalar>::infinity();
+  const Scalar extension = (finite_iso ? isolevel_ : (Scalar)0) + sqrt(3.0)*h_;
+  Eigen::AlignedBox<Scalar,3> box(
     V.colwise().minCoeff().array()-extension,
     V.colwise().maxCoeff().array()+extension);
-  // Precomputation
-  Eigen::MatrixXd FN,VN,EN;
-  Eigen::MatrixXi E;
-  Eigen::VectorXi EMAP;
-  per_face_normals(V,F,FN);
-  per_vertex_normals(V,F,PER_VERTEX_NORMALS_WEIGHTING_TYPE_ANGLE,FN,VN);
-  per_edge_normals(
-    V,F,PER_EDGE_NORMALS_WEIGHTING_TYPE_UNIFORM,FN,EN,E,EMAP);
-  AABB<Eigen::MatrixXd,3> tree;
+  // Precomputation (mesh is fixed; only the query points move)
+  Eigen::Matrix<Scalar,Eigen::Dynamic,3> FN,VN,EN;
+  Eigen::Matrix<Index,Eigen::Dynamic,2> E;
+  Eigen::Matrix<Index,Eigen::Dynamic,1> EMAP;
+  WindingNumberAABB<Scalar,Index> hier;
+  igl::FastWindingNumberBVH fwn_bvh;
+  AABB<DerivedV,3> tree;
   tree.init(V,F);
-  for(int ti = 0;ti<t.size();ti++)
+  switch(sign_type)
   {
-    const Eigen::Affine3d At = transform(t(ti));
+    default:
+      assert(false && "Unknown SignedDistanceType");
+    case SIGNED_DISTANCE_TYPE_UNSIGNED:
+      // do nothing
+      break;
+    case SIGNED_DISTANCE_TYPE_DEFAULT:
+    case SIGNED_DISTANCE_TYPE_WINDING_NUMBER:
+      hier.set_mesh(V,F);
+      hier.grow();
+      break;
+    case SIGNED_DISTANCE_TYPE_FAST_WINDING_NUMBER:
+      igl::fast_winding_number(V.template cast<float>().eval(),F,2,fwn_bvh);
+      break;
+    case SIGNED_DISTANCE_TYPE_PSEUDONORMAL:
+      per_face_normals(V,F,FN);
+      per_vertex_normals(V,F,PER_VERTEX_NORMALS_WEIGHTING_TYPE_ANGLE,FN,VN);
+      per_edge_normals(
+        V,F,PER_EDGE_NORMALS_WEIGHTING_TYPE_UNIFORM,FN,EN,E,EMAP);
+      break;
+  }
+  for(const Eigen::Transform<TScalar,3,Eigen::Affine> & T : transforms)
+  {
+    const Eigen::Transform<Scalar,3,Eigen::Affine> At = 
+      T.template cast<Scalar>();
     for(int g = 0;g<GV.rows();g++)
     {
       // Don't bother finding out how deep inside points are.
-      if(finite_iso && S(g)==S(g) && S(g)<isolevel-sqrt(3.0)*h)
+      if(finite_iso && S(g)==S(g) && S(g)<isolevel_-sqrt(3.0)*h_)
       {
         continue;
       }
-      const Eigen::RowVector3d gv =
-        (GV.row(g) - At.translation().transpose())*At.linear();
+      const RowVector3S gv =
+        (GV.row(g).template cast<Scalar>() - At.translation().transpose())*
+        At.linear();
       // If outside of extended box, then consider it "far away enough"
       if(finite_iso && !box.contains(gv.transpose()))
       {
         continue;
       }
-      Eigen::RowVector3d c,n;
+      RowVector3S c,n;
       int i;
-      double sqrd,s;
-      //signed_distance_pseudonormal(tree,V,F,FN,VN,EN,EMAP,gv,s,sqrd,i,c,n);
-      const double min_sqrd = 
+      Scalar sqrd,s = 1;
+      const Scalar min_sqrd = 
         finite_iso ? 
-        pow(sqrt(3.)*h+isolevel,2) : 
-        std::numeric_limits<double>::infinity();
+        pow(sqrt(3.)*h_+isolevel_,2) : 
+        std::numeric_limits<Scalar>::infinity();
       sqrd = tree.squared_distance(V,F,gv,min_sqrd,i,c);
       if(sqrd<min_sqrd)
       {
-        pseudonormal_test(V,F,FN,VN,EN,EMAP,gv,i,c,s,n);
+        // Determine sign
+        switch(sign_type)
+        {
+          default:
+            assert(false && "Unknown SignedDistanceType");
+          case SIGNED_DISTANCE_TYPE_UNSIGNED:
+            break;
+          case SIGNED_DISTANCE_TYPE_DEFAULT:
+          case SIGNED_DISTANCE_TYPE_WINDING_NUMBER:
+            s = 1.-2.*hier.winding_number(gv.transpose());
+            break;
+          case SIGNED_DISTANCE_TYPE_FAST_WINDING_NUMBER:
+          {
+            const Scalar w = 
+              fast_winding_number(fwn_bvh,2,gv.template cast<float>().eval());
+            s = 1.-2.*std::abs(w);
+            break;
+          }
+          case SIGNED_DISTANCE_TYPE_PSEUDONORMAL:
+            pseudonormal_test(V,F,FN,VN,EN,EMAP,gv,i,c,s,n);
+            break;
+        }
+        const SScalar sd = s*sqrt(sqrd);
         if(S(g) == S(g))
         {
-          S(g) = std::min(S(g),s*sqrt(sqrd));
+          S(g) = std::min(S(g),sd);
         }else
         {
-          S(g) = s*sqrt(sqrd);
+          S(g) = sd;
         }
       }
     }
@@ -95,24 +155,113 @@ IGL_INLINE void igl::swept_volume_signed_distance(
   {
 #ifndef NDEBUG
     // Check for nans
-    std::for_each(S.data(),S.data()+S.size(),[](const double s){assert(s==s);});
+    std::for_each(S.data(),S.data()+S.size(),[](const SScalar s){assert(s==s);});
 #endif
   }
 }
 
+template <
+  typename DerivedV,
+  typename DerivedF,
+  typename TScalar,
+  typename TAlloc,
+  typename DerivedGV,
+  typename Derivedres,
+  typename DerivedS>
 IGL_INLINE void igl::swept_volume_signed_distance(
-  const Eigen::MatrixXd & V,
-  const Eigen::MatrixXi & F,
-  const std::function<Eigen::Affine3d(const double t)> & transform,
-  const size_t & steps,
-  const Eigen::MatrixXd & GV,
-  const Eigen::RowVector3i & res,
-  const double h,
-  const double isolevel,
-  Eigen::VectorXd & S)
+  const Eigen::MatrixBase<DerivedV> & V,
+  const Eigen::MatrixBase<DerivedF> & F,
+  const std::vector<Eigen::Transform<TScalar,3,Eigen::Affine>,TAlloc> &
+    transforms,
+  const SignedDistanceType sign_type,
+  const Eigen::MatrixBase<DerivedGV> & GV,
+  const Eigen::MatrixBase<Derivedres> & res,
+  const typename DerivedGV::Scalar h,
+  const typename DerivedGV::Scalar isolevel,
+  Eigen::PlainObjectBase<DerivedS> & S)
 {
   using namespace igl;
-  S = Eigen::VectorXd::Constant(GV.rows(),1,std::numeric_limits<double>::quiet_NaN());
-  return 
-    swept_volume_signed_distance(V,F,transform,steps,GV,res,h,isolevel,S,S);
+  S = DerivedS::Constant(
+    GV.rows(),1,std::numeric_limits<typename DerivedS::Scalar>::quiet_NaN());
+  return swept_volume_signed_distance(
+    V,F,transforms,sign_type,GV,res,h,isolevel,S,S);
 }
+
+#ifdef IGL_STATIC_LIBRARY
+// Explicit template instantiation
+typedef Eigen::Transform<double,3,Eigen::Affine> Affine3dT;
+typedef Eigen::aligned_allocator<Affine3dT> Affine3dAlignedAlloc;
+typedef std::allocator<Affine3dT> Affine3dAlloc;
+template void igl::swept_volume_signed_distance<
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,-1,-1,0,-1,-1>,
+  double,
+  Affine3dAlignedAlloc,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,1,3,1,1,3>,
+  Eigen::Matrix<double,-1,1,0,-1,1>,
+  Eigen::Matrix<double,-1,1,0,-1,1> >(
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  Eigen::MatrixBase<Eigen::Matrix<int,-1,-1,0,-1,-1> > const &,
+  std::vector<Affine3dT,Affine3dAlignedAlloc> const &,
+  igl::SignedDistanceType,
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  Eigen::MatrixBase<Eigen::Matrix<int,1,3,1,1,3> > const &,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>::Scalar,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>::Scalar,
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,1,0,-1,1> > const &,
+  Eigen::PlainObjectBase<Eigen::Matrix<double,-1,1,0,-1,1> > &);
+template void igl::swept_volume_signed_distance<
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,-1,-1,0,-1,-1>,
+  double,
+  Affine3dAlignedAlloc,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,1,3,1,1,3>,
+  Eigen::Matrix<double,-1,1,0,-1,1> >(
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  Eigen::MatrixBase<Eigen::Matrix<int,-1,-1,0,-1,-1> > const &,
+  std::vector<Affine3dT,Affine3dAlignedAlloc> const &,
+  igl::SignedDistanceType,
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  Eigen::MatrixBase<Eigen::Matrix<int,1,3,1,1,3> > const &,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>::Scalar,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>::Scalar,
+  Eigen::PlainObjectBase<Eigen::Matrix<double,-1,1,0,-1,1> > &);
+template void igl::swept_volume_signed_distance<
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,-1,-1,0,-1,-1>,
+  double,
+  Affine3dAlloc,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,1,3,1,1,3>,
+  Eigen::Matrix<double,-1,1,0,-1,1>,
+  Eigen::Matrix<double,-1,1,0,-1,1> >(
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  Eigen::MatrixBase<Eigen::Matrix<int,-1,-1,0,-1,-1> > const &,
+  std::vector<Affine3dT,Affine3dAlloc> const &,
+  igl::SignedDistanceType,
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  Eigen::MatrixBase<Eigen::Matrix<int,1,3,1,1,3> > const &,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>::Scalar,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>::Scalar,
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,1,0,-1,1> > const &,
+  Eigen::PlainObjectBase<Eigen::Matrix<double,-1,1,0,-1,1> > &);
+template void igl::swept_volume_signed_distance<
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,-1,-1,0,-1,-1>,
+  double,
+  Affine3dAlloc,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>,
+  Eigen::Matrix<int,1,3,1,1,3>,
+  Eigen::Matrix<double,-1,1,0,-1,1> >(
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  Eigen::MatrixBase<Eigen::Matrix<int,-1,-1,0,-1,-1> > const &,
+  std::vector<Affine3dT,Affine3dAlloc> const &,
+  igl::SignedDistanceType,
+  Eigen::MatrixBase<Eigen::Matrix<double,-1,-1,0,-1,-1> > const &,
+  Eigen::MatrixBase<Eigen::Matrix<int,1,3,1,1,3> > const &,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>::Scalar,
+  Eigen::Matrix<double,-1,-1,0,-1,-1>::Scalar,
+  Eigen::PlainObjectBase<Eigen::Matrix<double,-1,1,0,-1,1> > &);
+#endif

--- a/include/igl/swept_volume_signed_distance.h
+++ b/include/igl/swept_volume_signed_distance.h
@@ -8,20 +8,20 @@
 #ifndef IGL_SWEPT_VOLUME_SIGNED_DISTANCE_H
 #define IGL_SWEPT_VOLUME_SIGNED_DISTANCE_H
 #include "igl_inline.h"
+#include "signed_distance.h"
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <functional>
+#include <vector>
 namespace igl
 {
-  /// Compute the signed distance to a sweep surface of a mesh under-going
-  /// an arbitrary motion V(t) discretely sampled at `steps`-many moments in
-  /// time at a grid.
+  /// Compute the signed distance to a sweep surface of a mesh under-going a
+  /// rigid motion discretely sampled at a list of transformations at a grid.
   ///
   /// @param[in] V  #V by 3 list of mesh positions in reference pose
   /// @param[in] F  #F by 3 list of triangle indices [0,n)
-  /// @param[in] transform  function handle so that transform(t) returns the rigid
-  ///     transformation at time t∈[0,1]
-  /// @param[in] steps  number of time steps: steps=3 --> t∈{0,0.5,1}
+  /// @param[in] transforms  #transforms list of rigid transformations, one per
+  ///     time step
+  /// @param[in] sign_type  method for computing distance _sign_
   /// @param[in] GV  #GV by 3 list of evaluation point grid positions
   /// @param[in] res  3-long resolution of GV grid
   /// @param[in] h  edge-length of grid
@@ -32,28 +32,47 @@ namespace igl
   /// @param[in] S0  #GV initial values (will take minimum with these), can be same
   ///     as S)
   /// @param[out] S  #GV list of signed distances
+  template <
+    typename DerivedV,
+    typename DerivedF,
+    typename TScalar,
+    typename TAlloc,
+    typename DerivedGV,
+    typename Derivedres,
+    typename DerivedS0,
+    typename DerivedS>
   IGL_INLINE void swept_volume_signed_distance(
-    const Eigen::MatrixXd & V,
-    const Eigen::MatrixXi & F,
-    const std::function<Eigen::Affine3d(const double t)> & transform,
-    const size_t & steps,
-    const Eigen::MatrixXd & GV,
-    const Eigen::RowVector3i & res,
-    const double h,
-    const double isolevel,
-    const Eigen::VectorXd & S0,
-    Eigen::VectorXd & S);
+    const Eigen::MatrixBase<DerivedV> & V,
+    const Eigen::MatrixBase<DerivedF> & F,
+    const std::vector<Eigen::Transform<TScalar,3,Eigen::Affine>,TAlloc> &
+      transforms,
+    const SignedDistanceType sign_type,
+    const Eigen::MatrixBase<DerivedGV> & GV,
+    const Eigen::MatrixBase<Derivedres> & res,
+    const typename DerivedGV::Scalar h,
+    const typename DerivedGV::Scalar isolevel,
+    const Eigen::MatrixBase<DerivedS0> & S0,
+    Eigen::PlainObjectBase<DerivedS> & S);
   /// \overload
+  template <
+    typename DerivedV,
+    typename DerivedF,
+    typename TScalar,
+    typename TAlloc,
+    typename DerivedGV,
+    typename Derivedres,
+    typename DerivedS>
   IGL_INLINE void swept_volume_signed_distance(
-    const Eigen::MatrixXd & V,
-    const Eigen::MatrixXi & F,
-    const std::function<Eigen::Affine3d(const double t)> & transform,
-    const size_t & steps,
-    const Eigen::MatrixXd & GV,
-    const Eigen::RowVector3i & res,
-    const double h,
-    const double isolevel,
-    Eigen::VectorXd & S);
+    const Eigen::MatrixBase<DerivedV> & V,
+    const Eigen::MatrixBase<DerivedF> & F,
+    const std::vector<Eigen::Transform<TScalar,3,Eigen::Affine>,TAlloc> &
+      transforms,
+    const SignedDistanceType sign_type,
+    const Eigen::MatrixBase<DerivedGV> & GV,
+    const Eigen::MatrixBase<Derivedres> & res,
+    const typename DerivedGV::Scalar h,
+    const typename DerivedGV::Scalar isolevel,
+    Eigen::PlainObjectBase<DerivedS> & S);
   }
 
 #ifndef IGL_STATIC_LIBRARY

--- a/tutorial/707_SweptVolume/main.cpp
+++ b/tutorial/707_SweptVolume/main.cpp
@@ -4,8 +4,10 @@
 #include <igl/swept_volume.h>
 #include <igl/opengl/glfw/Viewer.h>
 #include <igl/PI.h>
+#include <igl/LinSpaced.h>
 #include <Eigen/Core>
 #include <iostream>
+#include <vector>
 
 
 int main(int argc, char * argv[])
@@ -35,10 +37,22 @@ int main(int argc, char * argv[])
   viewer.core().is_animating = !show_swept_volume;
   const int grid_size = 50;
   const int time_steps = 200;
-  const double isolevel = 0.1;
+  // Dilate the swept volume by a distance of 10% of the bunny's largest side
+  // (isolevel is a distance in the units of V)
+  const double isolevel =
+    0.01*(V.colwise().maxCoeff()-V.colwise().minCoeff()).maxCoeff();
+  // Preload the motion as a list of rigid transformations sampled uniformly in
+  // time over t∈[0,1]
+  std::vector<Eigen::Affine3d,Eigen::aligned_allocator<Eigen::Affine3d> >
+    transforms(time_steps);
+  {
+    const Eigen::VectorXd t = igl::LinSpaced<Eigen::VectorXd>(time_steps,0,1);
+    for(int ti = 0;ti<time_steps;ti++) { transforms[ti] = transform(t(ti)); }
+  }
   std::cerr<<"Computing swept volume...";
   igl::swept_volume(
-    V,F,transform,time_steps,grid_size,isolevel,SV,SF);
+    V,F,transforms,igl::SIGNED_DISTANCE_TYPE_FAST_WINDING_NUMBER,grid_size,isolevel,
+    SV,SF);
   std::cerr<<" finished."<<std::endl;
 
   viewer.callback_pre_draw =


### PR DESCRIPTION
I want to make python bindings and the transform(t) + steps was silly. I factored that into just a list of transforms (I guess more memory, but seems small compared to the rest) and templated the functions better. There was also a bug in the iso_level type that probably never made that work as expected.