### PR TITLE
Remove obsolete macOS Mojave hide/show window hack

### DIFF
--- a/include/igl/opengl/glfw/Viewer.cpp
+++ b/include/igl/opengl/glfw/Viewer.cpp
@@ -257,15 +257,6 @@ namespace glfw
       }
       if (!loop)
         return !glfwWindowShouldClose(window);
-
-      #ifdef __APPLE__
-        static bool first_time_hack  = true;
-        if(first_time_hack) {
-          glfwHideWindow(window);
-          glfwShowWindow(window);
-          first_time_hack = false;
-        }
-      #endif
     }
     return EXIT_SUCCESS;
   }


### PR DESCRIPTION
`Viewer::launch_rendering` hides and immediately re-shows the window on the first frame, on macOS only. Every libigl viewer app therefore flashes its window once on launch.

```cpp
#ifdef __APPLE__
  static bool first_time_hack  = true;
  if(first_time_hack) {
    glfwHideWindow(window);
    glfwShowWindow(window);
    first_time_hack = false;
  }
#endif
```

This has been dead weight for seven years.

## Why it exists

It was added in b367156d (2018-10-18) to work around [glfw#1334](https://github.com/glfw/glfw/issues/1334), where OpenGL windows on macOS 10.14 Mojave stayed blank until moved or resized, because layer-backed views became the default. It replaced 59251ca3's `GLFW_TRANSPARENT_FRAMEBUFFER` hint, which fixed the same bug but broke viewer transparency (see #983).

## Why it is no longer needed

GLFW fixed the underlying bug upstream **eight days later**:

- glfw/glfw@5595fa3ae60386bdb6ae4caf8f488779e3c342a3 — "Cocoa: Fix OpenGL rendering not being displayed" (2018-10-26), implementing `-updateLayer` so the `NSOpenGLContext` refreshes on AppKit's normal display cycle. Shipped in GLFW 3.3.

libigl picked that up three weeks after the hack landed:

- #977 (merged 2018-11-06) bumped GLFW to `53c8c72c`, which contains `5595fa3a`.
- The current pin `3327050c` (`cmake/recipes/external/glfw.cmake:11`) still contains it — verifiable in the fetched tree at `src/cocoa_window.m`, `-wantsUpdateLayer` / `-updateLayer`.

So the correctness now comes entirely from GLFW's `updateLayer`, not from any hide/show dance. `_glfwPlatformShowWindow` is a bare `orderFront:`, so the external hide/show is redundant rather than complementary.

It looks like this was simply never revisited: a comment on #977 stated that glfw#1334 was still open, when it had actually been closed 11 days earlier.

## Testing

- Builds clean on macOS (Apple clang, arm64) with no errors.
- The diff is a pure 9-line deletion of a self-contained block; nothing else changes.

**This PR deliberately carries no CI evidence, because CI cannot produce any.** `.github/workflows/continuous.yml` passes `-DLIBIGL_GLFW_TESTS=OFF`, tutorials are built but never run, and GitHub-hosted runners bottom out at macOS 13 — so window compositing has no automated coverage, and 10.14 is untestable regardless. This is asking for a human macOS look at a tutorial window appearing correctly on frame one.

## Known caveat

`cmake/recipes/external/glfw.cmake:1-3` early-returns `if(TARGET glfw::glfw)`, so a parent project can inject its own GLFW. Someone on macOS 10.14 building against a **pre-3.3** GLFW would regress. That is narrow and self-inflicted — GLFW 3.3 is from April 2019 — but it is real.

If you would rather not accept even that, the alternative is to gate instead of delete:

```cpp
#if defined(__APPLE__) && GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR < 3
  // ... keep the hack ...
#endif
```

Happy to switch to that form if preferred.

---

This pull request was written by Claude Code (the code change, the investigation, and this description). The GLFW commit/version claims above were verified directly against the fetched GLFW source tree; the "would upstream accept this" judgement is, of course, yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)